### PR TITLE
quotename-transact-sql.md - Acceptable single characters

### DIFF
--- a/docs/t-sql/functions/quotename-transact-sql.md
+++ b/docs/t-sql/functions/quotename-transact-sql.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "QUOTENAME (Transact-SQL) | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/14/2017"

--- a/docs/t-sql/functions/quotename-transact-sql.md
+++ b/docs/t-sql/functions/quotename-transact-sql.md
@@ -45,7 +45,7 @@ QUOTENAME ( 'character_string' [ , 'quote_character' ] )
  Is a string of Unicode character data. *character_string* is **sysname** and is limited to 128 characters. Inputs greater than 128 characters return NULL.  
   
  '*quote_character*'  
- Is a one-character string to use as the delimiter. Can be a single quotation mark ( **'** ), a left or right bracket ( **[]** ), a double quotation mark ( **"** ), a left or right parenthesis ( **()** ), a greater than or less than sign ( **><** ), a left or right brace ( **{}** ) or a backtick ( **\`**). NULL returns if an unacceptable character is supplied. If *quote_character* is not specified, brackets are used.  
+ Is a one-character string to use as the delimiter. Can be a single quotation mark ( **'** ), a left or right bracket ( **[]** ), a double quotation mark ( **"** ), a left or right parenthesis ( **()** ), a greater than or less than sign ( **><** ), a left or right brace ( **{}** ) or a backtick ( **\`** ). NULL returns if an unacceptable character is supplied. If *quote_character* is not specified, brackets are used.  
   
 ## Return Types  
  **nvarchar(258)**  

--- a/docs/t-sql/functions/quotename-transact-sql.md
+++ b/docs/t-sql/functions/quotename-transact-sql.md
@@ -45,7 +45,7 @@ QUOTENAME ( 'character_string' [ , 'quote_character' ] )
  Is a string of Unicode character data. *character_string* is **sysname** and is limited to 128 characters. Inputs greater than 128 characters return NULL.  
   
  '*quote_character*'  
- Is a one-character string to use as the delimiter. Can be a single quotation mark ( **'** ), a left or right bracket ( **[]** ), or a double quotation mark ( **"** ). If *quote_character* is not specified, brackets are used.  
+ Is a one-character string to use as the delimiter. Can be a single quotation mark ( **'** ), a left or right bracket ( **[]** ), a double quotation mark ( **"** ), a left or right parenthesis ( **()** ), a greater than or less than sign ( **><** ), a left or right brace ( **{}** ) or a backtick ( **\`**). If an unaccepted character is supplied, NULL will be returned. If *quote_character* is not specified, brackets are used.  
   
 ## Return Types  
  **nvarchar(258)**  

--- a/docs/t-sql/functions/quotename-transact-sql.md
+++ b/docs/t-sql/functions/quotename-transact-sql.md
@@ -45,7 +45,7 @@ QUOTENAME ( 'character_string' [ , 'quote_character' ] )
  Is a string of Unicode character data. *character_string* is **sysname** and is limited to 128 characters. Inputs greater than 128 characters return NULL.  
   
  '*quote_character*'  
- Is a one-character string to use as the delimiter. Can be a single quotation mark ( **'** ), a left or right bracket ( **[]** ), a double quotation mark ( **"** ), a left or right parenthesis ( **()** ), a greater than or less than sign ( **><** ), a left or right brace ( **{}** ) or a backtick ( **\`**). If an unaccepted character is supplied, NULL will be returned. If *quote_character* is not specified, brackets are used.  
+ Is a one-character string to use as the delimiter. Can be a single quotation mark ( **'** ), a left or right bracket ( **[]** ), a double quotation mark ( **"** ), a left or right parenthesis ( **()** ), a greater than or less than sign ( **><** ), a left or right brace ( **{}** ) or a backtick ( **\`**). NULL returns if an unacceptable character is supplied. If *quote_character* is not specified, brackets are used.  
   
 ## Return Types  
  **nvarchar(258)**  


### PR DESCRIPTION
The documentation currently states that only single and double quotes (`'` `&` ") and brackets (`[]`) are accepted. There are several more characters than that that can be passed. Also noted that if an unacceptable character is provided, then NULL will be returned.