### PR TITLE
Update configure-distributed-availability-groups.md

### DIFF
--- a/docs/database-engine/availability-groups/windows/configure-distributed-availability-groups.md
+++ b/docs/database-engine/availability-groups/windows/configure-distributed-availability-groups.md
@@ -179,7 +179,7 @@ GO
 ```  
   
 > [!NOTE]  
->  The **LISTENER_URL** specifies the listener for each availability group along with the database mirroring endpoint of the availability group. In this example, that is port `5022` (not port `60173` used to create the listener). If you are using a load balancer, for instance in Azure, ensure you add a rule to the firewall to allow the listener port, in addition to the SQL Server instance port. 
+>  The **LISTENER_URL** specifies the listener for each availability group along with the database mirroring endpoint of the availability group. In this example, that is port `5022` (not port `60173` used to create the listener). If you are using a load balancer, for instance in Azure, [add a load balancing rule for the distributed availability group port](http://docs.microsoft.com/azure/virtual-machines/windows/sql/virtual-machines-windows-portal-sql-alwayson-int-listener#add-load-balancing-rule-for-distributed-availability-group). Add the rule for the listener port, in addition to the SQL Server instance port. 
   
 ## Join distributed availability group on second cluster  
  Then join the distributed availability group on the second WSFC.  

--- a/docs/database-engine/availability-groups/windows/configure-distributed-availability-groups.md
+++ b/docs/database-engine/availability-groups/windows/configure-distributed-availability-groups.md
@@ -179,7 +179,7 @@ GO
 ```  
   
 > [!NOTE]  
->  The **LISTENER_URL** specifies the listener for each availability group along with the database mirroring endpoint of the availability group. In this example, that is port `5022` (not port `60173` used to create the listener). If you are using a load balancer, for instance in Azure, ensure you add port `5022` for the AG listeners in addition to port `1433`. 
+>  The **LISTENER_URL** specifies the listener for each availability group along with the database mirroring endpoint of the availability group. In this example, that is port `5022` (not port `60173` used to create the listener). If you are using a load balancer, for instance in Azure, ensure you add a rule to the firewall to allow the listener port, in addition to the SQL Server instance port. 
   
 ## Join distributed availability group on second cluster  
  Then join the distributed availability group on the second WSFC.  

--- a/docs/database-engine/availability-groups/windows/configure-distributed-availability-groups.md
+++ b/docs/database-engine/availability-groups/windows/configure-distributed-availability-groups.md
@@ -179,7 +179,7 @@ GO
 ```  
   
 > [!NOTE]  
->  The **LISTENER_URL** specifies the listener for each availability group along with the database mirroring endpoint of the availability group. In this example, that is port `5022` (not port `60173` used to create the listener).  
+>  The **LISTENER_URL** specifies the listener for each availability group along with the database mirroring endpoint of the availability group. In this example, that is port `5022` (not port `60173` used to create the listener). If you are using a load balancer, for instance in Azure, ensure you add port `5022` for the AG listeners in addition to port `1433`. 
   
 ## Join distributed availability group on second cluster  
  Then join the distributed availability group on the second WSFC.  


### PR DESCRIPTION
As per the comment on the page, the instructions don't cover configuring the additional port in the load balancer. This has affected two of my customers and I suspect others as well. This small change should prevent further issues.