### PR TITLE
Fix bad example for sp_changemergepublication

### DIFF
--- a/docs/relational-databases/replication/publish/set-the-compatibility-level-for-merge-publications.md
+++ b/docs/relational-databases/replication/publish/set-the-compatibility-level-for-merge-publications.md
@@ -107,11 +107,11 @@ DECLARE @publication AS sysname;
 SET @publication = N'AdvWorksSalesOrdersMerge' ;  
   
 -- Change the publication compatibility level to   
--- SQL Server 2012.  
+-- SQL Server 2008 or later.  
 EXEC sp_changemergepublication   
 @publication = @publication,   
 @property = N'publication_compatibility_level',   
-@value = N'110RTM';  
+@value = N'100RTM';  
 GO  
   
 ```  


### PR DESCRIPTION
As is [documented](https://docs.microsoft.com/sql/relational-databases/system-stored-procedures/sp-changemergepublication-transact-sql), `sp_changemergepublication` only accepts `90RTM` and `100RTM` for `publication_compatibility_level`, and it will give an error on other values. It's neither necessary nor possible to increase the compat level beyond `100RTM`, even for later versions of SQL Server, and implying it is [confuses people](https://stackoverflow.com/q/47076507/4137916).

A possible alternative is to remove this example altogether, as, at present, almost nobody has any need to change the property.