### PR TITLE
Correct version for Temporal Table Introduction

### DIFF
--- a/docs/relational-databases/tables/temporal-tables.md
+++ b/docs/relational-databases/tables/temporal-tables.md
@@ -19,7 +19,7 @@ manager: "jhubbard"
 # Temporal Tables
 [!INCLUDE[tsql-appliesto-ss2016-asdb-xxxx-xxx_md](../../includes/tsql-appliesto-ss2016-asdb-xxxx-xxx-md.md)]
 
-  [!INCLUDE[ssCurrent](../../includes/sscurrent-md.md)] introduces support for system-versioned temporal tables as a database feature that brings built-in support for providing information about data stored in the table at any point in time rather than only the data that is correct at the current moment in time. Temporal is a database feature that was introduced in ANSI SQL 2011 and is now supported in [!INCLUDE[ssCurrent](../../includes/sscurrent-md.md)].  
+  SQL Server 2016 introduces support for system-versioned temporal tables as a database feature that brings built-in support for providing information about data stored in the table at any point in time rather than only the data that is correct at the current moment in time. Temporal is a database feature that was introduced in ANSI SQL 2011 and is now supported in [!INCLUDE[ssCurrent](../../includes/sscurrent-md.md)].  
   
  **Quick Start**  
   


### PR DESCRIPTION
SQL Server 2016 introduced Temporal Tables, but the current documentation is pulling the latest version which is SQL Server 2017.  This conflicts with the "This Topic Applies To" at the top of the article.

![image](https://user-images.githubusercontent.com/10823939/28400756-dc89805c-6cda-11e7-8584-ab63b7c8d8ad.png)

[Here's what live currently looks like before this change](https://docs.microsoft.com/en-us/sql/relational-databases/tables/temporal-tables)

If you'd rather me put it in a different branch than live, let me know.

Thanks!
