### PR TITLE
Fix minor grammar issues

### DIFF
--- a/docs/connect/ado-net/step-4-connect-resiliently-to-sql-with-ado-net.md
+++ b/docs/connect/ado-net/step-4-connect-resiliently-to-sql-with-ado-net.md
@@ -27,14 +27,14 @@ This topic provides a C# code sample that demonstrates custom retry logic. The r
 Sources of transient faults include:  
   
 - A brief failure of the networking that supports the Internet.  
-- A cloud system might be load balancing its resources at the moment you query sent.  
+- A cloud system might be load balancing its resources at the moment your query was sent.  
   
   
 The ADO.NET classes for connecting to your local Microsoft SQL Server can also connect to Azure SQL Database. However, by themselves the ADO.NET classes cannot provide all the robustness and reliability necessary in production use. Your client program can encounter transient faults from which it should silently and gracefully recover and continue on its own.  
   
 ## Step 1: Identify transient errors  
   
-Your program must distinguish between transient errors versus persistent errors. Transient faults are error conditions that may clear up within a short period of time, such as transient network problems.  An example of a persistent error would be, if your program has a misspelling of the target database name - in this case, the "No such database found" error would persist, and has no chance of clearing up within a short period of time.  
+Your program must distinguish between transient errors versus persistent errors. Transient errors are error conditions that may clear up within a short period of time, such as transient network problems.  An example of a persistent error would be, if your program has a misspelling of the target database name - in this case, the "No such database found" error would persist, and has no chance of clearing up within a short period of time.  
   
 The list of error numbers that are categorized as transient faults is available at at [Error messages for SQL Database client applications](http://docs.microsoft.com/azure/sql-database/sql-database-develop-error-messages/)  
   
@@ -266,7 +266,7 @@ There are a variety of ways you can simulate a transient error to test your retr
   
 The code sample includes:  
   
-- A small second class named **TestSqlException**, which a property named **Number**.  
+- A small second class named **TestSqlException**, with a property named **Number**.  
 - `//throw new TestSqlException(4060);` , which you can uncomment.  
   
 If you uncomment the throw statement, and recompile, the next run of **RetryAdo2.exe** outputs something similar to the following.  
@@ -305,7 +305,7 @@ To prove the code handles persistent errors correctly, rerun the preceding test 
   
 1. Temporarily add 40615 as another error number to **TransientErrorNumbers**, and recompile.  
 2. Set a breakpoint on the line: `new QC.SqlConnectionStringBuilder()`.  
-3. Use the *Edit and Continue* feature to purposely misspell the server name, a couple lines below.  
+3. Use the *Edit and Continue* feature to purposely misspell the server name, a couple of lines below.  
     - Let the program run and come back to your breakpoint.  
     - The error 40615 occurs.  
 4. Fix the misspelling.  


### PR DESCRIPTION
Line 30 -  "your query was sent" rather than "you query sent"
Line 37 - Off topic sub headings, "Your program must distinguish between 'transient errors' versus 'persistent errors.'  The paragraph is discussing   these two topics but the start of the next sentence refers back to a previous topic not the sub topic, - Transient faults. Optionally to avoid double wording to change to "Transient errors are fault conditions..."
Line 269 - Wrong word used - which rather than with