### PR TITLE
changed to better reflect deprecation in 2012

### DIFF
--- a/docs/integration-services/install-windows/upgrade-integration-services.md
+++ b/docs/integration-services/install-windows/upgrade-integration-services.md
@@ -38,7 +38,7 @@ ms.workload: "On Demand"
  We recommended that you run Upgrade Advisor before you upgrade to [!INCLUDE[ssCurrent](../../includes/sscurrent-md.md)]. Upgrade Advisor reports issues that you might encounter if you migrate existing [!INCLUDE[ssISnoversion](../../includes/ssisnoversion-md.md)] packages to the new package format that [!INCLUDE[ssCurrent](../../includes/sscurrent-md.md)] uses.  
   
 > [!NOTE]  
->  Support for migrating or running Data Transformation Services (DTS) packages has been discontinued in in the current release of [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)][!INCLUDE[ssISnoversion](../../includes/ssisnoversion-md.md)]. The following DTS functionality has been discontinued.  
+>  Support for migrating or running Data Transformation Services (DTS) packages has been discontinued in SQL Server 2012. The following DTS functionality has been discontinued.  
 >   
 >  -   DTS runtime  
 > -   DTS API  


### PR DESCRIPTION
DTS packages were discontinued in SQL Server 2012. I propose updating the documentation to reflect the more accurate wording. 