### PR TITLE
Removed misleading and incorrect sentence

### DIFF
--- a/docs/database-engine/configure-windows/configure-the-remote-access-server-configuration-option.md
+++ b/docs/database-engine/configure-windows/configure-the-remote-access-server-configuration-option.md
@@ -53,7 +53,7 @@ ms.workload: "Active"
  This topic describes how to configure the **remote access** server configuration option in [!INCLUDE[ssCurrent](../../includes/sscurrent-md.md)] by using [!INCLUDE[ssManStudioFull](../../includes/ssmanstudiofull-md.md)] or [!INCLUDE[tsql](../../includes/tsql-md.md)]. The **remote access** option controls the execution of stored procedures from local or remote servers on which instances of [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] are running. This default value for this option is 1. This grants permission to run local stored procedures from remote servers or remote stored procedures from the local server. To prevent local stored procedures from being run from a remote server or remote stored procedures from being run on the local server, set the option to 0.  
   
 > [!IMPORTANT]  
->  [!INCLUDE[ssNoteDepNextDontUse](../../includes/ssnotedepnextdontuse-md.md)] Use [sp_addlinkedserver](../../relational-databases/system-stored-procedures/sp-addlinkedserver-transact-sql.md) instead. <br />When remote access is not enabled, execution of a stored procedure on a linked server, fails when using four part naming, such as the syntax `EXEC SQL01.TestDB.dbo.proc_test;`. Use `EXECUTE ... AT` syntax instead, such as `EXEC(N'TestDB.dbo.proc_test') AT [SQL01];`.
+>  [!INCLUDE[ssNoteDepNextDontUse](../../includes/ssnotedepnextdontuse-md.md)] Use [sp_addlinkedserver](../../relational-databases/system-stored-procedures/sp-addlinkedserver-transact-sql.md) instead.
   
  **In This Topic**  
   


### PR DESCRIPTION
"remote access" is indeed an obscure feature, and I
don't if it still possible to define a "remote server" à la SQL 6.5, but
probably not. For a execution of a stored procedure over a linked server,
the setting "remote access" has no meaning, but you need to set the server
option "rpc out". Which also is required for EXEC AT, if memory serves.

In any case, the sentence should just be removed.