### PR TITLE
Fix duplicate SQL 2012 in supported servers

### DIFF
--- a/docs/relational-databases/native-client/applications/support-policies-for-sql-server-native-client.md
+++ b/docs/relational-databases/native-client/applications/support-policies-for-sql-server-native-client.md
@@ -21,7 +21,7 @@ ms.workload: "On Demand"
   This topic discusses how various data-access components can be used with [!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)] Native Client.  
   
 ## Server Support  
- [!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)] Native Client 11.0 supports connections to, [!INCLUDE[ssKatmai](../../../includes/sskatmai-md.md)], [!INCLUDE[ssKilimanjaro](../../../includes/sskilimanjaro-md.md)], [!INCLUDE[ssSQL11](../../../includes/sssql11-md.md)], [!INCLUDE[ssSQL11](../../../includes/sssql11-md.md)], and [!INCLUDE[ssSDSfull](../../../includes/sssdsfull-md.md)].  
+ [!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)] Native Client 11.0 supports connections to, [!INCLUDE[ssKatmai](../../../includes/sskatmai-md.md)], [!INCLUDE[ssKilimanjaro](../../../includes/sskilimanjaro-md.md)], [!INCLUDE[ssSQL11](../../../includes/sssql11-md.md)], [!INCLUDE[ssSQL14](../../../includes/sssql14-md.md)], and [!INCLUDE[ssSDSfull](../../../includes/sssdsfull-md.md)].  
   
 ## Supported Operating System Versions  
  The following table lists which operating systems support [!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)] Native Client.  


### PR DESCRIPTION
Hopefully I did that right, I'm a little new to Git/Markdown.

The following URL lists SQL 2012 twice but then later on shows that SQL 2014 is supported with the SQL Native Client v11.0

https://docs.microsoft.com/en-us/sql/relational-databases/native-client/applications/support-policies-for-sql-server-native-client