### PR TITLE
Update Get-Help-Options to dba.se

### DIFF
--- a/docs/includes/paragraph-content/get-help-options.md
+++ b/docs/includes/paragraph-content/get-help-options.md
@@ -1,6 +1,6 @@
 ##  ![info_tip](../media/info-tip.png) Get Help 
 - [UserVoice - Suggestion to improve SQL Server?](https://feedback.azure.com/forums/908035-sql-server)
-- [Stack Overflow (tag sql-server) - ask SQL development questions](http://stackoverflow.com/questions/tagged/sql-server)
+- [DBA Stack Exchange (tag sql-server) - ask SQL Server questions](https://dba.stackexchange.com/questions/tagged/sql-server)
 - [Setup and Upgrade -  MSDN Forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=sqlsetupandupgrade&filter=alltypes&sort=lastpostdesc)
 - [SQL Server Data Tools - MSDN forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=ssdt&filter=alltypes&sort=lastpostdesc)
 - [Reddit - general discussion about SQL Server](https://www.reddit.com/r/SQLServer/)

--- a/docs/includes/paragraph-content/get-help-options.md
+++ b/docs/includes/paragraph-content/get-help-options.md
@@ -1,6 +1,7 @@
 ##  ![info_tip](../media/info-tip.png) Get Help 
 - [UserVoice - Suggestion to improve SQL Server?](https://feedback.azure.com/forums/908035-sql-server)
 - [DBA Stack Exchange (tag sql-server) - ask SQL Server questions](https://dba.stackexchange.com/questions/tagged/sql-server)
+    - [Stack Overflow (tag sql-server) - also has some answers about SQL development](http://stackoverflow.com/questions/tagged/sql-server) 
 - [Setup and Upgrade -  MSDN Forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=sqlsetupandupgrade&filter=alltypes&sort=lastpostdesc)
 - [SQL Server Data Tools - MSDN forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=ssdt&filter=alltypes&sort=lastpostdesc)
 - [Reddit - general discussion about SQL Server](https://www.reddit.com/r/SQLServer/)


### PR DESCRIPTION
DBA.SE is actually the better location for questions on SQL Server as it is the "Database Administrators Stack Exchange" whereas the stack overflow is for programming. Most questions from stack overflow end up getting no traffic for SQL Server and being migrated to DBA.SE