### PR TITLE
deleted the cross cluster migration Section

### DIFF
--- a/docs/database-engine/availability-groups/windows/failover-clustering-and-always-on-availability-groups-sql-server.md
+++ b/docs/database-engine/availability-groups/windows/failover-clustering-and-always-on-availability-groups-sql-server.md
@@ -56,11 +56,6 @@ ms.workload: "Active"
   
  For information about running [!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)] on Windows Server Failover Clustering (WSFC) nodes and about WSFC quorum, see [Windows Server Failover Clustering &#40;WSFC&#41; with SQL Server](../../../sql-server/failover-clusters/windows/windows-server-failover-clustering-wsfc-with-sql-server.md).  
   
-### Cross-Cluster Migration of Always On Availability Groups for OS Upgrade  
- Beginning with [!INCLUDE[ssSQL11SP1](../../../includes/sssql11sp1-md.md)], [!INCLUDE[ssHADR](../../../includes/sshadr-md.md)] supports cross-cluster migration of availability groups for deployments to a new Windows Server Failover Clustering (WSFC) cluster. A cross-cluster migration moves one availability group or a batch of availability groups to the new, destination WSFC cluster with minimal downtime. The cross-cluster migration process enables you to maintain your service level agreements (SLAs) when upgrading to a [!INCLUDE[win8srv](../../../includes/win8srv-md.md)] cluster. [!INCLUDE[ssSQL11SP1](../../../includes/sssql11sp1-md.md)] (or a later version) must be installed and enabled for Always On on the destination WSFC cluster. The success of a cross-cluster migration depends on thorough planning and preparation of the destination WSFC cluster.  
-  
- For more information, see [Cross-Cluster Migration of Always On Availability Groups for OS Upgrade](http://msdn.microsoft.com/library/jj873730.aspx).  
-  
 ##  <a name="SQLServerFC"></a> [!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)] Failover Cluster Instances (FCIs) and Availability Groups  
  You can set up a second layer of failover at the server-instance level by implementing [!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)] failover clustering together with the WSFC cluster. An availability replica can be hosted by either a standalone instance of [!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)] or an FCI instance. Only one FCI partner can host a replica for a given availability group. When an availability replica is running on an FCI, the possible owners list for the availability group will contain only the active FCI node.  
   


### PR DESCRIPTION
As per an e-mail thread on the MVP list from 2016, this was deleted from the old MSDN docs but I think it somehow was forked and wound up here. I have the e-mail from Jennifer Hubbard saying it was done.