### PR TITLE
Syntax and formatting fixes

### DIFF
--- a/docs/t-sql/queries/from-using-pivot-and-unpivot.md
+++ b/docs/t-sql/queries/from-using-pivot-and-unpivot.md
@@ -31,7 +31,7 @@ manager: "jhubbard"
 # FROM - Using PIVOT and UNPIVOT
 [!INCLUDE[tsql-appliesto-ss2008-all_md](../../includes/tsql-appliesto-ss2008-all-md.md)]
 
-  You can use the `PIVOT` and `UNPIVOT` relational operators to change a table-valued expression into another table. `PIVOT rotates a table-valued expression by turning the unique values from one column in the expression into multiple columns in the output, and performs aggregations where they are required on any remaining column values that are wanted in the final output. `UNPIVOT` performs the opposite operation to PIVOT by rotating columns of a table-valued expression into column values.  
+  You can use the `PIVOT` and `UNPIVOT` relational operators to change a table-valued expression into another table. `PIVOT` rotates a table-valued expression by turning the unique values from one column in the expression into multiple columns in the output, and performs aggregations where they are required on any remaining column values that are wanted in the final output. `UNPIVOT` performs the opposite operation to PIVOT by rotating columns of a table-valued expression into column values.  
   
  The syntax for `PIVOT` provides is simpler and more readable than the syntax that may otherwise be specified in a complex series of `SELECT...CASE` statements. For a complete description of the syntax for `PIVOT`, see [FROM (Transact-SQL)](../../t-sql/queries/from-transact-sql.md).  
   
@@ -76,15 +76,14 @@ GROUP BY DaysToManufacture;
   
  [!INCLUDE[ssResult](../../includes/ssresult-md.md)]  
   
- `DaysToManufacture          AverageCost`  
-  
- `0                          5.0885`  
-  
- `1                          223.88`  
-  
- `2                          359.1082`  
-  
- `4                          949.4105`  
+ ```
+ DaysToManufacture AverageCost
+ ----------------- -----------
+ 0                 5.0885
+ 1                 223.88
+ 2                 359.1082
+ 4                 949.4105
+ ```
   
  No products are defined with three `DaysToManufacture`.  
   
@@ -107,9 +106,11 @@ FOR DaysToManufacture IN ([0], [1], [2], [3], [4])
   
  [!INCLUDE[ssResult](../../includes/ssresult-md.md)]  
   
- `Cost_Sorted_By_Production_Days    0         1         2           3       4`  
-  
- `AverageCost                       5.0885    223.88    359.1082    NULL    949.4105`  
+```
+Cost_Sorted_By_Production_Days 0           1           2           3           4         
+------------------------------ ----------- ----------- ----------- ----------- -----------
+AverageCost                    5.0885      223.88      359.1082    NULL        949.4105
+```
   
 ## Complex PIVOT Example  
  A common scenario where `PIVOT` can be useful is when you want to generate cross-tabulation reports to summarize data. For example, suppose you want to query the `PurchaseOrderHeader` table in the `AdventureWorks2014` sample database to determine the number of purchase orders placed by certain employees. The following query provides this report, ordered by vendor.  
@@ -132,17 +133,15 @@ ORDER BY pvt.VendorID;
   
  Here is a partial result set.  
   
- `VendorID    Emp1        Emp2        Emp3        Emp4        Emp5`  
-  
- `1492        2           5           4           4           4`  
-  
- `1494        2           5           4           5           4`  
-  
- `1496        2           4           4           5           5`  
-  
- `1498        2           5           4           4           4`  
-  
- `1500        3           4           4           5           4`  
+```
+VendorID    Emp1        Emp2        Emp3        Emp4        Emp5  
+----------- ----------- ----------- ----------- ----------- -----------
+1492        2           5           4           4           4
+1494        2           5           4           5           4
+1496        2           4           4           5           5
+1498        2           5           4           4           4
+1500        3           4           4           5           4
+```
   
  The results returned by this subselect statement are pivoted on the `EmployeeID` column.  
   
@@ -183,31 +182,21 @@ GO
   
  Here is a partial result set.  
   
- `VendorID   Employee   Orders`  
-  
- `---------- ---------- ------`  
-  
- `1          Emp1       4`  
-  
- `1          Emp2       3`  
-  
- `1          Emp3       5`  
-  
- `1          Emp4       4`  
-  
- `1          Emp5       4`  
-  
- `2          Emp1       4`  
-  
- `2          Emp2       1`  
-  
- `2          Emp3       5`  
-  
- `2          Emp4       5`  
-  
- `2          Emp5       5`  
-  
- `...`  
+```
+VendorID    Employee    Orders
+----------- ----------- ------
+1            Emp1       4
+1            Emp2       3 
+1            Emp3       5
+1            Emp4       4
+1            Emp5       4
+2            Emp1       4
+2            Emp2       1
+2            Emp3       5
+2            Emp4       5
+2            Emp5       5
+...
+```
   
  Notice that `UNPIVOT` is not the exact reverse of `PIVOT`. `PIVOT` performs an aggregation and, therefore, merges possible multiple rows into a single row in the output. `UNPIVOT` does not reproduce the original table-valued expression result because rows have been merged. Besides, null values in the input of `UNPIVOT` disappear in the output, whereas there may have been original null values in the input before the `PIVOT` operation.  
   


### PR DESCRIPTION
Corrected syntax typo in lead. Converted result sets to multiline code elements so they are more aligned and consistent with other Docs pages