### PR TITLE
Added a tip about Azure user sessions to Remarks section

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-exec-sessions-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-exec-sessions-transact-sql.md
@@ -107,6 +107,10 @@ Everyone can see their own session information.
 -   unsuccessful_logons  
   
  If this option is not enabled, these columns will return null values. For more information about how to set this server configuration option, see [common criteria compliance enabled Server Configuration Option](../../database-engine/configure-windows/common-criteria-compliance-enabled-server-configuration-option.md).  
+ 
+ 
+ The admin connections on Azure SQL Database will see one row per authenticated session, while the non-admin connections will only see information related to their database user sessions. 
+ 
   
 ## Relationship Cardinalities  
   


### PR DESCRIPTION
Azure user sessions behave a bit different than box user sessions. They will only see information about their database user sessions. While the admin can see information about all authenticated sessions.