### PR TITLE
Fix typo in datetimeoffset

### DIFF
--- a/docs/t-sql/data-types/datetimeoffset-transact-sql.md
+++ b/docs/t-sql/data-types/datetimeoffset-transact-sql.md
@@ -129,7 +129,7 @@ SELECT @datetimeoffset AS '@datetimeoffset ', @date AS 'date';
   
 ```  
   
-If the conversion is to **time(n)**, the our, minute, second, and fractional seconds are copied. The time zone value is truncated. When the precision of the **datetimeoffset(n)** value is greater than the precision of the **time(n)** value, the value is rounded up. The following code shows the results of converting a `datetimeoffset(4)` value to a `time(3)` value.
+If the conversion is to **time(n)**, the hour, minute, second, and fractional seconds are copied. The time zone value is truncated. When the precision of the **datetimeoffset(n)** value is greater than the precision of the **time(n)** value, the value is rounded up. The following code shows the results of converting a `datetimeoffset(4)` value to a `time(3)` value.
   
 ```sql
 DECLARE @datetimeoffset datetimeoffset(4) = '12-10-25 12:32:10.1237 +01:0';  

--- a/docs/t-sql/data-types/datetimeoffset-transact-sql.md
+++ b/docs/t-sql/data-types/datetimeoffset-transact-sql.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "datetimeoffset (Transact-SQL) | Microsoft Docs"
 ms.custom: ""
 ms.date: "7/23/2017"


### PR DESCRIPTION
Changes "our" to "hour" in `docs/t-sql/data-types/datetimeoffset-transact-sql.md`