### PR TITLE
Listener and Read-Only connection - add database information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ _themes.MSDN.Modern/
 _themes.VS.Modern/
 
 .openpublishing.buildcore.ps1
-.vscode/*

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ _themes.MSDN.Modern/
 _themes.VS.Modern/
 
 .openpublishing.buildcore.ps1
+.vscode/*

--- a/docs/database-engine/availability-groups/windows/listeners-client-connectivity-application-failover.md
+++ b/docs/database-engine/availability-groups/windows/listeners-client-connectivity-application-failover.md
@@ -118,7 +118,9 @@ Server=tcp: AGListener,1433;Database=MyDB;IntegratedSecurity=SSPI
  *Read-only routing* refers to the ability of [!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)] to route incoming connections to an availability group listener to a secondary replica that is configured to allow read-only workloads. An incoming connection referencing an availability group listener name can automatically be routed to a read-only replica if the following are true:  
   
 -   At least one secondary replica is set to read-only access, and each read-only secondary replica and the primary replica are configured to support read-only routing. For more information, see [To Configure Availability Replicas for Read-Only Routing](#ConfigureARsForROR), later in this section.  
-  
+
+-   The connection string references a database involved in the Availability Group. An alternative to this would be the login used in the connection has the database configured as its default database. For more information, see [this article on how the algorithm works with read-only routing](https://blogs.msdn.microsoft.com/mattn/2012/04/25/calculating-read_only_routing_url-for-alwayson/).
+
 -   The connection string references an availability group listener, and the application intent of the incoming connection is set to read-only (for example, by using the **Application Intent=ReadOnly** keyword in the ODBC or OLEDB connection strings or connection attributes or properties). For more information, see [Read-Only Application Intent and Read-Only Routing](#ReadOnlyAppIntent), later in this section.  
   
 ###  <a name="ConfigureARsForROR"></a> To Configure Availability Replicas for Read-Only Routing  
@@ -149,7 +151,7 @@ Server=tcp: AGListener,1433;Database=MyDB;IntegratedSecurity=SSPI
 Server=tcp:AGListener,1433;Database=AdventureWorks;IntegratedSecurity=SSPI;ApplicationIntent=ReadOnly  
 ```  
   
- In this connection string example, the client is attempting to connect to an availability group listener named `AGListener` on port 1433 (you may also omit the port if the availability group listener is listening on 1433).  The connection string has the **ApplicationIntent** property set to **ReadOnly**, making this a *read-intent connection string*.  Without this setting, the server would not have attempted a read-only routing of the connection.  
+ In this connection string example, the client is attempting to connect to the AdventureWorks database via an availability group listener named `AGListener` on port 1433 (you may also omit the port if the availability group listener is listening on 1433).  The connection string has the **ApplicationIntent** property set to **ReadOnly**, making this a *read-intent connection string*.  Without this setting, the server would not have attempted a read-only routing of the connection.  
   
  The primary database of the availability group processes the incoming read-only routing request and attempts to locate an online, read-only replica that is joined to the primary replica and is configured for read-only routing.  The client receives back connection information from the primary replica server and connects to the identified read-only replica.  
   


### PR DESCRIPTION
Trying to just bring more attention to the fact that the ApplicationIntent property in the connection string alone will not cause read-only routing to work. The connection has to include the database in the given AG or you will always connect to the primary.

I've had the issue with clients recently that didn't take this into account so updated the doc to try and add more emphasis on that particular part.

I also updated the git ignore file to exclude VS Code setting files, the `.vscode` directory created in the project by VS Code.