### PR TITLE
add comparison table

### DIFF
--- a/docs/t-sql/statements/set-ansi-nulls-transact-sql.md
+++ b/docs/t-sql/statements/set-ansi-nulls-transact-sql.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "SET ANSI_NULLS (Transact-SQL) | Microsoft Docs"
 ms.custom: ""
 ms.date: "12/04/2017"

--- a/docs/t-sql/statements/set-ansi-nulls-transact-sql.md
+++ b/docs/t-sql/statements/set-ansi-nulls-transact-sql.md
@@ -61,7 +61,22 @@ SET ANSI_NULLS ON
  When SET ANSI_NULLS is OFF, the Equals (=) and Not Equal To (<>) comparison operators do not follow the ISO standard. A SELECT statement that uses WHERE *column_name* = **NULL** returns the rows that have null values in *column_name*. A SELECT statement that uses WHERE *column_name* <> **NULL** returns the rows that have nonnull values in the column. Also, a SELECT statement that uses WHERE *column_name* <> *XYZ_value* returns all rows that are not *XYZ_value* and that are not NULL.  
   
  When SET ANSI_NULLS is ON, all comparisons against a null value evaluate to UNKNOWN. When SET ANSI_NULLS is OFF, comparisons of all data against a null value evaluate to TRUE if the data value is NULL. If SET ANSI_NULLS is not specified, the setting of the ANSI_NULLS option of the current database applies. For more information about the ANSI_NULLS database option, see [ALTER DATABASE &#40;Transact-SQL&#41;](../../t-sql/statements/alter-database-transact-sql.md).  
+
+ The following table shows how the setting of ANSI_NULLS affects the results of a number of Boolean expressions using null and non-null values.  
   
+|Boolean Expression|SET ANSI_NULLS ON|SET ANSI_NULLS OFF|  
+|---------------|---------------|------------|  
+|NULL = NULL|UNKNOWN|TRUE|  
+|1 = NULL|UNKNOWN|FALSE|  
+|NULL <> NULL|UNKNOWN|FALSE|  
+|1 <> NULL|UNKNOWN|TRUE|  
+|NULL > NULL|UNKNOWN|UNKNOWN|  
+|1 > NULL|UNKNOWN|UNKNOWN|  
+|NULL IS NULL|TRUE|TRUE|  
+|1 IS NULL|FALSE|FALSE|  
+|NULL IS NOT NULL|FALSE|FALSE|  
+|1 IS NOT NULL|TRUE|TRUE|  
+
  SET ANSI_NULLS ON affects a comparison only if one of the operands of the comparison is either a variable that is NULL or a literal NULL. If both sides of the comparison are columns or compound expressions, the setting does not affect the comparison.  
   
  For a script to work as intended, regardless of the ANSI_NULLS database option or the setting of SET ANSI_NULLS, use IS NULL and IS NOT NULL in comparisons that might contain null values.  


### PR DESCRIPTION
I feel like the overall T-SQL documentation on boolean expressions involving NULLs has been crying out for a very clear example of how NULLs work under the ANSI_NULLS setting. I've created a table that I think illustrates this well, and put it where I think it would be most appropriate, but it may be better suited to a different location.