### PR TITLE
Correct copy and pasted query

### DIFF
--- a/docs/relational-databases/backup-restore/disable-sql-server-managed-backup-to-microsoft-azure.md
+++ b/docs/relational-databases/backup-restore/disable-sql-server-managed-backup-to-microsoft-azure.md
@@ -119,7 +119,7 @@ GO
   
     ```  
     EXEC msdb.managed_backup.sp_backup_config_basic  
-                    @database_name = 'TestDB'   
+                    @database_name = NULL   
                     ,@enable_backup = 0;  
     GO  
   

--- a/docs/relational-databases/backup-restore/disable-sql-server-managed-backup-to-microsoft-azure.md
+++ b/docs/relational-databases/backup-restore/disable-sql-server-managed-backup-to-microsoft-azure.md
@@ -119,8 +119,7 @@ GO
   
     ```  
     EXEC msdb.managed_backup.sp_backup_config_basic  
-                    @database_name = NULL   
-                    ,@enable_backup = 0;  
+                    @enable_backup = 0;  
     GO  
   
     ```  


### PR DESCRIPTION
This section of the documentation discussed disabling Managed Backup as a whole, at the Instance Level.  Specifically, the text in this sections paragraph states the need to set the database_name parameter to NULL; however, the SQL Syntax was copy and pasted from above in this document and was not updated to reflect this needed parameter value.  This update is to show this parameter being executed as NULL, as to apply to the whole SQL Instance.