### PR TITLE
Updated int, bigint, smallint, and tinyint (Transact-SQL) page

### DIFF
--- a/docs/t-sql/data-types/int-bigint-smallint-and-tinyint-transact-sql.md
+++ b/docs/t-sql/data-types/int-bigint-smallint-and-tinyint-transact-sql.md
@@ -88,7 +88,7 @@ CREATE TABLE dbo.MyTable
   
 GO  
   
-INSERT INTO dbo.MyTable VALUES (9223372036854775807, 214483647,32767,255);  
+INSERT INTO dbo.MyTable VALUES (9223372036854775807, 2147483647,32767,255);  
  GO  
 SELECT MyBigIntColumn, MyIntColumn, MySmallIntColumn, MyTinyIntColumn  
 FROM dbo.MyTable;  
@@ -99,7 +99,7 @@ FROM dbo.MyTable;
 ```sql
 MyBigIntColumn       MyIntColumn MySmallIntColumn MyTinyIntColumn  
 -------------------- ----------- ---------------- ---------------  
-9223372036854775807  214483647   32767            255  
+9223372036854775807  2147483647  32767            255  
   
 (1 row(s) affected)  
 ```  


### PR DESCRIPTION
"MyIntColumn" in Examples section to properly reflect the largest possible integer

Previous value was 214483647 instead of 2147483647