### PR TITLE
Update set-identity-insert-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/set-identity-insert-transact-sql.md
+++ b/docs/t-sql/statements/set-identity-insert-transact-sql.md
@@ -42,7 +42,7 @@ ms.workload: "Active"
   
 ```  
   
-SET IDENTITY_INSERT [ database_name . [ schema_name ] . ] table { ON | OFF }  
+SET IDENTITY_INSERT [ [ database_name . ] schema_name . ] table { ON | OFF }  
 ```  
   
 ## Arguments  


### PR DESCRIPTION
Peter_Harvey commented on the original document and he is correct (he should get the credit). The format should be:
SET IDENTITY_INSERT [ [ database_name . ] schema_name . ] table
instead of 
SET IDENTITY_INSERT [ database_name . [ schema_name ] . ] table