### PR TITLE
Rearrange acceptable data types for accessibility

### DIFF
--- a/docs/t-sql/functions/isnumeric-transact-sql.md
+++ b/docs/t-sql/functions/isnumeric-transact-sql.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "ISNUMERIC (Transact-SQL) | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/13/2017"

--- a/docs/t-sql/functions/isnumeric-transact-sql.md
+++ b/docs/t-sql/functions/isnumeric-transact-sql.md
@@ -50,15 +50,15 @@ ISNUMERIC ( expression )
  **int**  
   
 ## Remarks  
- ISNUMERIC returns 1 when the input expression evaluates to a valid numeric data type; otherwise it returns 0. Valid numeric data types include the following:  
-  
-|||  
-|-|-|  
-|**int**|**numeric**|  
-|**bigint**|**money**|  
-|**smallint**|**smallmoney**|  
-|**tinyint**|**float**|  
-|**decimal**|**real**|  
+ ISNUMERIC returns 1 when the input expression evaluates to a valid numeric data type; otherwise it returns 0. Valid [numeric data types](../../t-sql/data-types/numeric-types.md) include the following:  
+
+|||
+|-|-|
+| [Exact Numerics](../../t-sql/data-types/int-bigint-smallint-and-tinyint-transact-sql.md) | **bigint**, **int**, **smallint**, **tinyint** |
+| [Fixed Precision](../../t-sql/data-types/decimal-and-numeric-transact-sql.md) | **decimal**, **numeric** |
+| [Approximate](../../t-sql/data-types/float-and-real-transact-sql.md) | **float**, **real** |
+| [Monetary Values](../../t-sql/data-types/money-and-smallmoney-transact-sql.md) | **money**, **smallmoney** |
+
   
 > [!NOTE]  
 >  ISNUMERIC returns 1 for some characters that are not numbers, such as plus (+), minus (-), and valid currency symbols such as the dollar sign ($). For a complete list of currency symbols, see [money and smallmoney &#40;Transact-SQL&#41;](../../t-sql/data-types/money-and-smallmoney-transact-sql.md).  

--- a/docs/t-sql/functions/isnumeric-transact-sql.md
+++ b/docs/t-sql/functions/isnumeric-transact-sql.md
@@ -54,7 +54,7 @@ ISNUMERIC ( expression )
 
 |||
 |-|-|
-| [Exact Numerics](../../t-sql/data-types/int-bigint-smallint-and-tinyint-transact-sql.md) | **bigint**, **int**, **smallint**, **tinyint** |
+| [Exact Numerics](../../t-sql/data-types/int-bigint-smallint-and-tinyint-transact-sql.md) | **bigint**, **int**, **smallint**, **tinyint**, **bit** |
 | [Fixed Precision](../../t-sql/data-types/decimal-and-numeric-transact-sql.md) | **decimal**, **numeric** |
 | [Approximate](../../t-sql/data-types/float-and-real-transact-sql.md) | **float**, **real** |
 | [Monetary Values](../../t-sql/data-types/money-and-smallmoney-transact-sql.md) | **money**, **smallmoney** |


### PR DESCRIPTION
There are quite a few places throughout the documentation where tables are used to display list content in two columns.  This is one of those places.  Using tables for layout purposes is a well known faux-pas.

I still used a table here, but tried to categorize the content a bit so that the table makes a bit more sense and isn't just noise to a screen reader.  Might not be perfect, but I think it's a start.

Should tables like this one be reviewed and converted to lists?  Should the tables be restructured to increase their accessibility?