### PR TITLE
Update lesson-1-create-stored-access-policy-and-shared-access-signatures 

### DIFF
--- a/docs/relational-databases/lesson-1-create-stored-access-policy-and-shared-access-signature.md
+++ b/docs/relational-databases/lesson-1-create-stored-access-policy-and-shared-access-signature.md
@@ -113,21 +113,12 @@ To create a policy on container and generate a Shared Access Signature (SAS) key
   
     # Creates a new container in blob storage  
     $container = New-AzureStorageContainer -Context $storageContext -Name $containerName  
-    $cbc = $container.CloudBlobContainer  
   
     # Sets up a Stored Access Policy and a Shared Access Signature for the new container  
-    $permissions = $cbc.GetPermissions();  
-    $policyName = $policyName  
-    $policy = new-object 'Microsoft.WindowsAzure.Storage.Blob.SharedAccessBlobPolicy'  
-    $policy.SharedAccessStartTime = $(Get-Date).ToUniversalTime().AddMinutes(-5)  
-    $policy.SharedAccessExpiryTime = $(Get-Date).ToUniversalTime().AddYears(10)  
-    $policy.Permissions = "Read,Write,List,Delete"  
-    $permissions.SharedAccessPolicies.Add($policyName, $policy)  
-    $cbc.SetPermissions($permissions);  
-  
+    $policy = New-AzureStorageContainerStoredAccessPolicy -Container $containerName -Policy $policyName -Context $storageContext -StartTime $(Get-Date).ToUniversalTime().AddMinutes(-5) -ExpiryTime $(Get-Date).ToUniversalTime().AddYears(10) -Permission rwld
+
     # Gets the Shared Access Signature for the policy  
-    $policy = new-object 'Microsoft.WindowsAzure.Storage.Blob.SharedAccessBlobPolicy'  
-    $sas = $cbc.GetSharedAccessSignature($policy, $policyName)  
+    $sas = New-AzureStorageContainerSASToken -name $containerName -Policy $policyName -Context $storageContext
     Write-Host 'Shared Access Signature= '$($sas.Substring(1))''  
   
     # Outputs the Transact SQL to the clipboard and to the screen to create the credential using the Shared Access Signature  


### PR DESCRIPTION
I was unable to get the original code working, and as the comments for the page indicated, there were typos. This new code should work better. 

Page Comments: 

Jon_Kennerly3 5 days ago

Getting errors now, but this was working before. Did an update to the SDK change things?

Cannot find an overload for "Add" and the argument count: "2"

$permissions.SharedAccessPolicies.Add($policyName, $policy)

Cannot find an overload for "GetSharedAccessSignature" and the argument count: "2"

$sas = $cbc.GetSharedAccessSignature($policy, $policyName)

Charlie_Pyne Jul 6, 2017

CREATE CREDENTIAL command created via the PS script would not work for me.  

Generating the shared access signiture via Azure Portal and adding to the CREATE CREDENTIAL statement, (minus the leading "?"), worked fine.

Kent_Gaardmand Jun 25, 2017

Also $policyName = $policyName is not needed

Kent_Gaardmand Jun 25, 2017

$policy = new-object 'Microsoft.WindowsAzure.Storage.Blob.SharedAccessBlobPolicy' is listed twice, resulting in it being emtpy for creating $sas