### PR TITLE
Use Join-Path in Powershell script

### DIFF
--- a/docs/relational-databases/import-export/use-a-format-file-to-bulk-import-data-sql-server.md
+++ b/docs/relational-databases/import-export/use-a-format-file-to-bulk-import-data-sql-server.md
@@ -70,7 +70,7 @@ cls
 # revise directory as desired
 $dir = 'D:\BCP\';
 
-$bcpFile = $dir + 'MyFirstImport.bcp';
+$bcpFile = Join-Path -Path $dir -ChildPath 'MyFirstImport.bcp';
 
 # Confirm directory exists
 IF ((Test-Path -Path $dir) -eq 0)


### PR DESCRIPTION
Use Join-Path to produce the file path in the PowerShell script instead of string concatenation.