### PR TITLE
Update auto-stats-event-class.md

### DIFF
--- a/docs/relational-databases/event-classes/auto-stats-event-class.md
+++ b/docs/relational-databases/event-classes/auto-stats-event-class.md
@@ -1,4 +1,3 @@
-A---
 title: "Auto Stats Event Class | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/14/2017"

--- a/docs/relational-databases/event-classes/auto-stats-event-class.md
+++ b/docs/relational-databases/event-classes/auto-stats-event-class.md
@@ -1,4 +1,4 @@
----
+A---
 title: "Auto Stats Event Class | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/14/2017"
@@ -23,7 +23,7 @@ ms.workload: "Inactive"
 ---
 # Auto Stats Event Class
 [!INCLUDE[appliesto-ss-asdb-xxxx-xxx-md](../../includes/appliesto-ss-asdb-xxxx-xxx-md.md)]
-  The **Auto Stats** event class indicates that an automatic updating of index and column statistics has occurred.  
+  The **Auto Stats** event class indicates that an automatic updating of index and column statistics has occurred.  **Auto Stats** also fires when statistics are being loaded for use by the optimizer.
   
 ## Auto Stats Event Class Data Columns  
   


### PR DESCRIPTION
The auto_stats extended event doesn't only occur during statistics update. When the statistics are consumed by the optimizer the event fires showing "Loading without updating: SomeStatName". I wanted to clarify this at the start of the description.