### PR TITLE
Fix [!IMPORTANT] note inside code block

### DIFF
--- a/docs/t-sql/statements/create-index-transact-sql.md
+++ b/docs/t-sql/statements/create-index-transact-sql.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "CREATE INDEX (Transact-SQL) | Microsoft Docs"
 ms.custom: ""
 ms.date: "12/21/2017"

--- a/docs/t-sql/statements/create-index-transact-sql.md
+++ b/docs/t-sql/statements/create-index-transact-sql.md
@@ -103,10 +103,10 @@ CREATE UNIQUE INDEX i1 ON t1 (col1 DESC, col2 ASC, col3 DESC);
 ![Topic link icon](../../database-engine/configure-windows/media/topic-link.gif "Topic link icon") [Transact-SQL Syntax Conventions](../../t-sql/language-elements/transact-sql-syntax-conventions-transact-sql.md)  
   
 ## Syntax  
-  
+
+### Syntax for SQL Server and Azure SQL Database
+
 ```  
--- Syntax for SQL Server and Azure SQL Database
-  
 CREATE [ UNIQUE ] [ CLUSTERED | NONCLUSTERED ] INDEX index_name   
     ON <object> ( column [ ASC | DESC ] [ ,...n ] )   
     [ INCLUDE ( column_name [ ,...n ] ) ]  
@@ -162,14 +162,16 @@ CREATE [ UNIQUE ] [ CLUSTERED | NONCLUSTERED ] INDEX index_name
   
 <range> ::=   
 <partition_number_expression> TO <partition_number_expression>  
-  
-Backward Compatible Relational Index
+```
+
+### Backward Compatible Relational Index
 
 > [!IMPORTANT]
 > The backward compatible relational index syntax structure will be removed in a future version of [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)]. 
 > Avoid using this syntax structure in new development work, and plan to modify applications that currently use the feature. 
 > Use the syntax structure specified in <relational_index_option> instead.  
-  
+
+```  
 CREATE [ UNIQUE ] [ CLUSTERED | NONCLUSTERED ] INDEX index_name   
     ON <object> ( column_name [ ASC | DESC ] [ ,...n ] )   
     [ WITH <backward_compatible_index_option> [ ,...n ] ]  
@@ -191,10 +193,9 @@ CREATE [ UNIQUE ] [ CLUSTERED | NONCLUSTERED ] INDEX index_name
   | DROP_EXISTING   
 }  
 ```  
-
+### Syntax for Azure SQL Data Warehouse and Parallel Data Warehouse  
   
 ```  
--- Syntax for Azure SQL Data Warehouse and Parallel Data Warehouse  
   
 CREATE [ CLUSTERED | NONCLUSTERED ] INDEX index_name   
     ON [ database_name . [ schema ] . | schema . ] table_name   


### PR DESCRIPTION
`> [!IMPORTANT]` does not work inside code blocks. This is an attempt to fix it by breaking the code block into three parts and converting syntax sub-sections from comments inside the code block into level-3 subtitles. 

Another option would be to not use `> [!IMPORTANT]`