### PR TITLE
Add recommendation to consider changing default value

### DIFF
--- a/docs/database-engine/configure-windows/configure-the-cost-threshold-for-parallelism-server-configuration-option.md
+++ b/docs/database-engine/configure-windows/configure-the-cost-threshold-for-parallelism-server-configuration-option.md
@@ -71,6 +71,8 @@ FROM sys.dm_os_sys_info
 -   This option is an advanced option and should be changed only by an experienced database administrator or certified [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] technician.  
   
 -   In certain cases, a parallel plan may be chosen even though the query's cost plan is less than the current **cost threshold for parallelism** value. This can happen because the decision to use a parallel or serial plan is based on a cost estimate provided before the full optimization is complete.  
+
+-   While the default value of 5 is retained for backwards compatibility, it is likely that a higher value is appropriate for current systems. Many SQL Server professionals suggest a value of 25 or 50 as a starting point, and to perform application testing with higher and lower values to optimize application performance.
   
 ###  <a name="Security"></a> Security  
   


### PR DESCRIPTION
The default value of 5 is now regarded as far too low by almost everyone working with the product. This reality should be recognized on this page. We typically start with 50 and often work up. I know that others start with 25 and work up. I don't know anyone who starts with the default value of 5. This guidance should be provided.