### PR TITLE
Revert "Add Sequel to the list of ORMs"

### DIFF
--- a/docs/connect/sql-connection-libraries.md
+++ b/docs/connect/sql-connection-libraries.md
@@ -76,7 +76,7 @@ The following table lists examples of Object Relational Mapping (ORM) frameworks
 | PHP | [Eloquent ORM, included in Laravel install](http://laravel.com/docs/) |
 | Node.js | [Sequelize ORM](http://docs.sequelizejs.com) |
 | Python | [Django](http://www.djangoproject.com/) |
-| Ruby | [Ruby on Rails](http://rubyonrails.org/)<br />[Sequel: The Database Toolkit for Ruby](http://sequel.jeremyevans.net/) |
+| Ruby | [Ruby on Rails](http://rubyonrails.org/) |
 | &nbsp; | <br /> |
 
 


### PR DESCRIPTION
Reverts MicrosoftDocs/sql-docs#419
my fault for not communicating better but we do want to limit the number of links.  there are lots of great resources but we cannot list them all for a variety of reasons including we are on the hook to be sure they stay fresh.  So a rough bar is those that are aligned with general/central organizations..