### PR TITLE
Remove the "constant" restriction

### DIFF
--- a/docs/t-sql/functions/ntile-transact-sql.md
+++ b/docs/t-sql/functions/ntile-transact-sql.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "NTILE (Transact-SQL) | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/16/2017"

--- a/docs/t-sql/functions/ntile-transact-sql.md
+++ b/docs/t-sql/functions/ntile-transact-sql.md
@@ -41,7 +41,7 @@ NTILE (integer_expression) OVER ( [ <partition_by_clause> ] < order_by_clause > 
   
 ## Arguments  
  *integer_expression*  
- Is a positive integer constant expression that specifies the number of groups into which each partition must be divided. *integer_expression* can be of type **int**, or **bigint**.  
+ Is a positive integer expression that specifies the number of groups into which each partition must be divided. *integer_expression* can be of type **int**, or **bigint**.  
   
  \<partition_by_clause>  
  Divides the result set produced by the [FROM](../../t-sql/queries/from-transact-sql.md) clause into partitions to which the function is applied. For the PARTITION BY syntax, see [OVER Clause &#40;Transact-SQL&#41;](../../t-sql/queries/select-over-clause-transact-sql.md).  


### PR DESCRIPTION
Since at least SQL Server 2012, `NTILE` supports arbitrary expressions in the argument, not merely constants. If the behavior was different in 2008/2008R2, that should be noted (I have no instances to test with). The only restriction is that the argument cannot refer to columns in the FROM resultset. (It may be worth mentioning that separately in the remarks.)