### PR TITLE
Adding mssql user warning for Linux

### DIFF
--- a/docs/database-engine/configure-windows/database-engine-service-startup-options.md
+++ b/docs/database-engine/configure-windows/database-engine-service-startup-options.md
@@ -28,6 +28,8 @@ manager: "jhubbard"
   
 > [!WARNING]  
 >  Improper use of startup options can affect server performance and can prevent [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] from starting.  
+>
+>  Start SQL Server on Linux with the "mssql" user to prevent future startup issues. Example "sudo -u mssql /opt/mssql/bin/sqlservr [STARTUP OPTIONS]" 
   
 ## About Startup Options  
  When you install [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)], Setup writes a set of default startup options in the [!INCLUDE[msCoName](../../includes/msconame-md.md)] Windows registry. You can use these startup options to specify an alternate master database file, master database log file, or error log file. If the [!INCLUDE[ssDE](../../includes/ssde-md.md)] cannot locate the necessary files, [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] will not start.  


### PR DESCRIPTION
Warning for starting SQL Server on Linux with non-"mssql" users