### PR TITLE
include launch cloud shell button

### DIFF
--- a/docs/tools/sqlcmd-utility.md
+++ b/docs/tools/sqlcmd-utility.md
@@ -46,6 +46,8 @@ ms.workload: "Active"
 > [!NOTE]
 > The most recent versions of the sqlcmd utility is available as a web release from the [Download Center](http://go.microsoft.com/fwlink/?LinkID=825643). You need version 13.1 or higher to support Always Encrypted (`-g`) and Azure Active Directory authentication (`-G`). (You may have several versions of sqlcmd.exe installed on your computer. Be sure you are using the correct version. To determine the version, execute `sqlcmd -?`.)
 
+You can try the sqlcmd utility from Azure Cloud Shell as it is pre-installed by default: [![Launch Cloud Shell](https://shell.azure.com/images/launchcloudshell.png "Launch Cloud Shell")](https://shell.azure.com)
+
   To run sqlcmd statements in SSMS, select SQLCMD Mode from the top navigation Query Menu dropdown.  
   
 > [!IMPORTANT] 


### PR DESCRIPTION
sqlcmd is installed by default in cloud shell allowing your users to instantly try the tool from a web-based terminal