### PR TITLE
corrected a mangled unicode example

### DIFF
--- a/docs/t-sql/functions/nchar-transact-sql.md
+++ b/docs/t-sql/functions/nchar-transact-sql.md
@@ -56,8 +56,8 @@ NCHAR ( integer_expression )
   
 ```  
 CREATE DATABASE test COLLATE Finnish_Swedish_100_CS_AS_SC;  
-DECLARE @d nvarchar(10) = N'ࣅ炙   
--– Old style method.  
+DECLARE @d nvarchar(10) = N'𣅿';
+-- Old style method.  
 SELECT NCHAR(0xD84C) + NCHAR(0xDD7F);   
   
 -- Preferred method.   


### PR DESCRIPTION
The documentation markdown source wasn't correctly encoding a single UTF-8 character, as well as having unbalanced single quotes and an en-dash that should have been a hyphen for a SQL comment.