### PR TITLE
Update sp-set-firewall-rule-azure-sql-database.md

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-set-firewall-rule-azure-sql-database.md
+++ b/docs/relational-databases/system-stored-procedures/sp-set-firewall-rule-azure-sql-database.md
@@ -31,13 +31,13 @@ manager: "jhubbard"
 # sp_set_firewall_rule (Azure SQL Database)
 [!INCLUDE[tsql-appliesto-xxxxxx-asdb-asdw-xxx_md](../../includes/tsql-appliesto-xxxxxx-asdb-asdw-xxx-md.md)]
 
-  Creates or updates the server-level firewall settings for your [!INCLUDE[ssSDS](../../includes/sssds-md.md)] server. This stored procedure is only available in the master database to the server-level principal login.  
+  Creates or updates the server-level firewall settings for your [!INCLUDE[ssSDS](../../includes/sssds-md.md)] server. This stored procedure is only available in the master database to the server-level principal login or assigned Azure Active Directory principal.  
   
   
 ## Syntax  
   
 ```
-sp_set_firewall_rule [@name = ] 'name', 
+sp_set_firewall_rule [@name =] 'name', 
     [@start_ip_address =] 'start_ip_address', 
     [@end_ip_address =] 'end_ip_address'
 [ ; ]  
@@ -48,45 +48,41 @@ sp_set_firewall_rule [@name = ] 'name',
   
 |Name|Datatype|Description|  
 |----------|--------------|-----------------|  
-|[@name = ] ‘name’|**NVARCHAR(128)**|The name used to describe and distinguish the server-level firewall setting.|  
-|[@start_ip_address =] ’start_ip_address’|**VARCHAR(50)**|The lowest IP address in the range of the server-level firewall setting. IP addresses equal to or greater than this can attempt to connect to the [!INCLUDE[ssSDS](../../includes/sssds-md.md)] server. The lowest possible IP address is `0.0.0.0`.|  
-|[@end_ip_address =] ‘end_ip_address’|**VARCHAR(50)**|The highest IP address in the range of the server-level firewall setting. IP addresses equal to or less than this can attempt to connect to the [!INCLUDE[ssSDS](../../includes/sssds-md.md)] server. The highest possible IP address is `255.255.255.255`.<br /><br /> Note: Windows Azure connection attempts are allowed when both this field and the *start_ip_address* field equals `0.0.0.0`.|  
+|[@name =] 'name'|**NVARCHAR(128)**|The name used to describe and distinguish the server-level firewall setting.|  
+|[@start_ip_address =] 'start_ip_address'|**VARCHAR(50)**|The lowest IP address in the range of the server-level firewall setting. IP addresses equal to or greater than this can attempt to connect to the [!INCLUDE[ssSDS](../../includes/sssds-md.md)] server. The lowest possible IP address is `0.0.0.0`.|  
+|[@end_ip_address =] 'end_ip_address'|**VARCHAR(50)**|The highest IP address in the range of the server-level firewall setting. IP addresses equal to or less than this can attempt to connect to the [!INCLUDE[ssSDS](../../includes/sssds-md.md)] server. The highest possible IP address is `255.255.255.255`.<br /><br /> Note: Azure connection attempts are allowed when both this field and the *start_ip_address* field equals `0.0.0.0`.|  
   
 ## Remarks  
  The names of server-level firewall settings must be unique. If the name of the setting provided for the stored procedure already exists in the firewall settings table, the starting and ending IP addresses will be updated. Otherwise, a new server-level firewall setting will be created.  
   
- When you add a server-level firewall setting where the beginning and ending IP addresses are equal to `0.0.0.0`, you enable access to your [!INCLUDE[ssSDS](../../includes/sssds-md.md)] server from Windows Azure. Provide a value to the *name* parameter that will help you remember what the server-level firewall setting is for.  
+ When you add a server-level firewall setting where the beginning and ending IP addresses are equal to `0.0.0.0`, you enable access to your [!INCLUDE[ssSDS](../../includes/sssds-md.md)] server from Azure. Provide a value to the *name* parameter that will help you remember what the server-level firewall setting is for.  
   
  In [!INCLUDE[ssSDS](../../includes/sssds-md.md)], login data required to authenticate a connection and server-level firewall rules are temporarily cached in each database. This cache is periodically refreshed. To force a refresh of the authentication cache and make sure that a database has the latest version of the logins table, execute [DBCC FLUSHAUTHCACHE &#40;Transact-SQL&#41;](../../t-sql/database-console-commands/dbcc-flushauthcache-transact-sql.md).  
   
 ## Permissions  
- Only the server-level principal login created by the provisioning process can create or modify server level firewall rules. The user must be connected to the master database to execute sp_set_firewall_rule.  
+ Only the server-level principal login created by the provisioning process or an Azure Active Directory principal assigned as admin can create or modify server level firewall rules. The user must be connected to the master database to execute sp_set_firewall_rule.  
   
 ## Examples  
- The following code creates a server-level firewall setting called `Allow Windows Azure` that enables access from Windows Azure. Execute the following in the virtual master database.  
+ The following code creates a server-level firewall setting called `Allow Azure` that enables access from Azure. Execute the following in the virtual master database.  
   
 ```  
 -- Enable Windows Azure connections.  
