### PR TITLE
Update best-practice-with-the-query-store.md

### DIFF
--- a/docs/relational-databases/performance/best-practice-with-the-query-store.md
+++ b/docs/relational-databases/performance/best-practice-with-the-query-store.md
@@ -147,7 +147,7 @@ Navigate to the Query Store sub-folder under the database node in Object Explore
   
  When you identify a query with sub-optimal performance, your action depends on the nature of the problem.  
   
--   If the query was executed with multiple plans and the last plan is significantly worse than previous plan, you can use the plan forcing mechanism to force it. [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] SQL SERVER tries to force the plan in the optimizer. If plan forcing fails, a XEvent is fired and the optimizer is instructed to optimize in the normal way. 
+-   If the query was executed with multiple plans and the last plan is significantly worse than previous plan, you can use the plan forcing mechanism to force it. [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] tries to force the plan in the optimizer. If plan forcing fails, an XEvent is fired and the optimizer is instructed to optimize in the normal way. 
   
      ![query-store-force-plan](../../relational-databases/performance/media/query-store-force-plan.png "query-store-force-plan")  
 

--- a/docs/relational-databases/performance/best-practice-with-the-query-store.md
+++ b/docs/relational-databases/performance/best-practice-with-the-query-store.md
@@ -147,7 +147,7 @@ Navigate to the Query Store sub-folder under the database node in Object Explore
   
  When you identify a query with sub-optimal performance, your action depends on the nature of the problem.  
   
--   If the query was executed with multiple plans and the last plan is significantly worse than previous plan, you can use the plan forcing mechanism to force [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] to always use the optimal plan for future executions.  
+-   If the query was executed with multiple plans and the last plan is significantly worse than previous plan, you can use the plan forcing mechanism to force it. [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] SQL SERVER tries to force the plan in the optimizer. If plan forcing fails, a XEvent is fired and the optimizer is instructed to optimize in the normal way. 
   
      ![query-store-force-plan](../../relational-databases/performance/media/query-store-force-plan.png "query-store-force-plan")  
 


### PR DESCRIPTION
forcing a plan via sp_query_store_force_plan  is not deterministic. in order to always have the forced plan we need a plan guide. 
 regardless of a forced plan in the query store, if something is changed  (for example the number of rows ) , a new plan is buit.
 this happens very often with huge tables , in attachment an example; the flagged circle is the forced plan, and it is not used.
![forcedplanko](https://user-images.githubusercontent.com/41946901/43584861-e3c964fa-9663-11e8-8e73-94031741f83d.JPG)
