### PR TITLE
Update row-level-security.md

### DIFF
--- a/docs/relational-databases/security/row-level-security.md
+++ b/docs/relational-databases/security/row-level-security.md
@@ -57,9 +57,7 @@ manager: "jhubbard"
   
  Both filter and block predicates and security policies have the following behavior:  
   
--   You may define a predicate function that joins with another table and/or invokes a function. If the security policy is created with `SCHEMABINDING = ON`, then the join or function is accessible from the query and works as expected without any additional permission checks. If the security policy is created with `SCHEMABINDING = OFF`, then users will need **SELECT** or **EXECUTE** permissions on these additional tables and functions in order to query the target table.  
-  
-     You may define a predicate function that joins with another table and/or invokes a function. The join/function is accessible from the query and works as expected without any additional permission checks.  
+-   You may define a predicate function that joins with another table and/or invokes a function. If the security policy is created with `SCHEMABINDING = ON`, then the join or function is accessible from the query and works as expected without any additional permission checks. If the security policy is created with `SCHEMABINDING = OFF`, then users will need **SELECT** or **EXECUTE** permissions on these additional tables and functions in order to query the target table.
   
 -   You may issue a query against a table that has a security predicate defined but disabled. Any rows that would have been filtered or blocked are not affected.  
   


### PR DESCRIPTION
"You may define a predicate function that joins with another table..." is repeated in the next line, but without the `SCHEMABINDING` information. It seems like a duplicate sentence.