### PR TITLE
Add context to log location warning

### DIFF
--- a/docs/linux/sql-server-linux-availability-group-cluster-ubuntu.md
+++ b/docs/linux/sql-server-linux-availability-group-cluster-ubuntu.md
@@ -112,7 +112,7 @@ sudo systemctl enable pacemaker
 1. Create the cluster. 
 
    >[!WARNING]
-   >Due to a known issue that the clustering vendor is investigating, starting the cluster ('pcs cluster start') will fail with below error. This is because the log file configured in /etc/corosync/corosync.conf is wrong. To workaround this issue, change the log file to: /var/log/corosync/corosync.log. Alternatively you could create the /var/log/cluster/corosync.log file.
+   >Due to a known issue that the clustering vendor is investigating, starting the cluster ('pcs cluster start') will fail with below error. This is because the log file configured in /etc/corosync/corosync.conf which is created when the cluster setup command is run, is wrong. To workaround this issue, change the log file to: /var/log/corosync/corosync.log. Alternatively you could create the /var/log/cluster/corosync.log file.
  
    ```Error
    Job for corosync.service failed because the control process exited with error code. 


### PR DESCRIPTION
Adding context about when the corosync.conf file is created as the warning is placed ahead of the sample code to create the cluster, which in turn creates the conf file. The flow of the document means that anyone reading it might try to locate the conf file ahead of it existing. This addition of detail about when the file is created will prevent that.