### PR TITLE
Fixing parameter name typo

### DIFF
--- a/docs/advanced-analytics/tutorials/walkthrough-deploy-and-use-the-model.md
+++ b/docs/advanced-analytics/tutorials/walkthrough-deploy-and-use-the-model.md
@@ -66,7 +66,7 @@ A stored procedure for batch scoring was created when you initially ran the Powe
 
     + You use a SELECT statement to call the stored model from a SQL table. The model is retrieved from the table as **varbinary(max)** data, stored in the SQL variable _@lmodel2_, and passed as the parameter *mod* to the system stored procedure [sp_execute_external_script](../../relational-databases/system-stored-procedures/sp-execute-external-script-transact-sql.md).
 
-    + The data used as inputs for scoring is defined as a SQL query and stored as a string in the SQL variable _@input_. As data is retrieved from the database, it is stored in a data frame called *InputDataSet*, which is just the default name for input data to the [sp_execute_external_script](../../relational-databases/system-stored-procedures/sp-execute-external-script-transact-sql.md) procedure; you can define another variable name if needed by using the parameter _@input\_data\_1\_name_.
+    + The data used as inputs for scoring is defined as a SQL query and stored as a string in the SQL variable _@input_. As data is retrieved from the database, it is stored in a data frame called *InputDataSet*, which is just the default name for input data to the [sp_execute_external_script](../../relational-databases/system-stored-procedures/sp-execute-external-script-transact-sql.md) procedure; you can define another variable name if needed by using the parameter *_@input_data_1_name_*.
 
     + To generate the scores, the stored procedure calls the `rxPredict` function from the **RevoScaleR** library.
 


### PR DESCRIPTION
Comment text on commit is incorrect--this removes unnecessary slashes from a parameter name