### PR TITLE
Improve sample code to indicate a range is created

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-set-database-firewall-rule-azure-sql-database.md
+++ b/docs/relational-databases/system-stored-procedures/sp-set-database-firewall-rule-azure-sql-database.md
@@ -56,33 +56,33 @@ sp_set_database_firewall_rule [@name = ] [N]'name'
  The following table demonstrates the supported arguments and options in [!INCLUDE[ssSDS](../../includes/sssds-md.md)].  
   
 > [!NOTE]  
->  Windows Azure connection attempts are allowed when both this field and the *start_ip_address* field equals `0.0.0.0`.  
+>  Azure connection attempts are allowed when both this field and the *start_ip_address* field equals `0.0.0.0`.  
   
 ## Remarks  
  The names of database-level firewall settings for a database must be unique. If the name of the database-level firewall setting provided for the stored procedure already exists in the database-level firewall settings table, the starting and ending IP addresses will be updated. Otherwise, a new database-level firewall setting will be created.  
   
- When you add a database-level firewall setting where the beginning and ending IP addresses are equal to `0.0.0.0`, you enable access to your database in the [!INCLUDE[ssSDS](../../includes/sssds-md.md)] server from Windows Azure. Provide a value to the *name* parameter that will help you remember what the firewall setting is for.  
+ When you add a database-level firewall setting where the beginning and ending IP addresses are equal to `0.0.0.0`, you enable access to your database in the [!INCLUDE[ssSDS](../../includes/sssds-md.md)] server from any Azure resource. Provide a value to the *name* parameter that will help you remember what the firewall setting is for.  
   
 ## Permissions  
  Requires **CONTROL** permission on the database.  
   
 ## Examples  
- The following code creates a database-level firewall setting called `Allow Windows Azure` that enables access to your database from Windows Azure.  
+ The following code creates a database-level firewall setting called `Allow Azure` that enables access to your database from Azure.  
   
 ```  
--- Enable Windows Azure connections.  
-EXECUTE sp_set_database_firewall_rule N'Allow Windows Azure','0.0.0.0','0.0.0.0';  
+-- Enable Azure connections.  
+EXECUTE sp_set_database_firewall_rule N'Allow Azure', '0.0.0.0', '0.0.0.0';  
   
 ```  
   
- The following code creates a database-level firewall setting called `Example DB Setting 1` for only the IP address `0.0.0.4`. Then, the `sp_set_database firewall_rule` stored procedure is called again to allow an additional IP address, `0.0.0.5`, in that firewall setting.  
+ The following code creates a database-level firewall setting called `Example DB Setting 1` for only the IP address `0.0.0.4`. Then, the `sp_set_database firewall_rule` stored procedure is called again to update the end IP address to `0.0.0.6`, in that firewall setting. This creates a range which allows IP addresses `0.0.0.4`, `0.0.0.5`, and `0.0.0.6` to access the database.
   
 ```  
 -- Create database-level firewall setting for only IP 0.0.0.4  
-EXECUTE sp_set_database_firewall_rule N'Example DB Setting 1','0.0.0.4','0.0.0.4';  
+EXECUTE sp_set_database_firewall_rule N'Example DB Setting 1', '0.0.0.4', '0.0.0.4';  
   
--- Update database-level firewall setting to also allow IP 0.0.0.5  
-EXECUTE sp_set_database_firewall_rule N'Example DB Setting 1','0.0.0.4','0.0.0.5';  
+-- Update database-level firewall setting to create a range of allowed IP addresses
+EXECUTE sp_set_database_firewall_rule N'Example DB Setting 1', '0.0.0.4', '0.0.0.6';  
   
 ```  
   


### PR DESCRIPTION
Incrementing the firewall end IP address by just 1 may create a false impression that they are individual IPs rather than a range. The description wasn't helpful either.
Also removed "Windows" from "Windows Azure": It hasn't been called that in a while I think. 
Also added some spaces between stored procedure parameter values, to be consistent with T-SQL docs (https://docs.microsoft.com/en-us/sql/relational-databases/stored-procedures/specify-parameters)