### PR TITLE
Fix formatting values from YYYY to yyyy and DD to dd

### DIFF
--- a/docs/t-sql/functions/date-and-time-data-types-and-functions-transact-sql.md
+++ b/docs/t-sql/functions/date-and-time-data-types-and-functions-transact-sql.md
@@ -60,6 +60,11 @@ The [!INCLUDE[tsql](../../includes/tsql-md.md)] date and time data types are lis
 >  The [!INCLUDE[tsql](../../includes/tsql-md.md)] [rowversion](../../t-sql/data-types/rowversion-transact-sql.md) data type is not a date or time data type. **timestamp** is a deprecated synonym for **rowversion**.  
   
 ##  <a name="DateandTimeFunctions"></a> Date and Time functions  
+|[date](../../t-sql/data-types/date-transact-sql.md)|yyyy-MM-dd|0001-01-01 through 9999-12-31|1 day|3|No|No|
+|[smalldatetime](../../t-sql/data-types/smalldatetime-transact-sql.md)|yyyy-MM-dd hh:mm:ss|1900-01-01 through 2079-06-06|1 minute|4|No|No|
+|[datetime](../../t-sql/data-types/datetime-transact-sql.md)|yyyy-MM-dd hh:mm:ss[.nnn]|1753-01-01 through 9999-12-31|0.00333 second|8|No|No|
+|[datetime2](../../t-sql/data-types/datetime2-transact-sql.md)|yyyy-MM-dd hh:mm:ss[.nnnnnnn]|0001-01-01 00:00:00.0000000 through 9999-12-31 23:59:59.9999999|100 nanoseconds|6 to 8|Yes|No|
+|[datetimeoffset](../../t-sql/data-types/datetimeoffset-transact-sql.md)|yyyy-MM-dd hh:mm:ss[.nnnnnnn] [+&#124;-]hh:mm|0001-01-01 00:00:00.0000000 through 9999-12-31 23:59:59.9999999 (in UTC)|100 nanoseconds|8 to 10|Yes|Yes|
 The [!INCLUDE[tsql](../../includes/tsql-md.md)] date and time functions are listed in the following tables. For more information about determinism, see [Deterministic and Nondeterministic Functions](../../relational-databases/user-defined-functions/deterministic-and-nondeterministic-functions.md).
   
 ###  <a name="GetSystemDateandTimeValues"></a> Functions that get system Date and Time values 


### PR DESCRIPTION
SQL-Server 2016 does not accept YYYY or DD as valid formatting values 