### PR TITLE
APRC data not persisted on restart

### DIFF
--- a/docs/relational-databases/automatic-tuning/automatic-tuning.md
+++ b/docs/relational-databases/automatic-tuning/automatic-tuning.md
@@ -76,6 +76,8 @@ When the [!INCLUDE[ssde_md](../../includes/ssde_md.md)] applies the last known g
 than the regressed plan, the new plan will be unforced and the [!INCLUDE[ssde_md](../../includes/ssde_md.md)] will compile a new plan. If [!INCLUDE[ssde_md](../../includes/ssde_md.md)] verifies
 that the forced plan is better than regressed one, the forced plan will be retained until a recompile (for example, on next statistics or schema change) if it is better than the regressed plan.
 
+Note: Any plans auto forced do not persit on a restart of the SQL Server instance.
+
 ### Enabling automatic plan choice correction
 
 You can enable automatic tuning per database and specify that last good plan should be forced whenever some plan change regression is detected. Automatic tuning is enabled using
@@ -152,6 +154,8 @@ FROM sys.dm_db_tuning_recommendations
 
 Although [!INCLUDE[ssde_md](../../includes/ssde_md.md)] provides all information required to identify plan choice regressions; continuous
 monitoring and fixing performance issues might be a tedious process. Automatic tuning makes this process much easier.
+
+Note: Data in this DMV does not persist after a restart of the SQL Server instance.
 
 ## Automatic index management
 


### PR DESCRIPTION
Forced plans are no longer forced that were auto forced and recommendations no longer exists in DMV.