### PR TITLE
Update delete-columns-from-a-table.md

### DIFF
--- a/docs/relational-databases/tables/delete-columns-from-a-table.md
+++ b/docs/relational-databases/tables/delete-columns-from-a-table.md
@@ -30,7 +30,7 @@ ms.workload: "Active"
   This topic describes how to delete table columns in [!INCLUDE[ssCurrent](../../includes/sscurrent-md.md)] by using [!INCLUDE[ssManStudioFull](../../includes/ssmanstudiofull-md.md)] or [!INCLUDE[tsql](../../includes/tsql-md.md)].  
   
 > [!CAUTION]  
->  When you delete a column from a table, it and all the data it contains are deleted from the database. This action cannot be undone.  
+>  When you delete a column from a table, it and all the data it contains are deleted.
   
  **In This Topic**  
   


### PR DESCRIPTION
Good day team,

1. I do not like the use of "DELETE Columns" in the page name, when it should be "DROP Columns". I recomend to change it, but I do nothing regarding this point.

2. I edited the first comment since it is not accurate

When you drop a column you do not delete the data from the disk, but only change the metadata of the table structure. The Data is still there and can be restored by reading the binary data from the disk theoretically (I show it is lectures on "SQL Internals" from time time). In fact unless you do another action like REBUILD, then you do not reclaim the space from the row structure.

I gave full explanation and demo in this thread in the forum:
https://social.msdn.microsoft.com/Forums/en-US/61f1666a-f233-4572-b647-97c67846e2ab/some-guidelines-for-update-largetable-set-c1-0?forum=transactsql

Therefore, I removed the statement "This action cannot be undone", and the "from the database" since it is still in the database file but it's not in the table (the virtual element we call table).