### PR TITLE
64-bit path and removed version specific number

### DIFF
--- a/docs/relational-databases/policy-based-management/import-a-policy-based-management-policy.md
+++ b/docs/relational-databases/policy-based-management/import-a-policy-based-management-policy.md
@@ -35,7 +35,7 @@ manager: "jhubbard"
 ##  <a name="BeforeYouBegin"></a> Before You Begin  
   
 ###  <a name="Restrictions"></a> Limitations and Restrictions  
- [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] ships with policies that can be used to monitor an instance of [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)]. By default, these policies are not installed on the [!INCLUDE[ssDEnoversion](../../includes/ssdenoversion-md.md)], but they can be imported from the default location of C:\Program Files\Microsoft SQL Server\130\Tools\Policies\DatabaseEngine\1033.  
+ [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] ships with policies that can be used to monitor an instance of [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)]. By default, these policies are not installed on the [!INCLUDE[ssDEnoversion](../../includes/ssdenoversion-md.md)], but they can be imported from the default location of C:\Program Files\Microsoft SQL Server\###\Tools\Policies\DatabaseEngine\1033 or C:\Program Files (x86)\Microsoft SQL Server\###\Tools\Policies\DatabaseEngine\1033 on 64-bit installs.
   
 ###  <a name="Security"></a> Security  
   


### PR DESCRIPTION
Added the path for C:\Program Files (x86).... as that is used for 64-bit installs. Also changed the numeric version specific folder of 130 to ### to be more version agnostic