### PR TITLE
Added cluster autostart command for Ubuntu pacemaker-based Availability Groups

### DIFF
--- a/docs/linux/sql-server-linux-availability-group-cluster-ubuntu.md
+++ b/docs/linux/sql-server-linux-availability-group-cluster-ubuntu.md
@@ -122,6 +122,7 @@ The following command creates a three-node cluster. Before you run the script, r
    sudo pcs cluster auth <node1> <node2> <node3> -u hacluster -p <password for hacluster>
    sudo pcs cluster setup --name <clusterName> <node1> <node2…> <node3>
    sudo pcs cluster start --all
+   sudo pcs cluster enable --all
    ```
    
    >[!NOTE]


### PR DESCRIPTION
Without `sudo pcs cluster enable --all` the cluster won't come back online automatically across restarts and manual intervention is required (in the form of ` sudo pcs cluster start --all`).

I think most DBAs expect the node to rejoin the AG automatically after a restart/failure because that is the Windows Server Failover Cluster behaviour. Adding `sudo pcs cluster enable --all` takes care of that.