### PR TITLE
Update sql-server-linux-availability-group-configure-rs.md

### DIFF
--- a/docs/linux/sql-server-linux-availability-group-configure-rs.md
+++ b/docs/linux/sql-server-linux-availability-group-configure-rs.md
@@ -26,7 +26,7 @@ You can configure a SQL Server Always On Availability Group (AG) for read-scale 
 
 ## Create the AG
 
-Create the AG. Set `CLUSTER_TYPE = NONE`. In addition, set each replica with `FAILOVER_MODE = NONE`. Client applications running analytics or reporting workloads can directly connect to the secondary databases. You also can create a read-only routing list. Connections to the primary replica forward read connection requests to each of the secondary replicas from the routing list in a round-robin fashion.
+Create the AG. Set `CLUSTER_TYPE = NONE`. In addition, set each replica with `FAILOVER_MODE = MANUAL`. Client applications running analytics or reporting workloads can directly connect to the secondary databases. You also can create a read-only routing list. Connections to the primary replica forward read connection requests to each of the secondary replicas from the routing list in a round-robin fashion.
 
 The following Transact-SQL script creates an AG named `ag1`. The script configures the AG replicas with `SEEDING_MODE = AUTOMATIC`. This setting causes SQL Server to automatically create the database on each secondary server after it is added to the AG. Update the following script for your environment. Replace the `<node1>` and `<node2>` values with the names of the SQL Server instances that host the replicas. Replace the `<5022>` value with the port you set for the endpoint. Run the following Transact-SQL script on the primary SQL Server replica:
 


### PR DESCRIPTION
For Read-Scale Secondaries there is nothing called FAILOVER_MODE=NONE this can have values of AUTOMATIC , MANUAL , EXTERNAL. Please consult with AG Engineering team before making the changes. i found this typo hence raising this change request.