### PR TITLE
Updated endpoint to standard definition

### DIFF
--- a/docs/includes/ss-linux-cluster-availability-group-create-prereq.md
+++ b/docs/includes/ss-linux-cluster-availability-group-create-prereq.md
@@ -137,7 +137,7 @@ Update the following Transact-SQL script for your environment on all SQL Server 
 ```SQL
 CREATE ENDPOINT [Hadr_endpoint]
     AS TCP (LISTENER_PORT = **<5022>**)
-    FOR DATA_MIRRORING (
+    FOR DATABASE_MIRRORING (
 	    ROLE = ALL,
 	    AUTHENTICATION = CERTIFICATE dbm_certificate,
 		ENCRYPTION = REQUIRED ALGORITHM AES
@@ -151,7 +151,7 @@ ALTER ENDPOINT [Hadr_endpoint] STATE = STARTED;
 ```SQL
 CREATE ENDPOINT [Hadr_endpoint]
     AS TCP (LISTENER_PORT = **<5022>**)
-    FOR DATA_MIRRORING (
+    FOR DATABASE_MIRRORING (
 	    ROLE = WITNESS,
 	    AUTHENTICATION = CERTIFICATE dbm_certificate,
 		ENCRYPTION = REQUIRED ALGORITHM AES


### PR DESCRIPTION
Change from "DATA_MIRRORING" to "DATABASE_MIRRORING" to standardize on the same nomenclature that is used in the CREATE ENDPOINT Doc article. While *technically* DATA_MIRRORING works (in on-prem situations) it's not the standard, updating to reflect this.