### PR TITLE
Documenting WITH RESULT SETS options

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-execute-external-script-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-execute-external-script-transact-sql.md
@@ -67,6 +67,7 @@ sp_execute_external_script
         [ db_name . [ schema_name ] . | schema_name . ]   
         {table_name | view_name | table_valued_function_name }  
     | AS TYPE [ schema_name.]table_type_name  
+    | AS FOR XML  
 }  
 ```  
   
@@ -106,6 +107,35 @@ sp_execute_external_script
   
  [ @parameter1 = '*value1*'  [ OUT | OUTPUT ] [ ,...n ] ]  
  A list of values for the input parameters used by the external script.  
+ 
+ [ WITH \<execute_option> ]  
+ Possible execute options. The RESULT SETS options cannot be specified when this procedure is executed using `INSERT…EXEC`.  
+  
+|Term|Definition|  
+|----------|----------------|  
+|RESULT SETS UNDEFINED|This option provides no guarantee of what results, if any, will be returned.  The script executes without error regardless of whether or not it returns results.<br /><br />No result set definition is provided. If results are output by the script, all columns will be returned as unnamed columns. This is true even if columns are assigned names within the script.<br /><br />RESULT SETS UNDEFINED is the default behavior if a result_sets_option is not provided.|  
+|RESULT SETS NONE|Guarantees that no results will be returned. If the script produces results, an error is returned.|  
+|RESULT SETS (*\<result_sets_definition>*)|Guarantees that results will be returned that are structured as specified by *\<result_sets_definition>*. For more information, see *\<result_sets_definition>* later in this topic.<br /><br />If the script does not return results or if they are incompatible with *\<result_sets_definition>*, an error is returned.|
+  
+\<result_sets_definition>
+ Describes the result set returned by this procedure. The clauses of the result_sets_definition have the following meaning  
+  
+|Term|Definition|  
+|----------|----------------|  
+|{<br /><br /> column_name<br /><br /> data_type<br /><br /> [ COLLATE collation_name]<br /><br /> [NULL &#124; NOT NULL]<br /><br /> }|See the table below.|  
+|db_name|The name of the database containing the table, view or table valued function.|  
+|schema_name|The name of the schema owning the table, view or table valued function.|  
+|table_name &#124; view_name &#124; table_valued_function_name|Specifies that the columns returned will be those specified in the table, view or table valued function named. Table variables and synonyms are not supported in the `AS OBJECT` syntax.|  
+|AS TYPE [schema_name.]table_type_name|Specifies that the columns returned will be those specified in the table type.|  
+|AS FOR XML|Causes results to be formatted as though they were produced by a `SELECT … FOR XML …` statement. To use this option, the results produced by the script must consist of a single, ntext-compatible column.|  
+  
+|Term|Definition|  
+|----------|----------------|  
+|column_name|The names of each column. If the number of columns differs from the result set, an error occurs.|  
+|data_type|The data types of each column. If the data types differ, an implicit conversion to the defined data type is performed. If the conversion fails, an error is returned.|  
+|COLLATE collation_name|The collation of each column.|  
+|NULL &#124; NOT NULL|The nullability of each column. If the defined nullability is NOT NULL and the data returned contains NULLs an error occurs. If not specified, the default value conforms to the setting of the ANSI_NULL_DFLT_ON and ANSI_NULL_DFLT_OFF options.|  
+
   
 ## Remarks  
  Use **sp_execute_external_script** to execute scripts written in a supported language such as R. In [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)], [!INCLUDE[rsql_productname](../../includes/rsql-productname-md.md)] is comprised of a server component installed with [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)], and a set of workstation tools and connectivity libraries that connect the data scientist to the high-performance environment of [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)]. Install R Services (In-Database) during [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] setup to enable the execution of R scripts. For more information, see [Set up SQL Server R Services &#40;In-Database&#41;](../../advanced-analytics/r-services/set-up-sql-server-r-services-in-database.md).  
@@ -168,17 +198,11 @@ SELECT tipped, passenger_count, trip_time_in_secs, trip_distance, d.direct_dista
   
 -   CLR user-defined types  
   
- `WITH RESULTS SETS`  clause is mandatory if you are returning a result set from R . The specified column data types need to match the types supported in R (**bit**, **int**, **float**, **datetime**, **varchar**)  
-  
  **datetime** values in the input are converted to NA on the R side for values that do not fit the permissible range of values in R. this is required because [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] permits a larger range of values than is supported in the R language.  
   
  Float values (for example, +Inf, -Inf, NaN) are not supported in [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] even though both languages use IEEE 754. Current behavior just sends the values to [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] directly and as a result sqlclient in [!INCLUDE[ssManStudio](../../includes/ssmanstudio-md.md)] throws error. These values convert to **NULL**.  
   
- When using the `WITH RESULTS SET` clause, an error is raised in the following conditions:  
-  
--   The number of columns doesn’t match the number of columns in the R data frame.  
-  
--   Any [!INCLUDE[tsql](../../includes/tsql-md.md)] data type that cannot be mapped to an R data type is transfered as NULL. Any R result set that cannot be mapped to a [!INCLUDE[tsql](../../includes/tsql-md.md)] data type, transfers as NULL.  
+ Any R result set that cannot be mapped to a [!INCLUDE[tsql](../../includes/tsql-md.md)] data type, is output as NULL.  
   
 ## Permissions  
  Requires **EXECUTE ANY EXTERNAL SCRIPT** database permission.  


### PR DESCRIPTION
Text describing `WITH RESUT SETS` is adapted from the description of that set of options on https://docs.microsoft.com/en-us/sql/t-sql/language-elements/execute-transact-sql.

Change includes removing erroneous statement that `WITH RESULTS SETS` is mandatory if data is returned by an R script. The fact that this is incorrect is demonstrated by the fact that the following query/R script returns results without errors and without a `WITH RESULT SETS` clause:

    EXEC sp_execute_external_script
    @language = N'R',
    @script = N'OutputDataSet = InputDataSet',
    @input_data_1 = N'SELECT 1';

Also, change removes a couple of other remarks about returning results from R scripts that are covered by the new 'WITH RESULT SETS' description.