### PR TITLE
SQL Server supports user provided certs.

### DIFF
--- a/docs/linux/sql-server-linux-security-overview.md
+++ b/docs/linux/sql-server-linux-security-overview.md
@@ -25,7 +25,7 @@ SQL Server on Linux currently has the following limitations:
 * A standard password policy is provided. MUST_CHANGE is the only option you may configure.  
 * Extensible Key Management is not supported. 
 * Using keys stored in the Azure Key Vault is not supported.
-* SQL Server generates its own self-signed certificate for encrypting connections. Currently, SQL Server cannot be configured to use a user provided certificate for SSL or TLS. 
+* SQL Server generates its own self-signed certificate for encrypting connections. SQL Server can be configured to use a user provided certificate for TLS. 
 
 For more infomation about security features available in SQL Server, see the [Security Center for SQL Server Database Engine and Azure SQL Database](../relational-databases/security/security-center-for-sql-server-database-engine-and-azure-sql-database.md).
 


### PR DESCRIPTION
SQL Server can be configured to use a user provided certificate for TLS. Making change to reflect this in our docs