### PR TITLE
Remove reference to selecting a rule in the Default section

### DIFF
--- a/docs/relational-databases/databases/create-a-user-defined-data-type-alias.md
+++ b/docs/relational-databases/databases/create-a-user-defined-data-type-alias.md
@@ -61,7 +61,7 @@ manager: "jhubbard"
      Select the base data type from the list box. The list box displays all data types except for the **geography**, **geometry**, **hierarchyid**, **sysname**, **timestamp** , and **xml** data types. The data type of an existing user-defined data type is not editable.  
   
      **Default**  
-     Optionally select a rule or a default to bind to the user-defined data type alias.  
+     Optionally select a default to bind to the user-defined data type alias.  
   
      **Length/Precision**  
      Displays the length or precision of the data type as applicable. **Length** applies to character-based user-defined data types; **Precision** applies only to numeric-based user-defined data types. The label changes depending on the data type selected earlier. This box is not editable if the length or precision of the selected data type is fixed.  


### PR DESCRIPTION
Rule has its own section, in the correct place alphabetically.