-exec sp_set_firewall_rule N'Allow Windows Azure','0.0.0.0','0.0.0.0';  
+exec sp_set_firewall_rule N'Allow Azure', '0.0.0.0', '0.0.0.0';  
   
 ```  
   
- The following code creates a server-level firewall setting called `Example setting 1` for only the IP address `0.0.0.2`. Then, the `sp_set_firewall_rule` stored procedure is called again to allow an additional IP address, `0.0.0.3`, in that firewall setting.  
+ The following code creates a server-level firewall setting called `Example setting 1` for only the IP address `0.0.0.2`. Then, the `sp_set_firewall_rule` stored procedure is called again to update the end IP address to `0.0.0.4`, in that firewall setting. This creates a range which allows IP addresses `0.0.0.2`, `0.0.0.3`, and `0.0.0.4` to access the server.  
   
 ```  
 -- Create server-level firewall setting for only IP 0.0.0.2  
-exec sp_set_firewall_rule N'Example setting 1','0.0.0.2','0.0.0.2';  
+exec sp_set_firewall_rule N'Example setting 1', '0.0.0.2', '0.0.0.2';  
   
--- Update server-level firewall setting to also allow IP 0.0.0.3  
-exec sp_set_firewall_rule N'Example setting 1','0.0.0.2','0.0.0.3';  
+-- Update server-level firewall setting to create a range of allowed IP addresses
+exec sp_set_firewall_rule N'Example setting 1', '0.0.0.2', '0.0.0.4';  
   
 ```  
   
 ## See Also  
  [Azure SQL Database Firewall](https://azure.microsoft.com/documentation/articles/sql-database-firewall-configure/)   
  [How to: Configure Firewall Settings (Azure SQL Database)](https://azure.microsoft.com/documentation/articles/sql-database-configure-firewall-settings/)   
- [sys.firewall_rules &#40;Azure SQL Database&#41;](../../relational-databases/system-catalog-views/sys-firewall-rules-azure-sql-database.md)  
-  
-  
-
-
+ [sys.firewall_rules &#40;Azure SQL Database&#41;](../../relational-databases/system-catalog-views/sys-firewall-rules-azure-sql-database.md)


### PR DESCRIPTION
Updated Permissions section to indicate that an Azure AD user assigned as the admin or member of an Azure AD group assigned as admin can also create and update rules.
Incrementing the firewall end IP address by just 1 may create a false impression that they are individual IPs rather than a range. The description wasn't helpful either.
Also remove curly quotes from parameter values.
Also added some spaces between stored procedure parameter values, to be consistent with T-SQL docs (https://docs.microsoft.com/en-us/sql/relational-databases/stored-procedures/specify-parameters)