### PR TITLE
Update misleading statements about TRUNCATE TABLE

### DIFF
--- a/docs/relational-databases/replication/administration/frequently-asked-questions-for-replication-administrators.md
+++ b/docs/relational-databases/replication/administration/frequently-asked-questions-for-replication-administrators.md
@@ -159,7 +159,7 @@ manager: craigg
 ## Database Maintenance  
   
 ### Why can't I run TRUNCATE TABLE on a published table?  
- TRUNCATE TABLE is a non-logged operation that does not fire triggers. It is not permitted because replication cannot track the changes caused by the operation: transactional replication tracks changes through the transaction log; merge replication tracks changes through triggers on published tables.  
+ TRUNCATE TABLE is a DDL statement that does not log individual row deletions and does not fire DML triggers. It is not permitted because replication cannot track the changes caused by the operation: transactional replication tracks changes through the transaction log; merge replication tracks changes through DML triggers on published tables.  
   
 ### What is the effect of running a bulk insert command on a replicated database?  
  For transactional replication, bulk inserts are tracked and replicated like other inserts. For merge replication, you must ensure that change tracking metadata is updated properly.  


### PR DESCRIPTION
The document says that TRUNCATE TABLE is non-logged, but that is incorrect and misleads the reader in a big way. It does not log the removal of individual rows, but the operation (removing pages) is captured in the transaction log. That is an important distinction because readers of this document may also be considering log shipping and will conclude that TRUNCATE TABLE is not compatible with that. Secondly, the document states that TRUNCATE TABLE does not fire triggers. While it does not fire DML triggers, which are used to detect changes for merge replication, it does fire DDL triggers.