### PR TITLE
Update deploy-integration-services-ssis-projects-and-packages.md

### DIFF
--- a/docs/integration-services/packages/deploy-integration-services-ssis-projects-and-packages.md
+++ b/docs/integration-services/packages/deploy-integration-services-ssis-projects-and-packages.md
@@ -145,7 +145,7 @@ For more info about the error described in this section and about the permission
   
      -or-  
   
-     From the command prompt, run **isdeploymentwizard.exe** from **%ProgramFiles%\Microsoft SQL Server\110\DTS\Binn**. On 64-bit computers, there is also a 32-bit version of the tool in **%ProgramFiles(x86)%\Microsoft SQL Server\100\DTS\Binn**.  
+     From the command prompt, run **isdeploymentwizard.exe** from **%ProgramFiles%\Microsoft SQL Server\130\DTS\Binn**. On 64-bit computers, there is also a 32-bit version of the tool in **%ProgramFiles(x86)%\Microsoft SQL Server\130\DTS\Binn**.  
   
 2.  On the **Select Source** page, click **Project deployment file** to select the deployment file for the project.  
   


### PR DESCRIPTION
Under,
https://docs.microsoft.com/en-us/sql/integration-services/packages/deploy-integration-services-ssis-projects-and-packages?view=sql-server-2017#deploy

Path for isdeploymentwizard.exe SQL Server 2017 is incorrectly mentioned, as below
"From the command prompt, run isdeploymentwizard.exe from %ProgramFiles%\Microsoft SQL Server\110\DTS\Binn. 
On 64-bit computers, there is also a 32-bit version of the tool in %ProgramFiles(x86)%\Microsoft SQL Server\100\DTS\Binn."

Correcting it to the right path, 
"From the command prompt, run isdeploymentwizard.exe from %ProgramFiles%\Microsoft SQL Server\130\DTS\Binn. 
On 64-bit computers, there is also a 32-bit version of the tool in %ProgramFiles(x86)%\Microsoft SQL Server\130\DTS\Binn."