### PR TITLE
Updated to install via dpkg

### DIFF
--- a/docs/sql-operations-studio/download.md
+++ b/docs/sql-operations-studio/download.md
@@ -60,10 +60,8 @@ This release of [!INCLUDE[name-sos](../includes/name-sos-short.md)] includes a s
 
    ```bash
    cd ~
-   cp ~/Downloads/sqlops-linux-<version string>.tar.gz ~
-   tar -xvf ~/sqlops-linux-<version string>.tar.gz
-   echo 'export PATH="$PATH:~/sqlops-linux-x64"' >> ~/.bashrc
-   source ~/.bashrc
+   sudo dpkg -i ./Downloads/sqlops-linux-<version string>.deb
+
    sqlops
    ```
 


### PR DESCRIPTION
Now that deb packages is available the installation can be done using dpkg. I've updated the docs to reflect that.