### PR TITLE
Update certprivatekey-transact-sql.md

### DIFF
--- a/docs/t-sql/functions/certprivatekey-transact-sql.md
+++ b/docs/t-sql/functions/certprivatekey-transact-sql.md
@@ -29,12 +29,12 @@ ms.workload: "Inactive"
 # CERTPRIVATEKEY (Transact-SQL)
 [!INCLUDE[tsql-appliesto-ss2012-asdb-xxxx-xxx-md](../../includes/tsql-appliesto-ss2012-asdb-xxxx-xxx-md.md)]
 
-Returns the private key of a certificate in binary format. This function takes three arguments.
+This function returns the private key of a certificate in binary format. This function takes three arguments.
 -   A certificate ID.  
--   An encryption password which is used to encrypt the private key bits when they are returned by the function, so that the keys are not exposed clear text to users.  
--   A decryption password which is optional. If a decryption password is specified, then it is used to decrypt the private key of the certificate otherwise database master key is used.  
+-   An encryption password, used to encrypt the private key bits returned by the function. This approach does not expose the keys as clear text text to users.  
+-   An optional decryption password. A specified decryption password is used to decrypt the private key of the certificate. Otherwise, the database master key is used.  
   
-Only users that have access to certificate’s private key will be able to use this function. This function returns the private key in PVK format.
+Only users with access to the certificate private key can use this function. This function returns the private key in PVK format.
   
 ## Syntax  
   
@@ -49,7 +49,7 @@ CERTPRIVATEKEY
   
 ## Arguments  
 *certificate_ID*  
-Is the **certificate_id** of the certificate. This is available from sys.certificates or by using the [CERT_ID &#40;Transact-SQL&#41;](../../t-sql/functions/cert-id-transact-sql.md) function. *cert_id* is type **int**
+The **certificate_id** of the certificate. Obtain this value from sys.certificates or from the [CERT_ID &#40;Transact-SQL&#41;](../../t-sql/functions/cert-id-transact-sql.md) function. *cert_id* has data type **int**.
   
 *encryption_password*  
 The password used to encrypt the returned binary value.
@@ -61,10 +61,10 @@ The password used to decrypt the returned binary value.
 **varbinary**
   
 ## Remarks  
-**CERTENCODED** and **CERTPRIVATEKEY** are used together to return different portions of a certificate in binary form.
+Use **CERTENCODED** and **CERTPRIVATEKEY** together to return different portions of a certificate, in binary form.
   
 ## Permissions  
-**CERTPRIVATEKEY** is available to public.
+**CERTPRIVATEKEY** is publicly available.
   
 ## Examples  
   
@@ -76,12 +76,12 @@ CREATE MASTER KEY ENCRYPTION BY PASSWORD = 'Use 5tr0ng P^55Words'
 GO  
 CREATE CERTIFICATE Shipping04   
 WITH SUBJECT = 'Sammamish Shipping Records',   
-EXPIRY_DATE = '20141031';  
+EXPIRY_DATE = '20401031';  
 GO  
 SELECT CERTPRIVATEKEY(CERT_ID('Shipping04'), 'jklalkaa/; uia3dd');  
 ```  
   
-For a more complex example that uses **CERTPRIVATEKEY** and **CERTENCODED** to copy a certificate to another database, see example B in the topic [CERTENCODED &#40;Transact-SQL&#41;](../../t-sql/functions/certencoded-transact-sql.md).
+See [CERTENCODED &#40;Transact-SQL&#41;](../../t-sql/functions/certencoded-transact-sql.md), Example B, for a more complex example that uses **CERTPRIVATEKEY** and **CERTENCODED** to copy a certificate to another database.
   
 ## See also
 [Security Functions &#40;Transact-SQL&#41;](../../t-sql/functions/security-functions-transact-sql.md)  


### PR DESCRIPTION
Text revisions to tighten and optimize the reading flow of the material. EXPIRY_DATE in the example changed to make the CREATE CERTIFICATE statement work properly.