### PR TITLE
Update managed-backup-sp-backup-config-schedule-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-stored-procedures/managed-backup-sp-backup-config-schedule-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/managed-backup-sp-backup-config-schedule-transact-sql.md
@@ -59,7 +59,7 @@ EXEC managed_backup.sp_backup_config_schedule
  The frequency type for the managed  backup operation, which can be set to 'Daily' or 'Weekly'.  
   
  @days_of_week  
- The days of the week for the backups when @full_backup_freq_type is set to Weekly. Specify full string names like 'Monday'.  You can also specify more than one day name, separated by commas. For example 'Monday, Wednesday, Friday'.  
+ The days of the week for the backups when @full_backup_freq_type is set to Weekly. Specify full string names like 'Monday'.  You can also specify more than one day name, separated by Pipe. For example N'Monday | Wednesday | Friday'.  
   
  @backup_begin_time  
  The start time of the backup window. Backups will not be started outside of the time window, which is defined by a combination of @backup_begin_time and @backup_duration.  


### PR DESCRIPTION
@days_of_week if we use comma, SQL will produce 45207 error 

EXEC managed_backup.sp_backup_config_schedule 
 @database_name = 'Rohit' 
,@scheduling_option = 'Custom' 
,@full_backup_freq_type = 'Weekly' 
,@days_of_week =  'Monday, Wednesday, Friday'  
,@backup_begin_time = '07:00' 
,@backup_duration = '02:00' 
,@log_backup_freq = '00:05'

Msg 45207, Level 17, State 4, Procedure sp_add_task_command, Line 102 [Batch Start Line 9]
The value specified for parameter @days_of_week is not valid. A valid scheduling parameter is required.
