### PR TITLE
fix: Metadata and intenal MS staging link

### DIFF
--- a/docs/relational-databases/tables/manage-retention-of-historical-data-in-system-versioned-temporal-tables.md
+++ b/docs/relational-databases/tables/manage-retention-of-historical-data-in-system-versioned-temporal-tables.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Manage Retention of Historical Data in System-Versioned Temporal Tables | Microsoft Docs"
 ms.custom: ""
 ms.date: "05/18/2017"
@@ -48,7 +48,7 @@ monikerRange: "= azuresqldb-current || >= sql-server-2016 || = sqlallproducts-al
   
 > **NOTE:**  Using the Stretch Database approach only applies to [!INCLUDE[ssCurrent](../../includes/sscurrent-md.md)] and does not apply to [!INCLUDE[sqldbesa](../../includes/sqldbesa-md.md)].  
   
- [Stretch Database](../../sql-server/stretch-database/stretch-database.md) in [!INCLUDE[ssCurrent](../../includes/sscurrent-md.md)] migrates your historical data transparently to Azure. For additional security, you can encrypt data in motion using SQL Server's [Always Encrypted](https://msdnstage.redmond.corp.microsoft.com/library/mt163865.aspx) feature. Additionally, you can use [Row-Level Security](../../relational-databases/security/row-level-security.md) and other advanced SQL Server security features with Temporal and Stretch Database to protect your data.  
+ [Stretch Database](../../sql-server/stretch-database/stretch-database.md) in [!INCLUDE[ssCurrent](../../includes/sscurrent-md.md)] migrates your historical data transparently to Azure. For additional security, you can encrypt data in motion using SQL Server's [Always Encrypted](https://msdn.microsoft.com/library/mt163865.aspx) feature. Additionally, you can use [Row-Level Security](../../relational-databases/security/row-level-security.md) and other advanced SQL Server security features with Temporal and Stretch Database to protect your data.  
   
  Using the Stretch Database approach, you can stretch some or all of your temporal history tables to Azure and SQL Server will silently move historical data to Azure. Stretch-enabling a history table does not change how you interact with the temporal table in terms of data modification and temporal querying.  
   

--- a/docs/relational-databases/tables/system-versioned-temporal-tables-with-memory-optimized-tables.md
+++ b/docs/relational-databases/tables/system-versioned-temporal-tables-with-memory-optimized-tables.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "System-Versioned Temporal Tables with Memory-Optimized Tables | Microsoft Docs"
 ms.custom: ""
 ms.date: "07/12/2016"
@@ -37,7 +37,7 @@ monikerRange: "= azuresqldb-current || >= sql-server-2016 || = sqlallproducts-al
   
 -   History table for memory-optimized system-versioned table must be disk-based, regardless if it was created by the end user or the system.  
   
--   Queries that affect only the current table (in-memory) can be used in [natively compiled T-SQL modules](https://msdnstage.redmond.corp.microsoft.com/en-us/library/dn133184.aspx). Temporal queries using the FOR SYSTEM TIME clause are not supported in natively compiled modules. Use of the FOR SYSTEM TIME clause with memory-optimized tables in ad hoc queries and non-native modules is supported.  
+-   Queries that affect only the current table (in-memory) can be used in [natively compiled T-SQL modules](https://msdn.microsoft.com/en-us/library/dn133184.aspx). Temporal queries using the FOR SYSTEM TIME clause are not supported in natively compiled modules. Use of the FOR SYSTEM TIME clause with memory-optimized tables in ad hoc queries and non-native modules is supported.  
   
 -   When **SYSTEM_VERSIONING = ON**, an internal memory-optimized staging table is automatically created to accept the most recent system-versioned changes that are results of update and delete operations on memory-optimized current table.  
   


### PR DESCRIPTION
First line change is some sort of BOM or similar that was causing the metadata not to render correctly.
The link was to an internal MS staging server (i'm guessing), but once fixed it redirects to https://docs.microsoft.com/en-us/sql/relational-databases/in-memory-oltp/natively-compiled-stored-procedures?view=sql-server-2017