### PR TITLE
Correcting typo in consistency check parameter name

### DIFF
--- a/docs/relational-databases/tables/creating-a-system-versioned-temporal-table.md
+++ b/docs/relational-databases/tables/creating-a-system-versioned-temporal-table.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Creating a System-Versioned Temporal Table | Microsoft Docs"
 ms.custom: ""
 ms.date: "05/24/2016"

--- a/docs/relational-databases/tables/creating-a-system-versioned-temporal-table.md
+++ b/docs/relational-databases/tables/creating-a-system-versioned-temporal-table.md
@@ -179,7 +179,7 @@ ALTER TABLE InsurancePolicy
   
 -   Adding period will perform a data consistency check on the current table to make sure that the defaults for period columns are valid.  
   
--   When an existing history table is specified when enabling **SYSTEM_VERSIONING**, a data consistency check will be performed across both the current and the history table. It can be skipped if you specify **DATA_CONISTENCY_CHECK = OFF** as an additional parameter.  
+-   When an existing history table is specified when enabling **SYSTEM_VERSIONING**, a data consistency check will be performed across both the current and the history table. It can be skipped if you specify **DATA_CONSISTENCY_CHECK = OFF** as an additional parameter.  
   
 ### Migrate existing tables to built-in support  
  This example shows how to migrate an existing solution based on triggers to build-in temporal support. For this example, we assume that the current custom solution splits the current and historical data in two separate user tables (**ProjectTaskCurrent** and **ProjectTaskHistory**). If your existing solution uses single table to store actual and historical rows, then you should split the data into two tables prior to the migration steps shown in this example:  


### PR DESCRIPTION
I spotted a typo on the name `DATA_CONISTENCY_CHECK` (missing the first `S`)