### PR TITLE
Add info about automatic serial redo

### DIFF
--- a/docs/database-engine/availability-groups/windows/prereqs-restrictions-recommendations-always-on-availability.md
+++ b/docs/database-engine/availability-groups/windows/prereqs-restrictions-recommendations-always-on-availability.md
@@ -167,7 +167,7 @@ manager: craigg
     - A SQL Server instance uses up to 100 threads for parallel redo for secondary replicas. Each database uses up to one-half of the total number of CPU cores, but not more than 16 threads per database. If the total number of required threads for a single instance exceeds 100, SQL Server uses a single redo thread for every remaining database. Redo threads are released after ~15 seconds of inactivity. 
     
     >[NOTE}
-    > Databases are chosen to go single-threaded based on their ascending database ID. As such, the database creation order should be considered for SQL Server instances that host more databases per availability group than available worker threads. For example, on a system with 32 or more CPU cores, all databases starting with the 7th database, that joined the availability group will be in serial redo mode irrespective of the actual redo workload for each database. Databases that require parallel redo should be added to the availability group first.    
+    > Databases are chosen to go single-threaded based on their ascending database ID. As such, the database creation order should be considered for SQL Server instances that host more databases per availability group than available worker threads. For example, on a system with 32 or more CPU cores, all databases starting with the 7th database that joined the availability group will be in serial redo mode irrespective of the actual redo workload for each database. Databases that require parallel redo should be added to the availability group first.    
   
 -   In addition, availability groups use unshared threads, as follows:  
   

--- a/docs/database-engine/availability-groups/windows/prereqs-restrictions-recommendations-always-on-availability.md
+++ b/docs/database-engine/availability-groups/windows/prereqs-restrictions-recommendations-always-on-availability.md
@@ -166,7 +166,7 @@ manager: craigg
 
     - A SQL Server instance uses up to 100 threads for parallel redo for secondary replicas. Each database uses up to one-half of the total number of CPU cores, but not more than 16 threads per database. If the total number of required threads for a single instance exceeds 100, SQL Server uses a single redo thread for every remaining database. Redo threads are released after ~15 seconds of inactivity. 
     
-    >[NOTE]
+    > [!NOTE]
     > Databases are chosen to go single-threaded based on their ascending database ID. As such, the database creation order should be considered for SQL Server instances that host more availability group databases than available worker threads. For example, on a system with 32 or more CPU cores, all databases starting with the 7th database that joined the availability group will be in serial redo mode irrespective of the actual redo workload for each database. Databases that require parallel redo should be added to the availability group first.    
   
 -   In addition, availability groups use unshared threads, as follows:  

--- a/docs/database-engine/availability-groups/windows/prereqs-restrictions-recommendations-always-on-availability.md
+++ b/docs/database-engine/availability-groups/windows/prereqs-restrictions-recommendations-always-on-availability.md
@@ -165,6 +165,8 @@ manager: craigg
     -   If a given thread is idle for a while, it is released back into the general [!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)] thread pool. Normally, an inactive thread is released after ~15 seconds of inactivity. However, depending on the last activity, an idle thread might be retained longer.  
 
     - A SQL Server instance uses up to 100 threads for parallel redo for secondary replicas. Each database uses up to one-half of the total number of CPU cores, but not more than 16 threads per database. If the total number of required threads for a single instance exceeds 100, SQL Server uses a single redo thread for every remaining database. Redo threads are released after ~15 seconds of inactivity. 
+    
+       - When the 100 thread limit is exceeded, the databases that get parallel redo threads are chosen in database order (by database id ascending)
 
   
 -   In addition, availability groups use unshared threads, as follows:  

--- a/docs/database-engine/availability-groups/windows/prereqs-restrictions-recommendations-always-on-availability.md
+++ b/docs/database-engine/availability-groups/windows/prereqs-restrictions-recommendations-always-on-availability.md
@@ -166,8 +166,8 @@ manager: craigg
 
     - A SQL Server instance uses up to 100 threads for parallel redo for secondary replicas. Each database uses up to one-half of the total number of CPU cores, but not more than 16 threads per database. If the total number of required threads for a single instance exceeds 100, SQL Server uses a single redo thread for every remaining database. Redo threads are released after ~15 seconds of inactivity. 
     
