### PR TITLE
syntax fix

### DIFF
--- a/docs/integration-services/dtutil-utility.md
+++ b/docs/integration-services/dtutil-utility.md
@@ -203,7 +203,7 @@ dtutil /SQL srcPackage /EXISTS
  To determine whether a package exists in the **msdb** database on a local instance of [!INCLUDE[ssNoVersion](../includes/ssnoversion-md.md)] that uses [!INCLUDE[ssNoVersion](../includes/ssnoversion-md.md)] Authentication, use the following syntax:  
   
 ```dos
-dtutil SQL srcPackage /SOURCEUSER srcUserName /SOURCEPASSWORD *hY$d56b /EXISTS  
+dtutil /SQL srcPackage /SOURCEUSER srcUserName /SOURCEPASSWORD *hY$d56b /EXISTS  
 ```  
   
 > [!NOTE]  


### PR DESCRIPTION
line 206: dtutil SQL srcPackage /SOURCEUSER srcUserName /SOURCEPASSWORD *hY$d56b /EXISTS   

did not have a "/" before SQL command.