### PR TITLE
Update installing-the-microsoft-odbc-driver-for-sql-server.md

### DIFF
--- a/docs/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server.md
+++ b/docs/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server.md
@@ -139,7 +139,7 @@ sudo apt-get install unixodbc-dev
 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 brew tap microsoft/mssql-release https://github.com/Microsoft/homebrew-mssql-release
 brew update
-brew install --no-sandbox msodbcsql17 mssql-tools
+brew install --no-sandbox msodbcsql mssql-tools
 ```
 
 ## Microsoft ODBC Driver 13.1 for SQL Server 


### PR DESCRIPTION
Changing msodbcsql17 to msodbcsql, the msodbcsql17 package is no longer in the tap.