### PR TITLE
Minor edits to Linux download instructions

### DIFF
--- a/docs/sql-operations-studio/download.md
+++ b/docs/sql-operations-studio/download.md
@@ -55,7 +55,10 @@ This release of [!INCLUDE[name-sos](../includes/name-sos-short.md)] includes a s
 
 ## Get SQL Operations Studio (preview) for Linux
 
-1. Download [[!INCLUDE[name-sos](../includes/name-sos-short.md)] for Linux](https://go.microsoft.com/fwlink/?linkid=870840).
+1. Download [!INCLUDE[name-sos](../includes/name-sos-short.md)] for Linux by using one of the installers or the tar.gz archive:
+    - [.deb](https://go.microsoft.com/fwlink/?linkid=870842)
+    - [.rpm](https://go.microsoft.com/fwlink/?linkid=870841)
+    - [.tar.gz](https://go.microsoft.com/fwlink/?linkid=870840)
 1. To extract the file and launch [!INCLUDE[name-sos](../includes/name-sos-short.md)], open a new Terminal window and type the following commands:
 
    **Debian Installation:**
@@ -79,7 +82,8 @@ This release of [!INCLUDE[name-sos](../includes/name-sos-short.md)] includes a s
    cd ~ 
    cp ~/Downloads/sqlops-linux-<version string>.tar.gz ~ 
    tar -xvf ~/sqlops-linux-<version string>.tar.gz 
-   echo 'export PATH="$PATH:~/sqlops-linux-x64"' >> ~/.bashrc source ~/.bashrc 
+   echo 'export PATH="$PATH:~/sqlops-linux-x64"' >> ~/.bashrc
+   source ~/.bashrc 
    sqlops 
    ``` 
 

--- a/docs/sql-operations-studio/download.md
+++ b/docs/sql-operations-studio/download.md
@@ -55,7 +55,7 @@ This release of [!INCLUDE[name-sos](../includes/name-sos-short.md)] includes a s
 
 ## Get SQL Operations Studio (preview) for Linux
 
-1. Download [!INCLUDE[name-sos](../includes/name-sos-short.md)] for Linux by using one of the installers or the tar.gz archive:
+1. Download [!INCLUDE[name-sos](../includes/name-sos-short.md) for Linux by using one of the installers or the tar.gz archive:
     - [.deb](https://go.microsoft.com/fwlink/?linkid=870842)
     - [.rpm](https://go.microsoft.com/fwlink/?linkid=870841)
     - [.tar.gz](https://go.microsoft.com/fwlink/?linkid=870840)


### PR DESCRIPTION
Updates the Linux download instructions to include links to all downloads (.tar.gz, .deb, and .rpm) and fixes a typo in the .tar.gz installation instructions where two commands were on the same line