### PR TITLE
Corrected and clarified ANSI_NULLS remarks

### DIFF
--- a/docs/t-sql/language-elements/comparison-operators-transact-sql.md
+++ b/docs/t-sql/language-elements/comparison-operators-transact-sql.md
@@ -48,7 +48,7 @@ manager: craigg
   
  Unlike other [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] data types, a **Boolean** data type cannot be specified as the data type of a table column or variable, and cannot be returned in a result set.  
   
- When SET ANSI_NULLS is ON, an operator that has one or two NULL expressions returns UNKNOWN. When SET ANSI_NULLS is OFF, the same rules apply, except for the equals (=) and not equals (<>) operators. When SET ANSI_NULLS is OFF, these operators will treat NULL as a known value, equivalent to any other NULL, and will only return TRUE or FALSE (never UNKNOWN).  
+ When SET ANSI_NULLS is ON, an operator that has one or two NULL expressions returns UNKNOWN. When SET ANSI_NULLS is OFF, the same rules apply, except for the equals (=) and not equals (<>) operators. When SET ANSI_NULLS is OFF, these operators treat NULL as a known value, equivalent to any other NULL, and only return TRUE or FALSE (never UNKNOWN).  
   
  Expressions with **Boolean** data types are used in the WHERE clause to filter the rows that qualify for the search conditions and in control-of-flow language statements such as IF and WHILE, for example:  
   

--- a/docs/t-sql/language-elements/comparison-operators-transact-sql.md
+++ b/docs/t-sql/language-elements/comparison-operators-transact-sql.md
@@ -48,7 +48,7 @@ manager: craigg
   
  Unlike other [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] data types, a **Boolean** data type cannot be specified as the data type of a table column or variable, and cannot be returned in a result set.  
   
- When SET ANSI_NULLS is ON, an operator that has one or two NULL expressions returns UNKNOWN. When SET ANSI_NULLS is OFF, the same rules apply, except an equals (=) operator returns TRUE if both expressions are NULL. For example, NULL = NULL returns TRUE when SET ANSI_NULLS is OFF.  
+ When SET ANSI_NULLS is ON, an operator that has one or two NULL expressions returns UNKNOWN. When SET ANSI_NULLS is OFF, the same rules apply, except for the equals (=) and not equals (<>) operators. When SET ANSI_NULLS is OFF, these operators will treat NULL as a known value, equivalent to any other NULL, and will only return TRUE or FALSE (never UNKNOWN).  
   
  Expressions with **Boolean** data types are used in the WHERE clause to filter the rows that qualify for the search conditions and in control-of-flow language statements such as IF and WHILE, for example:  
   

