### PR TITLE
Join database to second secondary

### DIFF
--- a/docs/database-engine/availability-groups/windows/configure-distributed-availability-groups.md
+++ b/docs/database-engine/availability-groups/windows/configure-distributed-availability-groups.md
@@ -205,6 +205,12 @@ ALTER AVAILABILITY GROUP [distributedag]
 GO  
 ```  
 
+## <a name="failover"></a> Join the database on the secondary of the second availability group
+After the database on the seoncdary of the second availabilty group has went into a restoring state you have to manually join it to the availability group.
+
+```sql  
+ALTER DATABASE [db1] SET HADR AVAILABILITY GROUP = [ag1];   
+```  
   
 ## <a name="failover"></a> Fail over to a secondary availability group  
 Only manual failover is supported at this time. The following Transact-SQL statement fails over the distributed availability group named `distributedag`:  

--- a/docs/database-engine/availability-groups/windows/configure-distributed-availability-groups.md
+++ b/docs/database-engine/availability-groups/windows/configure-distributed-availability-groups.md
@@ -206,7 +206,7 @@ GO
 ```  
 
 ## <a name="failover"></a> Join the database on the secondary of the second availability group
-After the database on the seoncdary of the second availabilty group has went into a restoring state you have to manually join it to the availability group.
+After the database on the secondary of the second availability group has went into a restoring state you have to manually join it to the availability group.
 
 ```sql  
 ALTER DATABASE [db1] SET HADR AVAILABILITY GROUP = [ag1];   


### PR DESCRIPTION
Based on a support case I had open with Microsoft you have to after the direct seeding of the database is completed on the second secondary join database to the secondary.  I had to do this each of the 8 times I created a distributed AG.