### PR TITLE
Update memory-properties.md

### DIFF
--- a/docs/analysis-services/server-properties/memory-properties.md
+++ b/docs/analysis-services/server-properties/memory-properties.md
@@ -61,9 +61,9 @@ The following properties apply to both tabular and multidimensional modes unless
 
  Values between 1 and 100 represent percentages of **Total Physical Memory** or **Virtual Address Space**, whichever is less. Values over 100 represent memory limits in bytes.
  
- **Note:** Maximum memory utilized per instance of Analysis Services	
- * Enterprise Edition - Operating System Maximum	
- * Standard Edition - Tabular: 16 GB or MOLAP: 64 GB
+**Note:** Maximum memory utilized per instance of Analysis Services is dependant on the SQL Server Edition
+- [SQL Server 2016](https://docs.microsoft.com/en-us/sql/sql-server/editions-and-components-of-sql-server-2016#Cross-BoxScaleLimits)
+- [SQL Server 2017](https://docs.microsoft.com/en-us/sql/sql-server/editions-and-components-of-sql-server-2017#Cross-BoxScaleLimits)
   
  **LowMemoryLimit**  
  A signed 64-bit double-precision floating-point number property that defines the first threshold at which Analysis Services begins releasing memory for low priority objects, such as an infrequently used cache. Once the memory is allocated, the server does not release memory below this limit. The default value is 65; which indicates the low memory limit is 65% of physical memory or the virtual address space, whichever is less.  

--- a/docs/analysis-services/server-properties/memory-properties.md
+++ b/docs/analysis-services/server-properties/memory-properties.md
@@ -60,6 +60,10 @@ HardMemoryLimit | Another threshold at which Analysis Services begins rejecting 
 The following properties apply to both tabular and multidimensional modes unless specified otherwise.
 
  Values between 1 and 100 represent percentages of **Total Physical Memory** or **Virtual Address Space**, whichever is less. Values over 100 represent memory limits in bytes.
+ 
+ **Note:** Maximum memory utilized per instance of Analysis Services	
+ * Enterprise Edition - Operating System Maximum	
+ * Standard Edition - Tabular: 16 GB or MOLAP: 64 GB
   
  **LowMemoryLimit**  
  A signed 64-bit double-precision floating-point number property that defines the first threshold at which Analysis Services begins releasing memory for low priority objects, such as an infrequently used cache. Once the memory is allocated, the server does not release memory below this limit. The default value is 65; which indicates the low memory limit is 65% of physical memory or the virtual address space, whichever is less.  


### PR DESCRIPTION
I spent hours troubleshooting performance issues and cube processing errors due to memory pressure. I looked at perfmon counters and they always stuck at 16GB regardless of how much free memory (50GB in my case) I had on the server. Whenever I googled "16gb limit ssas" and all sorts of variations it all point back to the above documentation. No where in this is there any mention of limits based on the edition of the sql server. Only after someone in the community pointed me to this [page](https://docs.microsoft.com/en-us/sql/sql-server/editions-and-components-of-sql-server-2016#Cross-BoxScaleLimits) did I realise where the problem lies. I propose the above change or somehow mention and link to the link provided.