### PR TITLE
right-click the AdventureWorks2012 database

### DIFF
--- a/docs/ssms/tutorials/lesson-3-2-create-custom-templates.md
+++ b/docs/ssms/tutorials/lesson-3-2-create-custom-templates.md
@@ -68,7 +68,7 @@ ms.workload: "On Demand"
   
 8.  Press F5 to execute this script, creating the **WorkOrdersForBlade** procedure.  
   
-9. In Object Explorer, right-click your server, and then click **New Query**. A new Query Editor window opens.  
+9. In Object Explorer, right-click the **AdventureWorks2012** database, and then click **New Query**. A new Query Editor window opens.  
   
 10. In Query Editor, type **EXECUTE dbo.WorkOrdersForBlade**, and then press F5 to execute the query. Confirm that the **Results** pane returns a list of work orders for blades.  
   


### PR DESCRIPTION
When right-clicking the server, by default the query is connected to the `master` database. Therefore, in the next step, `EXECUTE dbo.WorkOrdersForBlade` will fail with the following error:
```
Msg 2812, Level 16, State 62, Line 1
Could not find stored procedure 'dbo.WorkOrdersForBlade'.
```
Right-clicking the AdventureWorks2012 database ensures that the query will be connected to the database where the stored procedure has been previously created. In this case, `EXECUTE dbo.WorkOrdersForBlade` succeeds.