### PR TITLE
Fixed string_agg syntax

### DIFF
--- a/docs/t-sql/functions/string-agg-transact-sql.md
+++ b/docs/t-sql/functions/string-agg-transact-sql.md
@@ -30,7 +30,7 @@ Concatenates the values of string expressions and places separator values betwee
 ## Syntax  
   
 ```  
-STRING_AGG ( expression, separator [ <order_clause> ] )
+STRING_AGG ( expression, separator ) [ <order_clause> ]
 
 <order_clause> ::=   
     WITHIN GROUP ( ORDER BY <order_by_expression_list> [ ASC | DESC ] )   


### PR DESCRIPTION
If I'm understanding correctly, this looks like a typo. `string_agg(Foo, ', ') within group (order by Foo)` works, `string_agg(Foo, ', ' within group (order by Foo))` does not. 