### PR TITLE
Fix missing `)` in openjson-transact-sql.md

### DIFF
--- a/docs/t-sql/functions/openjson-transact-sql.md
+++ b/docs/t-sql/functions/openjson-transact-sql.md
@@ -357,7 +357,7 @@ DECLARE @json NVARCHAR(max)  = N'{
   WITH (id int,  
         firstName nvarchar(50), lastName nvarchar(50),   
         isAlive bit, age int,  
-        dateOfBirth datetime2, spouse nvarchar(50)
+        dateOfBirth datetime2, spouse nvarchar(50))
 ```  
   
 ## See Also  


### PR DESCRIPTION
Fixed a missing `)` in Example 5 in the `WITH` clause of the `OPENJSON` expression.