### PR TITLE
Fix definition of the generate_iris_model sproc

### DIFF
--- a/docs/advanced-analytics/r/using-r-in-azure-sql-database.md
+++ b/docs/advanced-analytics/r/using-r-in-azure-sql-database.md
@@ -103,8 +103,8 @@ The following stored procedure does the work of actually creating and training t
 
 ```sql
 CREATE PROCEDURE generate_iris_model
-  @trained_model VARBINARY(MAX) OUTPUT, 
-  @native_trained_model VARBINARY(MAX) OUTPUT
+    @trained_model VARBINARY(MAX) OUTPUT, 
+    @native_trained_model VARBINARY(MAX) OUTPUT
 AS
 BEGIN
   EXEC sp_execute_external_script @language = N'R'
@@ -117,6 +117,7 @@ BEGIN
   , @input_data_1_name = N'iris_rx_data'
   , @params = N'@trained_model VARBINARY(MAX) OUTPUT, @native_trained_model VARBINARY(MAX) OUTPUT'
   , @trained_model = @trained_model OUTPUT
+  , @native_trained_model = @native_trained_model OUTPUT
 END
 ```
 

--- a/docs/advanced-analytics/r/using-r-in-azure-sql-database.md
+++ b/docs/advanced-analytics/r/using-r-in-azure-sql-database.md
@@ -102,11 +102,13 @@ GO
 The following stored procedure does the work of actually creating and training the model, which can be saved in either of two binary formats.
 
 ```sql
-CREATE PROCEDURE generate_iris_model (@trained_model VARBINARY(MAX) OUTPUT, @native_trained_model VARBINARY(MAX) OUTPUT
+CREATE PROCEDURE generate_iris_model
+  @trained_model VARBINARY(MAX) OUTPUT, 
+  @native_trained_model VARBINARY(MAX) OUTPUT
 AS
 BEGIN
   EXEC sp_execute_external_script @language = N'R'
-	, @script = N'
+  , @script = N'
     iris_model <- rxDTree(Species ~ Sepal.Length + Sepal.Width + Petal.Length + Petal.Width, data = iris_rx_data);
     trained_model <- as.raw(serialize(iris_model, connection=NULL));
     native_trained_model <- rxSerializeModel(iris_model, realtimeScoringOnly = TRUE)
@@ -114,7 +116,8 @@ BEGIN
   , @input_data_1 = N'SELECT "Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width", "Species" FROM iris_data'
   , @input_data_1_name = N'iris_rx_data'
   , @params = N'@trained_model VARBINARY(MAX) OUTPUT, @native_trained_model VARBINARY(MAX) OUTPUT'
-	, @trained_model = @trained_model OUTPUT
+  , @trained_model = @trained_model OUTPUT
+END
 ```
 
 + The **OUTPUT** keyword on the input parameters indicates that the values should be passed through and used for output as well.


### PR DESCRIPTION
Definition was broken because parameter list had only opening parenthesis. I also fixed the inconsistent. indentation.