### PR TITLE
JSON data only applies to SQL Server 2016 and up

### DIFF
--- a/docs/relational-databases/json/json-data-sql-server.md
+++ b/docs/relational-databases/json/json-data-sql-server.md
@@ -23,7 +23,7 @@ manager: "craigg"
 ms.workload: "Active"
 ---
 # JSON Data (SQL Server)
-[!INCLUDE[appliesto-ss-asdb-xxxx-xxx-md](../../includes/appliesto-ss-asdb-xxxx-xxx-md.md)]
+[!INCLUDE[appliesto-ss2016-asdb-xxxx-xxx-md.md](../../includes/appliesto-ss2016-asdb-xxxx-xxx-md.md)]
 
 JSON is a popular textual data format used for exchanging data in  modern web and mobile applications. JSON is  also used for storing unstructured data in log files or NoSQL databases like Microsoft Azure Cosmos DB. Many REST web services return results formatted as JSON text or accept data formatted as JSON. For example, most Azure services such as Azure Search, Azure Storage, and Azure Cosmos DB have REST endpoints that return or consume JSON. JSON is also the main format for exchanging data between web pages and web servers using AJAX calls.  
   


### PR DESCRIPTION
As is this page shows that JSON data is available in any version of SQL Server, when it only applies to SQL Server 2016 and above.

Updated the header to use the `appliesto-ss2016-asdb-xxxx-xxx-md.md` include which shows the appropriate value for SQL Server.