### PR TITLE
Update the index function running result

### DIFF
--- a/docs/t-sql/functions/charindex-transact-sql.md
+++ b/docs/t-sql/functions/charindex-transact-sql.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "CHARINDEX (Transact-SQL) | Microsoft Docs"
 ms.custom: ""
 ms.date: "07/24/2017"

--- a/docs/t-sql/functions/charindex-transact-sql.md
+++ b/docs/t-sql/functions/charindex-transact-sql.md
@@ -184,7 +184,7 @@ GO
   
 ```
 -----------
-13
+11
 ```  
   
 ## Examples: [!INCLUDE[ssSDWfull](../../includes/sssdwfull-md.md)] and [!INCLUDE[ssPDW](../../includes/sspdw-md.md)]  


### PR DESCRIPTION
SELECT CHARINDEX ( 'TEST',  
       'This is a Test'  
       COLLATE Latin1_General_CI_AS);  return 11 instead of 13 

Customer Feedback: https://github.com/MicrosoftDocs/feedback/issues/591 