### PR TITLE
Update register-a-service-principal-name-spn-for-a-report-server.md

### DIFF
--- a/docs/reporting-services/report-server/register-a-service-principal-name-spn-for-a-report-server.md
+++ b/docs/reporting-services/report-server/register-a-service-principal-name-spn-for-a-report-server.md
@@ -22,7 +22,7 @@ manager: "kfile"
   If you are deploying [!INCLUDE[ssRSnoversion](../../includes/ssrsnoversion-md.md)] in a network that uses the Kerberos protocol for mutual authentication, you must create a Service Principal Name (SPN) for the Report Server service if you configure it to run as a domain user account.  
   
 ## About SPNs  
- An SPN is a unique identifier for a service on a network that uses Kerberos authentication. It consists of a service class, a host name, and a port. On a network that uses Kerberos authentication, an SPN for the server must be registered under either a built-in computer account (such as NetworkService or LocalSystem) or user account. SPNs are registered for built-in accounts automatically. However, when you run a service under a domain user account, you must manually register the SPN for the account you want to use.  
+ An SPN is a unique identifier for a service on a network that uses Kerberos authentication. It consists of a service class, a host name, and sometimes a port. HTTP SPNs do not require a port. On a network that uses Kerberos authentication, an SPN for the server must be registered under either a built-in computer account (such as NetworkService or LocalSystem) or user account. SPNs are registered for built-in accounts automatically. However, when you run a service under a domain user account, you must manually register the SPN for the account you want to use.  
   
  To create an SPN, you can use the **SetSPN** command line utility. For more information, see the following:  
   
@@ -36,14 +36,14 @@ manager: "kfile"
  The command syntax for using SetSPN utility to create an SPN for the report server resembles the following:  
   
 ```  
-Setspn -s http/<computername>.<domainname>:<port> <domain-user-account>  
+Setspn -s http/<computername>.<domainname> <domain-user-account>  
 ```  
   
  **SetSPN** is available with Windows Server. The **-s** argument adds a SPN after validating no duplicate exists. **NOTE:-s** is available in Windows Server starting with Windows Server 2008.  
   
  **HTTP** is the service class. The Report Server Web service runs in HTTP.SYS. A by-product of creating an SPN for HTTP is that all Web applications on the same computer that run in HTTP.SYS (including applications hosted in IIS) will be granted tickets based on the domain user account. If those services run under a different account, the authentication requests will fail. To avoid this problem, be sure to configure all HTTP applications to run under the same account, or consider creating host headers for each application and then creating separate SPNs for each host header. When you configure host headers, DNS changes are required regardless of the [!INCLUDE[ssRSnoversion](../../includes/ssrsnoversion-md.md)] configuration.  
   
- The values that you specify for \<*computername*>, \<*domainname*>, and \<*port*> identify the unique network address of the computer that hosts the report server. This can be a local host name or a fully qualified domain name (FQDN). If you only have one domain and are using port 80, you can omit \<*domainname*> and \<*port*> from your command line. \<*domain-user-account*> is the user account under which the Report Server service runs and for which the SPN must be registered.  
+ The values that you specify for \<*computername*> and \<*domainname*> identify the unique network address of the computer that hosts the report server. This can be a local host name or a fully qualified domain name (FQDN). If you only have one domain, you can omit \<*domainname*> from your command line. \<*domain-user-account*> is the user account under which the Report Server service runs and for which the SPN must be registered.  
   
 ## Register an SPN for Domain User Account  
   
@@ -58,16 +58,16 @@ Setspn -s http/<computername>.<domainname>:<port> <domain-user-account>
 4.  Copy the following command, replacing placeholder values with actual values that are valid for your network:  
   
     ```  
-    Setspn -s http/<computer-name>.<domain-name>:<port> <domain-user-account>  
+    Setspn -s http/<computer-name>.<domain-name> <domain-user-account>  
     ```  
   
-     For example: `Setspn -s http/MyReportServer.MyDomain.com:80 MyDomainUser`  
+     For example: `Setspn -s http/MyReportServer.MyDomain.com MyDomainUser`  
   
 5.  Run the command.  
   
 6.  Open the **RsReportServer.config** file and locate the `<AuthenticationTypes>` section.  
   
-7.  Add `<RSWindowsNegotiate/>` as the first entry in this section to enable NTLM.  
+7.  Add `<RSWindowsNegotiate/>` as the first entry in this section to enable Kerberos.  
   
 ## See Also  
  [Configure a Service Account &#40;SSRS Configuration Manager&#41;](http://msdn.microsoft.com/library/25000ad5-3f80-4210-8331-d4754dc217e0)   


### PR DESCRIPTION
I removed any references to a port requirement for an HTTP SPN. This has been proven to be false, as adding a port to an HTTP SPN would make it unique, and in the case of Reporting Services, it will be ignored. In the Network traces, you can see that the requested SPN is without the port. If the HTTP SPN is added with a port, the error that will come back would be a missing SPN, or go through NTLM as it's not able to find the correct SPN.

I also changed #7 to reflect "Kerberos" instead of "NTLM"