--- a/docs/t-sql/language-elements/equals-transact-sql.md
+++ b/docs/t-sql/language-elements/equals-transact-sql.md
@@ -56,7 +56,7 @@ expression = expression
 
 For more information, see [SET ANSI_NULLS &#40;Transact-SQL&#41;](../../t-sql/statements/set-ansi-nulls-transact-sql.md).
   
- A boolean expression resulting in UNKNOWN will behave similarly to FALSE in most, but not all cases. See [NULL and UNKNOWN &#40;Transact-SQL&#41;](../../t-sql/language-elements/null-and-unknown-transact-sql.md) and [NOT &#40;Transact-SQL&#41;](../../t-sql/language-elements/not-transact-sql.md) for more information.  
+ A boolean expression resulting in UNKNOWN behaves similarly to FALSE in most, but not all cases. See [NULL and UNKNOWN &#40;Transact-SQL&#41;](../../t-sql/language-elements/null-and-unknown-transact-sql.md) and [NOT &#40;Transact-SQL&#41;](../../t-sql/language-elements/not-transact-sql.md) for more information.  
   
   
 ## Examples  

--- a/docs/t-sql/language-elements/equals-transact-sql.md
+++ b/docs/t-sql/language-elements/equals-transact-sql.md
@@ -52,7 +52,7 @@ expression = expression
   
 -   If `ANSI_NULLS` is set to ON, the result of any comparison with NULL is UNKNOWN, following the ANSI convention that NULL is an unknown value and cannot be compared with any other value, including other NULLs.  
   
--   If `ANSI_NULLS` is set to OFF, the result of comparing NULL to NULL is TRUE, and the result of comparing NULL to any other value is FALSE.  
+-   If `ANSI_NULLS` is set to OFF, the result of comparing NULL equal to NULL is TRUE, and the result of comparing NULL equal to any other value is FALSE.  
 
 For more information, see [SET ANSI_NULLS &#40;Transact-SQL&#41;](../../t-sql/statements/set-ansi-nulls-transact-sql.md).
   

--- a/docs/t-sql/language-elements/equals-transact-sql.md
+++ b/docs/t-sql/language-elements/equals-transact-sql.md
@@ -52,7 +52,7 @@ expression = expression
   
 -   If `ANSI_NULLS` is set to ON, the result of any comparison with NULL is UNKNOWN, following the ANSI convention that NULL is an unknown value and cannot be compared with any other value, including other NULLs.  
   
--   If `ANSI_NULLS` is set to OFF, the result of comparing NULL equal to NULL is TRUE, and the result of comparing NULL equal to any other value is FALSE.  
+-   If `ANSI_NULLS` is set to OFF, the result of comparing NULL to NULL is TRUE, and the result of comparing NULL to any other value is FALSE.  
 
 For more information, see [SET ANSI_NULLS &#40;Transact-SQL&#41;](../../t-sql/statements/set-ansi-nulls-transact-sql.md).
   

--- a/docs/t-sql/language-elements/equals-transact-sql.md
+++ b/docs/t-sql/language-elements/equals-transact-sql.md
@@ -48,7 +48,7 @@ expression = expression
  Boolean  
   
 ## Remarks  
- When you compare a NULL value with another NULL or non-NULL value, the result depends on the `ANSI_NULLS` setting:  
+ When you compare using a NULL expression, the result depends on the `ANSI_NULLS` setting:  
   
 -   If `ANSI_NULLS` is set to ON, the result of any comparison with NULL is UNKNOWN, following the ANSI convention that NULL is an unknown value and cannot be compared with any other value, including other NULLs.  
   

--- a/docs/t-sql/language-elements/equals-transact-sql.md
+++ b/docs/t-sql/language-elements/equals-transact-sql.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "= (Equals) (Transact-SQL) | Microsoft Docs"
 ms.custom: ""
 ms.date: "12/06/2016"

--- a/docs/t-sql/language-elements/equals-transact-sql.md
+++ b/docs/t-sql/language-elements/equals-transact-sql.md
@@ -48,15 +48,15 @@ expression = expression
  Boolean  
   
 ## Remarks  
- When you compare two NULL expressions, the result depends on the `ANSI_NULLS` setting:  
+ When you compare a NULL value with another NULL or non-NULL value, the result depends on the `ANSI_NULLS` setting:  
   
--   If `ANSI_NULLS` is set to ON, the result is NULL, following the ANSI convention that a NULL (or unknown) value is not equal to another NULL or unknown value.  
+-   If `ANSI_NULLS` is set to ON, the result of any comparison with NULL is UNKNOWN, following the ANSI convention that NULL is an unknown value and cannot be compared with any other value, including other NULLs.  
   
--   If `ANSI_NULLS` is set to OFF, the result of NULL compared to NULL is TRUE.  
+-   If `ANSI_NULLS` is set to OFF, the result of comparing NULL to NULL is TRUE, and the result of comparing NULL to any other value is FALSE.  
 
 For more information, see [SET ANSI_NULLS &#40;Transact-SQL&#41;](../../t-sql/statements/set-ansi-nulls-transact-sql.md).
   
- Any sort of comparison of a NULL value (an unknown) to a non-NULL value always results in FALSE.  
+ A boolean expression resulting in UNKNOWN will behave similarly to FALSE in most, but not all cases. See [NULL and UNKNOWN &#40;Transact-SQL&#41;](../../t-sql/language-elements/null-and-unknown-transact-sql.md) and [NOT &#40;Transact-SQL&#41;](../../t-sql/language-elements/not-transact-sql.md) for more information.  
   
   
 ## Examples  


### PR DESCRIPTION
Fixed a number of errors and omissions related to SET ANSI_NULLS and boolean data types in "Comparison Operators" and "Equals".

Resolves issues noticed on SO in 2012: https://stackoverflow.com/q/9707111/152891