### PR TITLE
updated - with_clause text

### DIFF
--- a/docs/t-sql/functions/openjson-transact-sql.md
+++ b/docs/t-sql/functions/openjson-transact-sql.md
@@ -61,7 +61,7 @@ By default, the **OPENJSON** table-valued function returns three columns, which 
   
 ![Syntax for WITH clause in OPENJSON TVF](../../relational-databases/json/media/openjson-shema-syntax.png "OPENJSON WITH syntax")
 
-*with_clause* contains a list of columns with their types for **OPENJSON** to return. By default, **OPENJSON** matches keys in *jsonExpression* with the column names in *with_clause*. If a column name does not match a key name, you can provide an optional *column_path*, which is a [JSON Path Expression](../../relational-databases/json/json-path-expressions-sql-server.md) that references a key within the *jsonExpression*. 
+*with_clause* contains a list of columns with their types for **OPENJSON** to return. By default, **OPENJSON** matches keys in *jsonExpression* with the column names in *with_clause* (in this case, matches keys implies that it is case sensitive). If a column name does not match a key name, you can provide an optional *column_path*, which is a [JSON Path Expression](../../relational-databases/json/json-path-expressions-sql-server.md) that references a key within the *jsonExpression*. 
 
 ## Arguments  
 ### *jsonExpression*  


### PR DESCRIPTION
Provided a (hopefully) clear explanation about the "matches keys" regarding the columns and keys matching. SQL usually is case insensitive, but in this case it's not. I've been debugging why I was receiving nulls, and it was because my object properties start with capital letter.