### PR TITLE
Removing inaccurate content

### DIFF
--- a/docs/t-sql/statements/create-external-table-as-select-transact-sql.md
+++ b/docs/t-sql/statements/create-external-table-as-select-transact-sql.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "CREATE EXTERNAL TABLE AS SELECT (Transact-SQL) | Microsoft Docs"
 ms.custom: ""
 ms.date: "08/10/2017"

--- a/docs/t-sql/statements/create-external-table-as-select-transact-sql.md
+++ b/docs/t-sql/statements/create-external-table-as-select-transact-sql.md
@@ -32,18 +32,6 @@ monikerRange: ">= aps-pdw-2016 || = azure-sqldw-latest || = sqlallproducts-allve
 
   Creates an external table and then exports, in parallel, the results of a [!INCLUDE[tsql](../../includes/tsql-md.md)] SELECT statement to Hadoop or Azure Storage Blob.  
   
- Use the CREATE EXTERNAL TABLE AS SELECT (CETAS) statement to:  
-  
--   Export a database table to Hadoop or Azure blob storage.  
-  
--   Import data from Hadoop or Azure blob storage and store it in the database.  
-  
--   Query data from Hadoop or Azure blob storage, join it with database relational tables, and write the results back to Hadoop or Azure blob storage.  
-  
--   Query data from Hadoop or Azure blob storage, transform it by using the database's fast processing capabilities, and write it back to Hadoop or Azure blob storage.  
-  
- For more information, see [Get started with PolyBase](../../relational-databases/polybase/get-started-with-polybase.md).  
-  
  ![Topic link icon](../../database-engine/configure-windows/media/topic-link.gif "Topic link icon") [Transact-SQL Syntax Conventions &#40;Transact-SQL&#41;](../../t-sql/language-elements/transact-sql-syntax-conventions-transact-sql.md)  
   
 ## Syntax  


### PR DESCRIPTION
CETAS only exports data to hadoop and wasb, does not import data. Looks like someone copy-pasted this generic polybase content into this doc. And this statement is not supported in SQL Server, so removing the link for getting started with polybase doc, since that's specific to sql server.