### PR TITLE
Fixed typo on Data Compression doc

### DIFF
--- a/docs/relational-databases/data-compression/data-compression.md
+++ b/docs/relational-databases/data-compression/data-compression.md
@@ -87,7 +87,7 @@ For columnstore tables and indexes, all columnstore tables and indexes always us
 -   Use **COLUMNSTORE_ARCHIVE** data compression to compress columnstore data with archival compression.  
 -   Use **COLUMNSTORE** data compression to decompress archival compression. The resulting data continue to be compressed with columnstore compression.  
   
-To add archival compression, use [ALTER TABLE &#40;Transact-SQL&#41;](../../t-sql/statements/alter-table-transact-sql.md) or [ALTER INDEX &#40;Transact-SQL&#41;](../../t-sql/statements/alter-index-transact-sql.md) with the REBUILD option and DATA COMPRESSION = COLUMNSTORE.  
+To add archival compression, use [ALTER TABLE &#40;Transact-SQL&#41;](../../t-sql/statements/alter-table-transact-sql.md) or [ALTER INDEX &#40;Transact-SQL&#41;](../../t-sql/statements/alter-index-transact-sql.md) with the REBUILD option and DATA COMPRESSION = COLUMNSTORE_ARCHIVE.  
   
 #### Examples:  
 ```  


### PR DESCRIPTION
Changed the data compression option for adding archival compression. It is correct in the examples, but in the description before the examples it stated `COLUMNSTORE` instead of `COLUMNSTORE_ARCHIVE`.