-       - When the 100 thread limit is exceeded, the databases that get parallel redo threads are chosen in database order (by database id ascending)
-
+    >[NOTE}
+    > Databases are chosen to go single-threaded based on their ascending database ID. As such, the database creation order should be considered for SQL Server instances that host more databases per availability group than available worker threads. For example, on a system with 32 or more CPU cores, all databases starting with the 7th database that joined the availability group will be in serial redo mode irresepective of the actual redo workload for each database. Databases that require parallel redo should be added to the availability group first. 
   
 -   In addition, availability groups use unshared threads, as follows:  
   

--- a/docs/database-engine/availability-groups/windows/prereqs-restrictions-recommendations-always-on-availability.md
+++ b/docs/database-engine/availability-groups/windows/prereqs-restrictions-recommendations-always-on-availability.md
@@ -166,8 +166,8 @@ manager: craigg
 
     - A SQL Server instance uses up to 100 threads for parallel redo for secondary replicas. Each database uses up to one-half of the total number of CPU cores, but not more than 16 threads per database. If the total number of required threads for a single instance exceeds 100, SQL Server uses a single redo thread for every remaining database. Redo threads are released after ~15 seconds of inactivity. 
     
-    >[NOTE}
-    > Databases are chosen to go single-threaded based on their ascending database ID. As such, the database creation order should be considered for SQL Server instances that host more databases per availability group than available worker threads. For example, on a system with 32 or more CPU cores, all databases starting with the 7th database that joined the availability group will be in serial redo mode irrespective of the actual redo workload for each database. Databases that require parallel redo should be added to the availability group first.    
+    >[NOTE]
+    > Databases are chosen to go single-threaded based on their ascending database ID. As such, the database creation order should be considered for SQL Server instances that host more availability group databases than available worker threads. For example, on a system with 32 or more CPU cores, all databases starting with the 7th database that joined the availability group will be in serial redo mode irrespective of the actual redo workload for each database. Databases that require parallel redo should be added to the availability group first.    
   
 -   In addition, availability groups use unshared threads, as follows:  
   

--- a/docs/database-engine/availability-groups/windows/prereqs-restrictions-recommendations-always-on-availability.md
+++ b/docs/database-engine/availability-groups/windows/prereqs-restrictions-recommendations-always-on-availability.md
@@ -167,7 +167,7 @@ manager: craigg
     - A SQL Server instance uses up to 100 threads for parallel redo for secondary replicas. Each database uses up to one-half of the total number of CPU cores, but not more than 16 threads per database. If the total number of required threads for a single instance exceeds 100, SQL Server uses a single redo thread for every remaining database. Redo threads are released after ~15 seconds of inactivity. 
     
     >[NOTE}
-    > Databases are chosen to go single-threaded based on their ascending database ID. As such, the database creation order should be considered for SQL Server instances that host more databases per availability group than available worker threads. For example, on a system with 32 or more CPU cores, all databases starting with the 7th database that joined the availability group will be in serial redo mode irresepective of the actual redo workload for each database. Databases that require parallel redo should be added to the availability group first. 
+    > Databases are chosen to go single-threaded based on their ascending database ID. As such, the database creation order should be considered for SQL Server instances that host more databases per availability group than available worker threads. For example, on a system with 32 or more CPU cores, all databases starting with the 7th database, that joined the availability group will be in serial redo mode irrespective of the actual redo workload for each database. Databases that require parallel redo should be added to the availability group first.    
   
 -   In addition, availability groups use unshared threads, as follows:  
   


### PR DESCRIPTION
An important detail (about which databases are automatically put into serial redo mode when more than 100 parallel redo threads are required) was released in the following blog post (near the end, under the heading "Parallel redo thread usage and redo model control"):

https://blogs.msdn.microsoft.com/sql_server_team/sql-server-20162017-availability-group-secondary-replica-redo-model-and-performance/

I think it would make sense for that information to be included directly in this documentation page.  I've attempted to phrase Dong Cao's words so they fit into the context of this documentation.