### PR TITLE
TOP 10 PERCENT disconnect between code and text

### DIFF
--- a/docs/t-sql/queries/top-transact-sql.md
+++ b/docs/t-sql/queries/top-transact-sql.md
@@ -212,7 +212,7 @@ ORDER BY HireDate DESC;
 ```  
 USE AdventureWorks2012;  
 GO  
-SELECT TOP(10)WITH TIES  
+SELECT TOP(10) PERCENT WITH TIES  
 pp.FirstName, pp.LastName, e.JobTitle, e.Gender, r.Rate  
 FROM Person.Person AS pp   
     INNER JOIN HumanResources.Employee AS e  


### PR DESCRIPTION
There is a disconnect between the text and the code. The example states "The following example obtains the top 10 *percent* of all employees with the highest salary" but the code ommitted the PERCENT