### PR TITLE
In correct information existing powerpivot model

### DIFF
--- a/docs/analysis-services/tabular-models/restore-from-power-pivot.md
+++ b/docs/analysis-services/tabular-models/restore-from-power-pivot.md
@@ -25,7 +25,7 @@ manager: kfile
   
 -   By default, when you restore a database from [!INCLUDE[ssGemini](../../includes/ssgemini-md.md)], the Tabular model database Data Source Impersonation Info property is set to Default, which specifies the Analysis Services instance service account. It is recommended you change the impersonation credentials to a Windows user account in Database Properties. For more information, see [Impersonation](../../analysis-services/tabular-models/impersonation-ssas-tabular.md).  
   
--   Data in the [!INCLUDE[ssGemini](../../includes/ssgemini-md.md)] data model will be copied into an existing or new Tabular model database on the Analysis Services instance. If your [!INCLUDE[ssGemini](../../includes/ssgemini-md.md)] workbook contains linked tables, they will be recreated as a table without a data source, similar to a table created using Paste To New table.  
+-   Data in the [!INCLUDE[ssGemini](../../includes/ssgemini-md.md)] data model will be copied into a new Tabular model database on the Analysis Services instance. If your [!INCLUDE[ssGemini](../../includes/ssgemini-md.md)] workbook contains linked tables, they will be recreated as a table without a data source, similar to a table created using Paste To New table.  
   
 ### To Restore from Power Pivot  
   
@@ -33,7 +33,7 @@ manager: kfile
   
 2.  In the **Restore from [!INCLUDE[ssGemini](../../includes/ssgemini-md.md)]** dialog box, in **Restore Source**, in **Backup file**, click **Browse**, and then select an .abf or .xslx file to restore from.  
   
-3.  In **Restore Target**, in **Restore database**, type a name for a new database or for an existing database. If you do not specify a name, the name of the workbook is used.  
+3.  In **Restore Target**, in **Restore database**, type a name for a new database. If you do not specify a name, the name of the workbook is used.  
   
 4.  In **Storage location**, click **Browse**, and then select a location to store the database.  
   


### PR DESCRIPTION
If the database exists and we try to restore we would get an error. “Object cannot be restored because the object already exists.  Please select a different database name.. There was Defect 743287:Remove Override checkbox in restore from PowerPivot filled to change the behavior. But the documentation suggest we can override an existing database which is not true.