### PR TITLE
Fix incorrect comment/T-SQL code

### DIFF
--- a/docs/ssms/agent/disable-or-enable-a-job.md
+++ b/docs/ssms/agent/disable-or-enable-a-job.md
@@ -63,7 +63,7 @@ For detailed information, see [Implement SQL Server Agent Security](../../ssms/a
 3.  Copy and paste the following example into the query window and click **Execute**.  
   
     ```  
-    -- changes the name, description, and enables status of the job NightlyBackups.  
+    -- changes the name, description, and disables status of the job NightlyBackups.  
     USE msdb ;  
     GO  
   
@@ -71,7 +71,7 @@ For detailed information, see [Implement SQL Server Agent Security](../../ssms/a
         @job_name = N'NightlyBackups',  
         @new_name = N'NightlyBackups -- Disabled',  
         @description = N'Nightly backups disabled during server migration.',  
-        @enabled = 1 ;  
+        @enabled = 0 ;  
     GO  
     ```  
   


### PR DESCRIPTION
Comment and T-SQL enable the job status, but the new job name indicated it was disabled. 

Fixed T-SQL comment and @enabled flag to indicate the job is disabled, matching the new job name. 