### PR TITLE
Update command-line-management-tool-sqllocaldb-exe.md

### DIFF
--- a/docs/relational-databases/express-localdb-instance-apis/command-line-management-tool-sqllocaldb-exe.md
+++ b/docs/relational-databases/express-localdb-instance-apis/command-line-management-tool-sqllocaldb-exe.md
@@ -28,17 +28,17 @@ manager: "jhubbard"
 |Option|What it does|  
 |------------|------------------|  
 |`-?`|Prints help text.|  
-|`create&#124;c "instance name" [version-number] [-s]`|Creates a new LocalDB instance with a specified name and version.<br /><br /> If the [version-number] parameter is omitted, it defaults to the SqlLocalDB build version.<br /><br /> -s starts the new LocalDB instance after it is created.|  
-|`delete&#124;d “instance name”`|Deletes the LocalDB instance with the specified name.|  
-|`start&#124;s "instance name"`|Starts the LocalDB instance with the specified name.|  
-|`stop&#124;p "instance name" [-i&#124;-k]`|Stops the LocalDB instance with the specified name, after current queries finish running.<br /><br /> -i requests the LocalDB instance shutdown with the NOWAIT option.<br /><br /> -k kills the LocalDB instance process without contacting it.|  
-|`share&#124;h ["owner SID or account"] "private name" "shared name"`|Shares the specified private instance using the specified shared name. If the user SID or account name is omitted, it defaults to the current user.|  
-|`unshare&#124;u “shared name”`|Unshares the specified shared LocalDB instance.|  
-|`info&#124;i`|Lists all existing LocalDB instances that are owned by the current user and all shared LocalDB instances.|  
-|`info&#124;i “instance name”`|Prints the information about the specified LocalDB instance.|  
-|`versions&#124;v`|Lists all LocalDB versions installed on the computer.|  
+|`create\|c "instance name" [version-number] [-s]`|Creates a new LocalDB instance with a specified name and version.<br /><br /> If the [version-number] parameter is omitted, it defaults to the SqlLocalDB build version.<br /><br /> -s starts the new LocalDB instance after it is created.|  
+|`delete\|d "instance name"`|Deletes the LocalDB instance with the specified name.|  
+|`start\|s "instance name"`|Starts the LocalDB instance with the specified name.|  
+|`stop\|p "instance name" [-i\|-k]`|Stops the LocalDB instance with the specified name, after current queries finish running.<br /><br /> -i requests the LocalDB instance shutdown with the NOWAIT option.<br /><br /> -k kills the LocalDB instance process without contacting it.|  
+|`share\|h ["owner SID or account"] "private name" "shared name"`|Shares the specified private instance using the specified shared name. If the user SID or account name is omitted, it defaults to the current user.|  
+|`unshare\|u "shared name"`|Unshares the specified shared LocalDB instance.|  
+|`info\|i`|Lists all existing LocalDB instances that are owned by the current user and all shared LocalDB instances.|  
+|`info\|i "instance name"`|Prints the information about the specified LocalDB instance.|  
+|`versions\|v`|Lists all LocalDB versions installed on the computer.|  
 |||  
-|`trace&#124;t on&#124;off`|Turns tracing on and off.|  
+|`trace\|t on\|off`|Turns tracing on and off.|  
   
  SqlLocalDB treats spaces as delimiters; you must surround the instance names that contain spaces and special characters with quotes. For example:  
   


### PR DESCRIPTION
Fixed pipe symbol in documentation.  Was showing HTML code of `&#124;` instead of `|`