### PR TITLE
Unclear large string types can't be used

### DIFF
--- a/docs/t-sql/queries/contains-transact-sql.md
+++ b/docs/t-sql/queries/contains-transact-sql.md
@@ -172,7 +172,7 @@ CONTAINS (
  \<*contains_search_condition*>  
  Specifies the text to search for in *column_name* and the conditions for a match.  
   
-*\<contains_search_condition>* is **nvarchar**. An implicit conversion occurs when another character data type is used as input. In the following example, the `@SearchWord` variable, which is defined as `varchar(30)`, causes an implicit conversion in the `CONTAINS` predicate.
+*\<contains_search_condition>* is **nvarchar**. An implicit conversion occurs when another character data type is used as input. Large string data types nvarchar(max) and varchar(max) cannot be used. In the following example, the `@SearchWord` variable, which is defined as `varchar(30)`, causes an implicit conversion in the `CONTAINS` predicate.
   
 ```sql  
 USE AdventureWorks2012;  


### PR DESCRIPTION
The description of the data type does not explicitly call out nvarchar(max) or varchar(max) which don't work.