### PR TITLE
Update output-clause-transact-sql.md to fix indentation

### DIFF
--- a/docs/t-sql/queries/output-clause-transact-sql.md
+++ b/docs/t-sql/queries/output-clause-transact-sql.md
@@ -95,7 +95,7 @@ ms.workload: "Active"
   
 -   Have CHECK constraints or enabled rules.  
   
- *column_list*  
+*column_list*  
  Is an optional list of column names on the target table of the INTO clause. It is analogous to the column list allowed in the [INSERT](../../t-sql/statements/insert-transact-sql.md) statement.  
   
  *scalar_expression*  


### PR DESCRIPTION
After the *output_table* list on line 90, the following paragraphs through line 127 were indented at the list level because of the leading space before *column_list* on line 98.