### PR TITLE
IGNORE_DUP_KEY clarification

### DIFF
--- a/docs/t-sql/statements/alter-table-index-option-transact-sql.md
+++ b/docs/t-sql/statements/alter-table-index-option-transact-sql.md
@@ -84,7 +84,7 @@ manager: craigg
 >  Fill factor values 0 and 100 are identical in all respects.  
   
  IGNORE_DUP_KEY **=** { ON | **OFF** }  
- Specifies the error response when an insert operation attempts to insert duplicate key values into a unique index. The IGNORE_DUP_KEY option applies only to insert operations after the index is created or rebuilt. The option has no effect when executing [CREATE INDEX](../../t-sql/statements/create-index-transact-sql.md), [ALTER INDEX](../../t-sql/statements/alter-index-transact-sql.md), or [UPDATE](../../t-sql/queries/update-transact-sql.md). The default is OFF.  
+ Specifies the response type when an insert operation attempts to insert duplicate key values into a unique index. The IGNORE_DUP_KEY option applies only to insert operations after the index is created or rebuilt. The option has no effect when executing [CREATE INDEX](../../t-sql/statements/create-index-transact-sql.md), [ALTER INDEX](../../t-sql/statements/alter-index-transact-sql.md), or [UPDATE](../../t-sql/queries/update-transact-sql.md). The default is OFF.  
   
  ON  
  A warning message occurs when duplicate key values are inserted into a unique index. Only the rows violating the uniqueness constraint fail.  


### PR DESCRIPTION
The original text is confusing implying an error response for this option, even if the next paragraphs for ON/OFF options are a bit more clear. I think the proposed change better reflects the intent of this option.