### PR TITLE
Append to documentation regarding what BROKER_RECEIVE_WAITFOR means

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-os-wait-stats-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-os-wait-stats-transact-sql.md
@@ -126,7 +126,7 @@ This command resets all counters to 0.
 |BROKER_FORWARDER |TBD <br /> **Applies to**: [!INCLUDE[ssSQL12](../../includes/sssql11-md.md)] through [!INCLUDE[ssCurrent](../../includes/sscurrent-md.md)].| 
 |BROKER_INIT |Occurs when initializing Service Broker in each active database. This should occur infrequently.| 
 |BROKER_MASTERSTART |Occurs when a task is waiting for the primary event handler of the Service Broker to start. This should occur very briefly.| 
-|BROKER_RECEIVE_WAITFOR |Occurs when the RECEIVE WAITFOR is waiting. This is typical if no messages are ready to be received.| 
+|BROKER_RECEIVE_WAITFOR |Occurs when the RECEIVE WAITFOR is waiting. This may mean that either no messages are ready to be received in the queue or a lock contention is preventing it from receiving messages from the queue.| 
 |BROKER_REGISTERALLENDPOINTS |Occurs during the initialization of a Service Broker connection endpoint. This should occur very briefly.| 
 |BROKER_SERVICE |Occurs when the Service Broker destination list that is associated with a target service is updated or re-prioritized.| 
 |BROKER_SHUTDOWN |Occurs when there is a planned shutdown of Service Broker. This should occur very briefly, if at all.| 


### PR DESCRIPTION
This wait type has been misinterpreted by SQL CSS and lots of customers out there. You can find many blogs that restate the existing understanding of the wait type. As a result people have taken the wrong approach towards t-shooting issues.