### PR TITLE
Execute against non-dropped databases

### DIFF
--- a/docs/relational-databases/backup-restore/disable-sql-server-managed-backup-to-microsoft-azure.md
+++ b/docs/relational-databases/backup-restore/disable-sql-server-managed-backup-to-microsoft-azure.md
@@ -74,7 +74,8 @@ SELECT db_name
        FROM   
   
        msdb.managed_backup.fn_backup_db_config (NULL)  
-       WHERE is_managed_backup_enabled = 1  
+       WHERE is_managed_backup_enabled = 1 
+       AND is_dropped = 0
   
        --Select DBName from @DBNames  
   


### PR DESCRIPTION
Executing msdb.managed_backup.sp_backup_config_basic against an @database_name that has been dropped does not update dropped database configuration, only non-dropped database configuration records are updated.