### PR TITLE
Fixing SQL error in object-id-transact-sql.md

### DIFF
--- a/docs/t-sql/functions/object-id-transact-sql.md
+++ b/docs/t-sql/functions/object-id-transact-sql.md
@@ -130,7 +130,7 @@ GO
  The following example returns the object ID for the `FactFinance` table in the [!INCLUDE[ssawPDW](../../includes/ssawpdw-md.md)] database.  
   
 ```  
-SELECT OBJECT_ID(AdventureWorksPDW2012.dbo.FactFinance') AS 'Object ID';  
+SELECT OBJECT_ID('AdventureWorksPDW2012.dbo.FactFinance') AS 'Object ID';  
 ```  
   
 ## See Also  


### PR DESCRIPTION
Adding missing single-quote in....
```  
SELECT OBJECT_ID(AdventureWorksPDW2012.dbo.FactFinance') AS 'Object ID';  
```