### PR TITLE
Included a stronger recommendation to leave this disabled

### DIFF
--- a/docs/database-engine/configure-windows/xp-cmdshell-server-configuration-option.md
+++ b/docs/database-engine/configure-windows/xp-cmdshell-server-configuration-option.md
@@ -26,7 +26,7 @@ ms.workload: "Active"
 # xp_cmdshell Server Configuration Option
 [!INCLUDE[appliesto-ss-xxxx-xxxx-xxx-md](../../includes/appliesto-ss-xxxx-xxxx-xxx-md.md)]
 
-  The **xp_cmdshell** option is a [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] server configuration option that enables system administrators to control whether the **xp_cmdshell** extended stored procedure can be executed on a system. By default, the **xp_cmdshell** option is disabled on new installations and can be enabled by using the Policy-Based Management or by running the **sp_configure** system stored procedure as shown in the following code example:  
+  The **xp_cmdshell** option is a [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] server configuration option that enables system administrators to control whether the **xp_cmdshell** extended stored procedure can be executed on a system. By default, the **xp_cmdshell** option is disabled on new installations. Before enabling this option, it is important to consider the potential security implications associated with the use of this option. Newly-developed code should not use this option as it should generally be left disabled. Some legacy applications require it to be enabled, and if they cannot be modified to avoid the use of this option, it can be enabled by using the Policy-Based Management or by running the **sp_configure** system stored procedure as shown in the following code example:  
   
 ```  
 -- To allow advanced options to be changed.  


### PR DESCRIPTION
The current article discusses how to change the option but gives no hint on why it is disabled by default, and why it should normally remain that way. I've added content to explain that, and to suggest one of the limited situations where the option might need to be enabled.