### PR TITLE
fix: md extension on azure absolute link

### DIFF
--- a/docs/integration-services/lift-shift/ssis-azure-lift-shift-ssis-packages-overview.md
+++ b/docs/integration-services/lift-shift/ssis-azure-lift-shift-ssis-packages-overview.md
@@ -79,7 +79,7 @@ For info about how to connect to files and file shares, see [Open and save files
 
 When you provision an instance of SQL Database to host SSISDB, the Azure Feature Pack for SSIS and the Access Redistributable are also installed. These components provide connectivity to various **Azure** data sources and to **Excel and Access** files, in addition to the data sources supported by the built-in components.
 
-You can also install additional components - for example, you can install a driver that's not installed by default. For more info, see [Custom setup for the Azure-SSIS integration runtime](/azure/articles/data-factory/how-to-configure-azure-ssis-ir-custom-setup.md).
+You can also install additional components - for example, you can install a driver that's not installed by default. For more info, see [Custom setup for the Azure-SSIS integration runtime](/azure/articles/data-factory/how-to-configure-azure-ssis-ir-custom-setup).
 
 If you're an ISV, you can update the installation of your licensed components to make them available on Azure. For more info, see [Develop paid or licensed custom components for the Azure-SSIS integration runtime](https://docs.microsoft.com/azure/data-factory/how-to-develop-azure-ssis-ir-licensed-components).
 

--- a/docs/integration-services/load-data-to-sql-data-warehouse.md
+++ b/docs/integration-services/load-data-to-sql-data-warehouse.md
@@ -18,7 +18,7 @@ ms.author: douglasl
 ---
 # Load data from SQL Server to Azure SQL Data Warehouse with SQL Server Integration Services (SSIS)
 
-Create a SQL Server Integration Services (SSIS) package to load data from SQL Server into [Azure SQL Data Warehouse](/azure/sql-data-warehouse/index.md). You can optionally restructure, transform, and cleanse the data as it passes through the SSIS data flow.
+Create a SQL Server Integration Services (SSIS) package to load data from SQL Server into [Azure SQL Data Warehouse](/azure/sql-data-warehouse/index). You can optionally restructure, transform, and cleanse the data as it passes through the SSIS data flow.
 
 In this tutorial, you will:
 


### PR DESCRIPTION
Manual absolute links that have the `.md` extension don't resolve