### PR TITLE
Added an example of granting the CONTROL permission

### DIFF
--- a/docs/t-sql/statements/grant-database-permissions-transact-sql.md
+++ b/docs/t-sql/statements/grant-database-permissions-transact-sql.md
@@ -243,7 +243,17 @@ USE AdventureWorks2012;
 GRANT CREATE VIEW TO CarmineEs WITH GRANT OPTION;  
 GO  
 ```  
-  
+
+### D. Granting CONTROL permission to a database user.
+ The following example grants `CONTROL` permission on the `AdventureWorks2012` database to the database user `Sarah`. The user must exist in the database and the context must be set to the database.
+ 
+```  
+USE AdventureWorks2012;  
+GRANT CONTROL ON DATABASE:AdventureWorks2012 TO Sarah;  
+GO  
+```  
+
+
 ## See Also  
  [sys.database_permissions &#40;Transact-SQL&#41;](../../relational-databases/system-catalog-views/sys-database-permissions-transact-sql.md)   
  [sys.database_principals &#40;Transact-SQL&#41;](../../relational-databases/system-catalog-views/sys-database-principals-transact-sql.md)   

--- a/docs/t-sql/statements/grant-database-permissions-transact-sql.md
+++ b/docs/t-sql/statements/grant-database-permissions-transact-sql.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "GRANT Database Permissions (Transact-SQL) | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/05/2018"


### PR DESCRIPTION
The CONTROL permission is more complex and requires qualifying the object. Added an example to make this clear.