### PR TITLE
Update unicode-compression-implementation.md

### DIFF
--- a/docs/relational-databases/data-compression/unicode-compression-implementation.md
+++ b/docs/relational-databases/data-compression/unicode-compression-implementation.md
@@ -25,13 +25,13 @@ ms.workload: "Inactive"
 # Unicode Compression Implementation
 [!INCLUDE[appliesto-ss-asdb-xxxx-xxx-md](../../includes/appliesto-ss-asdb-xxxx-xxx-md.md)]
 
-  [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] uses an implementation of the Standard Compression Scheme for Unicode (SCSU) algorithm to compress Unicode values that are stored in row or page compressed objects. For these compressed objects, Unicode compression is automatic for **nchar(n)** and **nvarchar(n)** columns. The [!INCLUDE[ssDE](../../includes/ssde-md.md)] stores Unicode data as 2 bytes, regardless of locale. This is known as UCS-2 encoding. For some locales, the implementation of SCSU compression in SQL Server can save up to 50 percent in storage space.  
+  [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] uses an implementation of the Standard Compression Scheme for Unicode (SCSU) algorithm to compress Unicode values that are stored in row or page or ColumnStore compressed objects. For these compressed objects, Unicode compression is automatic for **nchar(n)** and **nvarchar(n)** columns. The [!INCLUDE[ssDE](../../includes/ssde-md.md)] stores Unicode data as 2 bytes, regardless of locale. This is known as UCS-2 encoding. For some locales, the implementation of SCSU compression in SQL Server can save up to 50 percent in storage space.  
   
 ## Supported Data Types  
  Unicode compression supports the fixed-length **nchar(n)** and **nvarchar(n)** data types. Data values that are stored off row or in **nvarchar(max)** columns are not compressed.  
   
 > [!NOTE]  
->  Unicode compression is not supported for **nvarchar(max)** data even if it is stored in row. However, this data type can still benefit from page compression.  
+>  Unicode compression is not supported for **nvarchar(max)** data even if it is stored in row. However, this data type can still benefit from page compression.  Unicode compression is supported for **nvarchar(max)** columns in ColumnStore column segments.
   
 ## Upgrading from Earlier Versions of SQL Server  
  When a [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] database is upgraded to [!INCLUDE[ssCurrent](../../includes/sscurrent-md.md)], Unicode compression–related changes are not made to any database object, compressed or uncompressed. After the database is upgraded, objects are affected as follows:  


### PR DESCRIPTION
This topic needs to explain the use of Unicode compression in Columnstore objects.  It appears that Unicode compression (or something similar) is in effect for ColumStores.  eg


use tempdb
go
drop table if exists uctest
create table uctest(
id int ,
a varchar(100) default left(replicate(cast(newid() as varchar(100)),10),100),
b nvarchar(100) default left(replicate(cast(newid() as varchar(100)),10),100),
c Nvarchar(max) default left(replicate(cast(newid() as varchar(100)),10),100),
index cci_uctest clustered columnstore

)

go

with q as (
select top 1000000 row_number() over (order by (select null)) rn 
from sys.objects o, sys.columns c, sys.columns c2
)
insert into uctest(id)
select rn from q
option (maxdop 1)


alter table uctest rebuild


select column_id,  sum(row_count) rows, sum(on_disk_size) dixe,   
       sum(row_count)/(sum(on_disk_size)/1024) rows_per_kb
from sys.column_store_segments cs
join sys.partitions p 
  on cs.partition_id = p.partition_id
where p.object_id = object_id('uctest')
group by column_id