### PR TITLE
Add code for Example A in CREATE DATABASE T-SQL statements element

### DIFF
--- a/docs/t-sql/statements/create-database-sql-server-transact-sql.md
+++ b/docs/t-sql/statements/create-database-sql-server-transact-sql.md
@@ -522,6 +522,9 @@ GO
 ```  
 USE master;  
 GO  
+IF DB_ID (N'mytest') IS NOT NULL
+DROP DATABASE mytest;
+GO
 CREATE DATABASE mytest;  
 GO  
 -- Verify the database files and sizes  


### PR DESCRIPTION
…because the description claims "This example also demonstrates how to drop the database named `mytest` if it exists, before creating the `mytest` database." This code was missing in the official documentation for Example A.
