### PR TITLE
Fixes typo in hyperlink text

### DIFF
--- a/docs/linux/sql-server-linux-availability-group-configure-ha.md
+++ b/docs/linux/sql-server-linux-availability-group-configure-ha.md
@@ -88,7 +88,7 @@ Run **only one** of the following scripts:
 
 - [Create availability group with three synchronous replicas](#threeSynch).
 - [Create availability group with two synchronous replicas and a configuration replica](#configOnly)
-- [Create availability group with three synchronous replicas](#readScale).
+- [Create availability group with two synchronous replicas](#readScale).
 
 <a name="threeSynch"></a>
 


### PR DESCRIPTION
Change to text, link says for Three sync replicas when it should read Two and links to the code snippet for two.