### PR TITLE
[CU9] SQL Server Agent is disabled if no conf entry

### DIFF
--- a/docs/linux/sql-server-linux-configure-mssql-conf.md
+++ b/docs/linux/sql-server-linux-configure-mssql-conf.md
@@ -54,7 +54,7 @@ ms.assetid: 06798dff-65c7-43e0-9ab3-ffb23374b322
 
 ## <a id="agent"></a> Enable SQL Server Agent
 
-The **sqlagent.enabled** setting enables [SQL Server Agent](sql-server-linux-run-sql-server-agent-job.md). By default, SQL Server Agent is disabled. If **sqlagent.enabled** is not present in the mssql.conf settings file, then SQL Server internally assumes that SQL Server Agent is enabled.
+The **sqlagent.enabled** setting enables [SQL Server Agent](sql-server-linux-run-sql-server-agent-job.md). By default, SQL Server Agent is disabled. If **sqlagent.enabled** is not present in the mssql.conf settings file, then SQL Server internally assumes that SQL Server Agent is disabled.
 
 To change this settings, use the following steps:
 


### PR DESCRIPTION
starting in CU9:

If sqlagent.enabled is not present in the mssql.conf settings file, then SQL Server internally assumes that SQL Server Agent is disabled.