### PR TITLE
Clarify DBCC EMPTYFILE behavior

### DIFF
--- a/docs/t-sql/database-console-commands/dbcc-shrinkfile-transact-sql.md
+++ b/docs/t-sql/database-console-commands/dbcc-shrinkfile-transact-sql.md
@@ -109,7 +109,7 @@ The following table describes the columns in the result set.
 ## Remarks  
 DBCC SHRINKFILE applies to the files in the current database. For more information about how to change the current database, see [USE &#40;Transact-SQL&#41;](../../t-sql/language-elements/use-transact-sql.md).
   
-DBCC SHRINKFILE operations can be stopped at any point in the process, and any completed work is retained.
+DBCC SHRINKFILE operations can be stopped at any point in the process, and any completed work is retained. If the EMPTYFILE parameter is used on a file and the operation is cancelled, the file will not be marked to prevent additional data from being added.
   
 When a DBCC SHRINKFILE operation fails, an error is raised.
   


### PR DESCRIPTION
When the operation is cancelled, the file used with EMPTYFILE is not marked as read-only and can still have new a data added. Clarified this.