### PR TITLE
Update temporal-table-usage-scenarios.md

### DIFF
--- a/docs/relational-databases/tables/temporal-table-usage-scenarios.md
+++ b/docs/relational-databases/tables/temporal-table-usage-scenarios.md
@@ -309,9 +309,9 @@ ALTER TABLE Product
 ALTER TABLE [Location]  
 ADD   
     SysStartTime datetime2 (2) GENERATED ALWAYS AS ROW START HIDDEN    
-        constraint DF_ValidFrom DEFAULT DATEADD(second, -1, SYSUTCDATETIME())  
+        constraint DFValidFrom DEFAULT DATEADD(second, -1, SYSUTCDATETIME())  
     , SysEndTime datetime2 (2)  GENERATED ALWAYS AS ROW END HIDDEN     
-        constraint DF_ValidTo DEFAULT '9999.12.31 23:59:59.99'  
+        constraint DFValidTo DEFAULT '9999.12.31 23:59:59.99'  
     , PERIOD FOR SYSTEM_TIME (SysStartTime, SysEndTime);  
   
 ALTER TABLE [Location]    


### PR DESCRIPTION
you can't have two constraints with same name in same database/schema..The article seems to imply, you can do that and people are asking questions regarding this(https://stackoverflow.com/questions/45433452/temporal-table-constraints/45433622#45433622)

changed constraints for location table