### PR TITLE
SSMS 2017 and PowerBI Report Server new SSMS props

### DIFF
--- a/docs/reporting-services/tools/server-properties-advanced-page-reporting-services.md
+++ b/docs/reporting-services/tools/server-properties-advanced-page-reporting-services.md
@@ -104,6 +104,15 @@ manager: "erikre"
  **EditSessionTimeout**  
  Specifies the number of seconds until a report edit session times out. The default value is 7200 seconds (2 hours).  
   
+ **EnableCustomVisuals**  
+ Should PowerBI ReportServer enable the display of PowerBI custom visuals. Values are True, False.  Default is True.  
+  
+ **EnablePowerBIReportExportData**  
+ Should PowerBI ReportServer enable the export of data from PowerBI visuals. Values are True, False.  Default is True.  
+   
+ **EnableXsrfValidation**  
+ Should PowerBI ReportServer and SQL Server Report Server require XSRF tokens to prevent XSRF (Cross-side request forgery) attacks.  When this value is false, the server will be less secure.  Values are True, False.  Default is True.  
+  
  **EnableTestConnectionDetailedErrors**  
  Indicates whether detailed error messages are sent to the client computer when users test data source connections using the report server. The default value is **true**. If the option is set to **false**, only generic error messages are sent.  
   


### PR DESCRIPTION
SSMS 2017 adds the ability to disable XSRF token validation

PowerBI Report Server adds XSRF switch, as well as the ability to switch on/off display of custom visuals and export of visual data in tabular format in PowerBI reports