### PR TITLE
Move "bit" under "numeric"

### DIFF
--- a/docs/t-sql/data-types/TOC.md
+++ b/docs/t-sql/data-types/TOC.md
@@ -3,8 +3,7 @@
 # [Conversion](data-type-conversion-database-engine.md)  
 # [Precedence](data-type-precedence-transact-sql.md)  
 # [Synonyms](data-type-synonyms-transact-sql.md)  
-# [Precision, Scale, and Length](precision-scale-and-length-transact-sql.md)  
-# [bit](bit-transact-sql.md)  
+# [Precision, Scale, and Length](precision-scale-and-length-transact-sql.md)    
 # [cursor](cursor-transact-sql.md)  
 # [Date and time](date-and-time-types.md)  
 ## [date](date-transact-sql.md)  
@@ -27,6 +26,7 @@
 ## [Write (Database Engine)](write-database-engine.md)  
 
 # [Numeric](numeric-types.md)  
+## [bit](bit-transact-sql.md)
 ## [decimal and numeric](decimal-and-numeric-transact-sql.md)  
 ## [float and real](float-and-real-transact-sql.md)  
 ## [int, bigint, smallint, and tinyint](int-bigint-smallint-and-tinyint-transact-sql.md)  


### PR DESCRIPTION
The definition of the "bit" data type is "An integer data type that can take a value of 1, 0, or NULL. "
When  a bit value is passed to the "isnumeric" function, 1 is returned.
The bit page was kind of floating in the table of contents, looking for a home.