### PR TITLE
TRUNCATE TABLE Restrictions for ADW & APS

### DIFF
--- a/docs/t-sql/statements/truncate-table-transact-sql.md
+++ b/docs/t-sql/statements/truncate-table-transact-sql.md
@@ -116,7 +116,13 @@ TRUNCATE TABLE [ { database_name . [ schema_name ] . | schema_name . ] table_nam
   
  For tables with one or more of these characteristics, use the DELETE statement instead.  
   
- TRUNCATE TABLE cannot activate a trigger because the operation does not log individual row deletions. For more information, see [CREATE TRIGGER &#40;Transact-SQL&#41;](../../t-sql/statements/create-trigger-transact-sql.md).  
+ TRUNCATE TABLE cannot activate a trigger because the operation does not log individual row deletions. For more information, see [CREATE TRIGGER &#40;Transact-SQL&#41;](../../t-sql/statements/create-trigger-transact-sql.md). 
+ 
+ In [!INCLUDE[sssdwfull](../../includes/sssdwfull-md.md)] and [!INCLUDE[sspdw](../../includes/sspdw-md.md)]:
+
+- TRUNCATE TABLE is not allowed within the EXPLAIN statement.
+
+- TRUNCATE TABLE cannot be ran inside of a transaction.
   
 ## Truncating Large Tables  
  [!INCLUDE[msCoName](../../includes/msconame-md.md)] [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] has the ability to drop or truncate tables that have more than 128 extents without holding simultaneous locks on all the extents required for the drop.  


### PR DESCRIPTION
Add restrictions for APS & ADW.  These were documented in .CHM of previous APS versions.