### PR TITLE
Increase accuracy of operator precedence

### DIFF
--- a/docs/t-sql/language-elements/operator-precedence-transact-sql.md
+++ b/docs/t-sql/language-elements/operator-precedence-transact-sql.md
@@ -36,9 +36,10 @@ manager: "jhubbard"
 |3|+ (Positive), - (Negative), + (Add), (+ Concatenate), - (Subtract), & (Bitwise AND), ^ (Bitwise Exclusive OR), &#124; (Bitwise OR)|  
 |4|=, >, \<, >=, <=, <>, !=, !>, !< (Comparison operators)|  
 |5|NOT|  
-|6|AND|  
-|7|ALL, ANY, BETWEEN, IN, LIKE, OR, SOME|  
-|8|= (Assignment)|  
+|6|ALL, ANY, BETWEEN, IN, LIKE, SOME|  
+|7|AND|
+|8|OR|
+|9|= (Assignment)|  
   
  When two operators in an expression have the same operator precedence level, they are evaluated left to right based on their position in the expression. For example, in the expression that is used in the following `SET` statement, the subtraction operator is evaluated before the addition operator.  
   


### PR DESCRIPTION
AND and OR have higher precedence than IN, LIKE, SOME, etc.

Consider the following example which TSQL accepts properly:

```sql
X = Y AND Z IN (1, 2, 3)
```

With the existing table and precedence numbers, this ought to be parsed as:

```sql
((X = Y) AND Z) IN (1, 2, 3)
```

But with my corrected numbers, it ought to be parsed

```sql
(X = Y) AND (Z IN (1, 2, 3))
```

which I believe is correct:

```sql
1> select 'Correct!' where 3 = 3 AND 7 in (7);
2> go

Correct!
(1 row affected)
1> select 'Correct!' where (3 = 3 AND 7) in (7);
2> go
Msg 4145 (severity 15, state 1) from 9d665ba5181d Line 1:
	"An expression of non-boolean type specified in a context where a condition is expected, near ')'."
````

I only noticed this as I'm writing a parser for the TSQL language and using this table tripped me up. 