### PR TITLE
A note about SQL Server password policy which cause docker to stop suddenly

### DIFF
--- a/docs/linux/quickstart-install-connect-docker.md
+++ b/docs/linux/quickstart-install-connect-docker.md
@@ -63,6 +63,9 @@ This image consists of SQL Server running on Linux based on Ubuntu 16.04. It can
    ```
 
    > [!NOTE]
+   > The password should follow the SQL Server default password policy, otherwise the container can not setup SQL server and will stop working. By default, the password must be at least 8 characters long and contain characters from three of the following four sets: Uppercase letters, Lowercase letters, Base 10 digits, and Symbols. You can examine the error log by executing the [docker logs](https://docs.docker.com/engine/reference/commandline/logs/) command.
+
+   > [!NOTE]
    > By default, this creates a container with the Developer edition of SQL Server 2017. The process for running production editions in containers is slightly different. For more information, see [Run production container images](sql-server-linux-configure-docker.md#production).
 
    The following table provides a description of the parameters in the previous `docker run` example:


### PR DESCRIPTION
Many of the juniors follow this guideline and most of them set a simple password such as "123" for their tutorial to set up their docker container. However, they see after some seconds docker stops working. The reason behind is SQL Server password policy. But, since they run the command with -d they can't see the log and are not able figure out what is the reason for their headache.