### PR TITLE
Comment on NEWSEQUENTIALID/UuidCreateSequential byte shuffling

### DIFF
--- a/docs/t-sql/functions/newsequentialid-transact-sql.md
+++ b/docs/t-sql/functions/newsequentialid-transact-sql.md
@@ -31,7 +31,7 @@ manager: "jhubbard"
 > [!IMPORTANT]  
 >  If privacy is a concern, do not use this function. It is possible to guess the value of the next generated GUID and, therefore, access data associated with that GUID.  
   
- NEWSEQUENTIALID is a wrapper over the Windows [UuidCreateSequential](http://go.microsoft.com/fwlink/?LinkId=164027) function.  
+ NEWSEQUENTIALID is a wrapper over the Windows [UuidCreateSequential](http://go.microsoft.com/fwlink/?LinkId=164027) function, with some [byte shuffling applied](https://blogs.msdn.microsoft.com/dbrowne/2012/07/03/how-to-generate-sequential-guids-for-sql-server-in-net/).
   
 > [!WARNING]  
 >  The UuidCreateSequential function has hardware dependencies. On [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)], clusters of sequential values can develop when databases (such as contained databases) are moved to other computers. When using Always On and on [!INCLUDE[sqldbesa](../../includes/sqldbesa-md.md)], clusters of sequential values can develop if the database fails over to a different computer.  


### PR DESCRIPTION
This pull request will add a comment on NEWSEQUENTIALID that the
result of the function Uuidcreatesequential is not used as-is, some
byte shuffling is performed.  A link to a relevant blog post that
describes the byte shuffling algorithm is also added.

https://blogs.msdn.microsoft.com/dbrowne/2012/07/03/how-to-generate-sequential-guids-for-sql-server-in-net/