### PR TITLE
More details added in the Return Types section

### DIFF
--- a/docs/t-sql/functions/decryptbykey-transact-sql.md
+++ b/docs/t-sql/functions/decryptbykey-transact-sql.md
@@ -61,7 +61,9 @@ DecryptByKey ( { 'ciphertext' | @ciphertext }
  Is a variable that contains data from which to generate an authenticator. Must match the value that was supplied to EncryptByKey.  
   
 ## Return Types  
- **varbinary** with a maximum size of 8,000 bytes.  
+ **varbinary** with a maximum size of 8,000 bytes.
+ 
+Returns NULL if the symmetric key used for encrypting the data is not open or the *ciphertext* is NULL.
   
 ## Remarks  
  DecryptByKey uses a symmetric key. This symmetric key must already be open in the database. There can be multiple keys open at the same time. You do not have to open the key immediately before decrypting the cipher text.  


### PR DESCRIPTION
Full working example, proving the changes:

/* creating the security objects */

	CREATE MASTER KEY ENCRYPTION
	BY PASSWORD = 'smGK_MasterKeyPassword@';

	-- 
	CREATE CERTIFICATE [Cert_Demo_V001]
	WITH SUBJECT = 'User for protecting symetric keys.'

	--
	CREATE SYMMETRIC KEY [SK_Demo_V001] WITH ALGORITHM = AES_256 ENCRYPTION
	BY CERTIFICATE [Cert_Demo_V001];

		--
	CREATE SYMMETRIC KEY [SK_Demo_V002] WITH ALGORITHM = AES_256 ENCRYPTION
	BY CERTIFICATE [Cert_Demo_V001];

/* declaring value and ecnrypting it */

	DECLARE @Email NVARCHAR(128) = 'gotqn';
	DECLARE @EmailEncrypted VARBINARY(256);

	OPEN SYMMETRIC KEY [SK_Demo_V001] DECRYPTION
	BY CERTIFICATE [Cert_Demo_V001];

	SELECT @EmailEncrypted = ENCRYPTBYKEY(KEY_GUID('SK_Demo_V001'),@Email);
	SELECT @EmailEncrypted AS [EncryptedValue];

	CLOSE SYMMETRIC KEY [SK_Demo_V001];

/* opening the same key and reading the value */

	OPEN SYMMETRIC KEY [SK_Demo_V001] DECRYPTION
	BY CERTIFICATE [Cert_Demo_V001];

	SELECT CONVERT(NVARCHAR(128), DECRYPTBYKEY(@EmailEncrypted)) AS [CorrectKeyIsUsed];

	CLOSE SYMMETRIC KEY [SK_Demo_V001];

/* opening the same key and reading the value */

	SELECT CONVERT(NVARCHAR(128), DECRYPTBYKEY(@EmailEncrypted)) AS [KeyIsNotOpened];

/* opening the same key and reading the value */

	OPEN SYMMETRIC KEY [SK_Demo_V002] DECRYPTION
	BY CERTIFICATE [Cert_Demo_V001];

	SELECT CONVERT(NVARCHAR(128), DECRYPTBYKEY(@EmailEncrypted)) AS [DifferntKeyIsOpened];

	CLOSE SYMMETRIC KEY [SK_Demo_V002];

/* opening the same key and reading the value */

	OPEN SYMMETRIC KEY [SK_Demo_V002] DECRYPTION
	BY CERTIFICATE [Cert_Demo_V001];

	SET @EmailEncrypted = NULL;
	SELECT CONVERT(NVARCHAR(128), DECRYPTBYKEY(@EmailEncrypted)) AS [NULLChiperTextIsUsed];

	CLOSE SYMMETRIC KEY [SK_Demo_V002];

/* clearing the objects */

	DROP SYMMETRIC KEY [SK_Demo_V001]
	DROP SYMMETRIC KEY [SK_Demo_V002]
	DROP CERTIFICATE [Cert_Demo_V001];
	DROP MASTER KEY;