### PR TITLE
Expanded definitions and updated for SQL Server 2017

### DIFF
--- a/docs/t-sql/functions/collation-functions-collationproperty-transact-sql.md
+++ b/docs/t-sql/functions/collation-functions-collationproperty-transact-sql.md
@@ -45,10 +45,10 @@ Is the property of the collation. *property* is **varchar(128)**, and can be any
   
 |Property name|Description|  
 |---|---|
-|**CodePage**|Non-Unicode code page of the collation.|  
-|**LCID**|Windows LCID of the collation.|  
-|**ComparisonStyle**|Windows comparison style of the collation. Returns 0 for all binary collations .|  
-|**Version**|The version of the collation, derived from the version field of the collation ID. Returns 2, 1, or 0.<br /><br /> Collations with "100" in the name) return 2.<br /><br /> Collations with "90" in the name) return 1.<br /><br /> All other collations return 0.|  
+|**CodePage**|Non-Unicode code page of the collation. Please see [Appendix G DBCS/Unicode Mapping Tables](https://msdn.microsoft.com/en-us/library/cc194886.aspx) and [Appendix H Code Pages](https://msdn.microsoft.com/en-us/library/cc195051.aspx) to translate these values and see their character mappings.|  
+|**LCID**|Windows LCID of the collation. Please see [LCID Structure](https://msdn.microsoft.com/en-us/library/cc233968.aspx) to translate these values (you will need to convert to `VARBINARY` first).|  
+|**ComparisonStyle**|Windows comparison style of the collation. Returns 0 for all binary collations (both `_BIN` and `_BIN2`) as well as when all properties are sensitive. Bitmask values:<br /><br /> Ignore case : 1<br /><br /> Ignore accent : 2<br /><br /> Ignore Kana : 65536<br /><br /> Ignore width : 131072|  
+|**Version**|The version of the collation, derived from the version field of the collation ID. Returns an integer value between 0 and 3.<br /><br /> Collations with "140" in the name return 3.<br /><br /> Collations with "100" in the name return 2.<br /><br /> Collations with "90" in the name return 1.<br /><br /> All other collations return 0.|  
   
 ## Return types
 **sql_variant**


### PR DESCRIPTION
Expanded definitions of "CodePage", "LCID", and "ComparisonStyle" properties so that they aren't a mystery to most people who don't know where to get those definitions. I copied the 4 bitmask values for "ComparisonStyle" from [DATABASEPROPERTYEX]( https://docs.microsoft.com/en-us/sql/t-sql/functions/databasepropertyex-transact-sql) but did not copy the "for example" portion as that seemed extraneous. But, if it is best that it be here for consistency then I can add it in.

Regarding the link used for "LCID": the page has the value in hex which requires the extra step of converting the INT value returned here, but that list is by far the most complete that I could find. In fact, I couldn't find any other list that included entries for values 0x00010407 through 0x00040411.

Regarding the addition to the "Version" info: I confirmed that info on SQL Server 2017 as **3** is returned for the new Japanese collations (i.e. the `Japanese_Bushu_Kakusu_140_` series and the `Japanese_XJIS_140_` series).