### PR TITLE
Update create-server-role-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/create-server-role-transact-sql.md
+++ b/docs/t-sql/statements/create-server-role-transact-sql.md
@@ -34,7 +34,7 @@ manager: "craigg"
 ms.workload: "On Demand"
 ---
 # CREATE SERVER ROLE (Transact-SQL)
-[!INCLUDE[tsql-appliesto-ss2012-xxxx-xxxx-pdw-md](../../includes/tsql-appliesto-ss2012-xxxx-xxxx-pdw-md.md)]
+[!INCLUDE[tsql-appliesto-ss2012-xxxx-xxxx-xxx-md](../../includes/tsql-appliesto-ss2012-xxxx-xxxx-pdw-md.md)]
 
   Creates a new user-defined server role.  
   

--- a/docs/t-sql/statements/create-server-role-transact-sql.md
+++ b/docs/t-sql/statements/create-server-role-transact-sql.md
@@ -34,7 +34,7 @@ manager: "craigg"
 ms.workload: "On Demand"
 ---
 # CREATE SERVER ROLE (Transact-SQL)
-[!INCLUDE[tsql-appliesto-ss2012-xxxx-xxxx-xxx-md](../../includes/tsql-appliesto-ss2012-xxxx-xxxx-pdw-md.md)]
+[!INCLUDE[tsql-appliesto-ss2012-xxxx-xxxx-xxx-md](../../includes/tsql-appliesto-ss2012-xxxx-xxxx-xxx-md.md)]
 
   Creates a new user-defined server role.  
   


### PR DESCRIPTION
CREATE SERVER ROLE is unsupported syntax in Parallel Data Warehouse. Corrected to SQL Server only