### PR TITLE
Update sql-server-linux-configure-mssql-conf.md

### DIFF
--- a/docs/linux/sql-server-linux-configure-mssql-conf.md
+++ b/docs/linux/sql-server-linux-configure-mssql-conf.md
@@ -57,7 +57,7 @@ ms.workload: "On Demand"
 
 ## <a id="agent"></a> Enable SQL Server Agent
 
-The **sqlagent.enabled** setting enables [SQL Server Agent](sql-server-linux-run-sql-server-agent-job.md). By default, SQL Server Agent is disabled. if sqlagent.enabled is not available in mssql.conf then we internally assume sql server agent is enabled.
+The **sqlagent.enabled** setting enables [SQL Server Agent](sql-server-linux-run-sql-server-agent-job.md). By default, SQL Server Agent is disabled. If **sqlagent.enabled** is not present in the mssql.conf settings file, then SQL Server internally assumes that SQL Server Agent is enabled.
 
 To change this settings, use the following steps:
 

--- a/docs/linux/sql-server-linux-configure-mssql-conf.md
+++ b/docs/linux/sql-server-linux-configure-mssql-conf.md
@@ -57,7 +57,7 @@ ms.workload: "On Demand"
 
 ## <a id="agent"></a> Enable SQL Server Agent
 
-The **sqlagent.enabled** setting enables [SQL Server Agent](sql-server-linux-run-sql-server-agent-job.md). By default, SQL Server Agent is disabled.
+The **sqlagent.enabled** setting enables [SQL Server Agent](sql-server-linux-run-sql-server-agent-job.md). By default, SQL Server Agent is disabled. if sqlagent.enabled is not available in mssql.conf then we internally assume sql server agent is enabled.
 
 To change this settings, use the following steps:
 


### PR DESCRIPTION
Updating the SQL Agent section to make sure users are aware , if mssql.conf file does not have an entry for enabled under [sqlagent] section we internally assume sql agent needs to be enabled and start the PE process.