### PR TITLE
Remove erroneous ':' in SQL date string

### DIFF
--- a/docs/relational-databases/system-catalog-views/sys-event-log-azure-sql-database.md
+++ b/docs/relational-databases/system-catalog-views/sys-event-log-azure-sql-database.md
@@ -131,7 +131,7 @@ start_time                    end_time
   
 ```  
 SELECT * FROM sys.event_log   
-WHERE start_time >= '2011-09-25:12:00:00'   
+WHERE start_time >= '2011-09-25 12:00:00'   
     AND end_time <= '2011-09-28 12:00:00';  
 ```  
   

--- a/docs/relational-databases/system-catalog-views/sys-event-log-azure-sql-database.md
+++ b/docs/relational-databases/system-catalog-views/sys-event-log-azure-sql-database.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "sys.event_log (Azure SQL Database) | Microsoft Docs"
 ms.custom: ""
 ms.date: "06/10/2016"


### PR DESCRIPTION
One of the date strings in the first query example is not well formed due to extra ':'.