### PR TITLE
Update sql-server-linux-shared-disk-cluster-red-hat-7-configure.md

### DIFF
--- a/docs/linux/sql-server-linux-shared-disk-cluster-red-hat-7-configure.md
+++ b/docs/linux/sql-server-linux-shared-disk-cluster-red-hat-7-configure.md
@@ -260,8 +260,8 @@ At this point both instances of SQL Server are configured to run with the databa
 
    ```bash
    sudo touch /var/opt/mssql/secrets/passwd
-   sudo echo '<loginName>' >> /var/opt/mssql/secrets/passwd
-   sudo echo '<loginPassword>' >> /var/opt/mssql/secrets/passwd
+   echo '<loginName>' | sudo tee -a /var/opt/mssql/secrets/passwd
+   echo '<loginPassword>' | sudo tee -a /var/opt/mssql/secrets/passwd
    sudo chown root:root /var/opt/mssql/secrets/passwd 
    sudo chmod 600 /var/opt/mssql/secrets/passwd    
    ```

--- a/docs/linux/sql-server-linux-shared-disk-cluster-red-hat-7-configure.md
+++ b/docs/linux/sql-server-linux-shared-disk-cluster-red-hat-7-configure.md
@@ -237,7 +237,7 @@ For additional information about using NFS, see the following resources:
    ``` 
    $ chown mssql /var/opt/mssql/data
    $ chgrp mssql /var/opt/mssql/data
-   $ su mssql
+   $ sudo su mssql
    $ cp /var/opt/mssql/tmp/* /var/opt/mssql/data/
    $ rm /var/opt/mssql/tmp/*
    $ exit

--- a/docs/linux/sql-server-linux-shared-disk-cluster-red-hat-7-configure.md
+++ b/docs/linux/sql-server-linux-shared-disk-cluster-red-hat-7-configure.md
@@ -209,7 +209,7 @@ For additional information about using NFS, see the following resources:
 1.  **On the primary node only**, save the database files to a temporary location.The following script, creates a new temporary directory, copies the database files to the new directory, and removes the old database files. As SQL Server runs as local user mssql, you need to make sure that after data transfer to the mounted share, local user has read-write access to the share. 
 
    ``` 
-   $ su mssql
+   $ sudo su mssql
    $ mkdir /var/opt/mssql/tmp
    $ cp /var/opt/mssql/data/* /var/opt/mssql/tmp
    $ rm /var/opt/mssql/data/*

--- a/docs/linux/sql-server-linux-shared-disk-cluster-red-hat-7-configure.md
+++ b/docs/linux/sql-server-linux-shared-disk-cluster-red-hat-7-configure.md
@@ -235,8 +235,8 @@ For additional information about using NFS, see the following resources:
 1.  Copy the database and log files that you saved to `/var/opt/mssql/tmp` to the newly mounted share `/var/opt/mssql/data`. This only needs to be done **on the primary node**. Make sure that you give read write permissions to 'mssql' local user.
 
    ``` 
-   $ chown mssql /var/opt/mssql/data
-   $ chgrp mssql /var/opt/mssql/data
+   $ sudo chown mssql /var/opt/mssql/data
+   $ sudo chgrp mssql /var/opt/mssql/data
    $ sudo su mssql
    $ cp /var/opt/mssql/tmp/* /var/opt/mssql/data/
    $ rm /var/opt/mssql/tmp/*


### PR DESCRIPTION
``sudo``  command is required to switch user ``su`` command because ``mssql`` user has no password by default.