### PR TITLE
SQL authenticated procedure call not permitted

### DIFF
--- a/docs/integration-services/system-stored-procedures/catalog-grant-permission-ssisdb-database.md
+++ b/docs/integration-services/system-stored-procedures/catalog-grant-permission-ssisdb-database.md
@@ -70,6 +70,8 @@ grant_permission [ @object_type = ] object_type
 -   Membership to the **ssis_admin** database role  
   
 -   Membership to the **sysadmin** server role  
+
+This procedure cannot be called by logins that were authenticated by SQL Server. It cannot be called by the sa login.
   
 ## Remarks  
  This stored procedure allows you to grant the permission types described in the following table:  


### PR DESCRIPTION
Hi Folks, this document says that members of the sysadmin server role can call this procedure. That is not true. It cannot be called by logins authenticated by SQL Server such as the sa login.
Regards,
Greg