### PR TITLE
Remove useless user and login

### DIFF
--- a/docs/includes/ss-linux-cluster-availability-group-create-prereq.md
+++ b/docs/includes/ss-linux-cluster-availability-group-create-prereq.md
@@ -130,7 +130,7 @@ CREATE CERTIFICATE dbm_certificate
 
 Database mirroring endpoints use the Transmission Control Protocol (TCP) to send and receive messages between the server instances that participate in database mirroring sessions or host availability replicas. The database mirroring endpoint listens on a unique TCP port number. 
 
-The following Transact-SQL script creates a listening endpoint named `Hadr_endpoint` for the availability group. It starts the endpoint and gives connection permission to the user that you created. Before you run the script, replace the values between `**< ... >**`. Optionally you can include an IP address `LISTENER_IP = (0.0.0.0)`. The listener IP address must be an IPv4 address. You can also use `0.0.0.0`. 
+The following Transact-SQL script creates a listening endpoint named `Hadr_endpoint` for the availability group. It starts the endpoint and gives connection permission to the certificate that you created. Before you run the script, replace the values between `**< ... >**`. Optionally you can include an IP address `LISTENER_IP = (0.0.0.0)`. The listener IP address must be an IPv4 address. You can also use `0.0.0.0`. 
 
 Update the following Transact-SQL script for your environment on all SQL Server instances: 
 

--- a/docs/includes/ss-linux-cluster-availability-group-create-prereq.md
+++ b/docs/includes/ss-linux-cluster-availability-group-create-prereq.md
@@ -79,15 +79,6 @@ GO
 
 For more information about this XE session, see [AlwaysOn extended events](http://msdn.microsoft.com/library/dn135324.aspx).
 
-## Create a database mirroring endpoint user
-
-The following Transact-SQL script creates a login named `dbm_login` and a user named `dbm_user`. Update the script with a strong password. To create the database mirroring endpoint user, run the following command on all SQL Server instances:
-
-```SQL
-CREATE LOGIN dbm_login WITH PASSWORD = '**<1Sample_Strong_Password!@#>**';
-CREATE USER dbm_user FOR LOGIN dbm_login;
-```
-
 ## Create a certificate
 
 The SQL Server service on Linux uses certificates to authenticate communication between the mirroring endpoints. 
@@ -123,12 +114,11 @@ chown mssql:mssql dbm_certificate.*
 
 ## Create the certificate on secondary servers
 
-The following Transact-SQL script creates a master key and a certificate from the backup that you created on the primary SQL Server replica. The command also authorizes the user to access the certificate. Update the script with strong passwords. The decryption password is the same password that you used to create the .pvk file in a previous step. To create the certificate, run the following script on all secondary servers:
+The following Transact-SQL script creates a master key and a certificate from the backup that you created on the primary SQL Server replica. Update the script with strong passwords. The decryption password is the same password that you used to create the .pvk file in a previous step. To create the certificate, run the following script on all secondary servers:
 
 ```SQL
 CREATE MASTER KEY ENCRYPTION BY PASSWORD = '**<Master_Key_Password>**';
-CREATE CERTIFICATE dbm_certificate   
-    AUTHORIZATION dbm_user
+CREATE CERTIFICATE dbm_certificate
     FROM FILE = '/var/opt/mssql/data/dbm_certificate.cer'
     WITH PRIVATE KEY (
     FILE = '/var/opt/mssql/data/dbm_certificate.pvk',
@@ -153,7 +143,6 @@ CREATE ENDPOINT [Hadr_endpoint]
 		ENCRYPTION = REQUIRED ALGORITHM AES
 		);
 ALTER ENDPOINT [Hadr_endpoint] STATE = STARTED;
-GRANT CONNECT ON ENDPOINT::[Hadr_endpoint] TO [dbm_login];
 ```
 
 >[!NOTE]
@@ -168,7 +157,6 @@ CREATE ENDPOINT [Hadr_endpoint]
 		ENCRYPTION = REQUIRED ALGORITHM AES
 		);
 ALTER ENDPOINT [Hadr_endpoint] STATE = STARTED;
-GRANT CONNECT ON ENDPOINT::[Hadr_endpoint] TO [dbm_login];
 ```
 
 The TCP port on the firewall must be open for the listener port.


### PR DESCRIPTION
This PR removes the useless login and user from the script below. Both login and user are useless as the endpoint authentication is done using the shared certificate.
For a security perspective is best to avoid creating useless principals in a production server (particularly is the the same password is replicated many times). 
Also the script is shorter and cleaner this way.

Tested on `Microsoft SQL Server 2017 (RTM-CU8) (KB4338363) - 14.0.3029.16 (X64)   Jun 13 2018 13:35:56   Copyright (C) 2017 Microsoft Corporation  Developer Edition (64-bit) on Linux (Ubuntu 16.04.4 LTS)`