### PR TITLE
Update best-practice-with-the-query-store.md

### DIFF
--- a/docs/relational-databases/performance/best-practice-with-the-query-store.md
+++ b/docs/relational-databases/performance/best-practice-with-the-query-store.md
@@ -314,7 +314,15 @@ WHERE is_forced_plan = 1;
  Execution plans reference objects using three-part names `database.schema.object`.   
 
 If you rename a database, plan forcing will fail which will cause recompilation in all subsequent query executions.  
+
+##  <a name="Recovery"></a> Use traceflags on mission critical servers to improve recovery from disaster
+ 
+  The global traceflags 7745 and 7752 can be used to improve performance of Query Store during High Availability and Disaster Recovery scenarios.
   
+  Traceflag 7745 will prevent the default behavior where Query Store writes data to disk before SQL Server can be shutdown.
+  
+  Traceflag 7752 allows SQL Server to run queries before Query Store has been fully loaded. Default Query Store behavior prevents queries from running before the Query Store has been recovered.
+
 ## See Also  
  [Query Store Catalog Views &#40;Transact-SQL&#41;](../../relational-databases/system-catalog-views/query-store-catalog-views-transact-sql.md)   
  [Query Store Stored Procedures &#40;Transact-SQL&#41;](../../relational-databases/system-stored-procedures/query-store-stored-procedures-transact-sql.md)   


### PR DESCRIPTION
I propose this change because I have found that these two traceflags are necessary for an optimal configuration of Query Store. During a failover, I saw the wait type QDS_LOADDB track 3 minutes of wait time, meaning that Query Store was waiting to load and queries could not run. This behavior is prevented by Traceflag 7752 and I propose that this documentation includes at least a mention of these, considering that best practices are often referenced by consultants and corporations who set up this new feature.

I hope I provided sufficient description of what they do.