### PR TITLE
Fixing syntax specification

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-execute-external-script-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-execute-external-script-transact-sql.md
@@ -36,15 +36,14 @@ manager: "jhubbard"
   
 ```  
 sp_execute_external_script   
-    @language = N'language' ,   
-    @script = N'script',  
-  
-    @input_data_1 = ] 'input_data_1'   
-    [ , @input_data_1_name = ] N'input_data_1_name' ]   
-    [ , @output_data_1_name = 'output_data_1_name' ]  
+    @language = N'language,   
+    @script = N'script'  
+    [ , @input_data_1 = N'input_data_1' ]   
+    [ , @input_data_1_name = N'input_data_1_name' ]   
+    [ , @output_data_1_name = N'output_data_1_name' ]  
     [ , @parallel = 0 | 1 ]  
-    [ , @params = ] N'@parameter_name data_type [ OUT | OUTPUT ] [ ,...n ]'  
-    [ , @parameter1 = ] 'value1' [ OUT | OUTPUT ] [ ,...n ]  
+    [ , @params = N'@parameter_name data_type [ OUT | OUTPUT ] [ ,...n ]'  
+    [ , @parameter1 = 'value1' [ OUT | OUTPUT ] [ ,...n ]  
     [ WITH <execute_option> ]  
 [;]  
   


### PR DESCRIPTION
In the existing specification:

- Some string parameter values require Unicode values but are missing the `N` prefix (e.g. `N'value'`) 
- The square brackets used to indicate optional parameters are incorrect.

This pull request addresses both of these issues.