### PR TITLE
Update back-up-the-service-master-key.md

### DIFF
--- a/docs/relational-databases/security/encryption/back-up-the-service-master-key.md
+++ b/docs/relational-databases/security/encryption/back-up-the-service-master-key.md
@@ -62,13 +62,12 @@ manager: "jhubbard"
 7.  Copy and paste the following example into the query window and click **Execute**.  
   
     ```  
-    -- Creates a backup of the "AdventureWorks2012" master key.  
-    -- Because this master key is not encrypted by the service master key, a password must be specified when it is opened.  
-    USE AdventureWorks2012;  
-    GO  
-    BACKUP SERVICE MASTER KEY TO FILE = 'c:\temp_backups\keys\service_master_ key'   
-        ENCRYPTION BY PASSWORD = '3dH85Hhk003GHk2597gheij4';  
-    GO  
+    -- Creates a backup of the service master key.
+    USE master;
+    GO
+    BACKUP SERVICE MASTER KEY TO FILE = 'c:\temp_backups\keys\service_master_ key'
+        ENCRYPTION BY PASSWORD = '3dH85Hhk003GHk2597gheij4';
+    GO
     ```  
   
     > [!NOTE]  


### PR DESCRIPTION
The Service Master Key shouldn't need to be in any user database context, and the comment relating to the password protection seems to have been copied from the code example on backing up the Database Master Key.

(Once again the entire section seems to want updating for a couple lines of example code. Weird.)