### PR TITLE
Fix SQL Syntax of language element DECLARE

### DIFF
--- a/docs/t-sql/language-elements/declare-local-variable-transact-sql.md
+++ b/docs/t-sql/language-elements/declare-local-variable-transact-sql.md
@@ -40,13 +40,13 @@ ms.workload: "Active"
   
 DECLARE   
 {   
-    { @local_variable [AS] data_type  | [ = value ] }  
+    { @local_variable [AS] data_type  [ = value ] }  
   | { @cursor_variable_name CURSOR }  
 } [,...n]   
 | { @table_variable_name [AS] <table_type_definition> }   
   
 <table_type_definition> ::=   
-     TABLE ( { <column_definition> | <table_constraint> } [ ,... ] )   
+     TABLE ( { <column_definition> | <table_constraint> } [ ,...n] )   
   
 <column_definition> ::=   
      column_name { scalar_data_type | AS computed_column_expression }  
@@ -63,7 +63,7 @@ DECLARE
      }   
   
 <table_constraint> ::=   
-     { { PRIMARY KEY | UNIQUE } ( column_name [ ,... ] )   
+     { { PRIMARY KEY | UNIQUE } ( column_name [ ,...n] )   
      | CHECK ( search_condition )   
      }   
   


### PR DESCRIPTION
...according to https://docs.microsoft.com/en-us/sql/t-sql/language-elements/transact-sql-syntax-conventions-transact-sql

The `|` (vertical bar) is a separation of a list of elements between brackets and is an either-or option. 

> Separates syntax items enclosed in brackets or braces. You can use only one of the items.

The `|` is not required to precede the `[ = value ]` definition for variables and was removed.


The `[,...n]` is to show that the preceding item can be repeated _n_ number of times. 

> Indicates the preceding item can be repeated n number of times. The occurrences are separated by commas.

The syntax definition for the language element `DECLARE` had two positions missing an _n_. This has been corrected.

The SQL Syntax for DECLARE was entered in http://www.colindaley.com/translator/Translator.aspx and translated and generated as a Railroad Diagram to graphically verify the syntax.




