### PR TITLE
Update sys-dm-exec-describe-first-result-set-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-exec-describe-first-result-set-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-exec-describe-first-result-set-transact-sql.md
@@ -40,7 +40,7 @@ ms.workload: "On Demand"
   
 ```  
   
-sys.dm_exec_describe_first_result(@tsql, @params, @include_browse_information)  
+sys.dm_exec_describe_first_result_set(@tsql, @params, @include_browse_information)  
 ```  
   
 ## Arguments  


### PR DESCRIPTION
Update sys.dm_exec_describe_first_result to sys.dm_exec_describe_first_result_set according to the task "Syntax section error for sys.dm_exec_describe_first_result_set" from Sergey Ten <sete@microsoft.com>.