### PR TITLE
Decryption by Password definition

### DIFF
--- a/docs/t-sql/statements/backup-certificate-transact-sql.md
+++ b/docs/t-sql/statements/backup-certificate-transact-sql.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "BACKUP CERTIFICATE (Transact-SQL) | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/14/2017"

--- a/docs/t-sql/statements/backup-certificate-transact-sql.md
+++ b/docs/t-sql/statements/backup-certificate-transact-sql.md
@@ -78,7 +78,7 @@ BACKUP CERTIFICATE certname TO FILE ='path_to_file'
  Is the password that is used to encrypt the private key before writing the key to the backup file. The password is subject to complexity checks.  
   
  *decryption_password*  
- Is the password that is used to decrypt the private key before backing up the key.  
+ Is the password that is used to decrypt the private key before backing up the key. This is not necessary if the certificate is encrypted by the master key. 
   
 ## Remarks  
  If the private key is encrypted with a password in the database, the decryption password must be specified.  


### PR DESCRIPTION
I believe there should be a callout that this clause is not necessary if the certificate is encrypted by the master key.