### PR TITLE
Add Backup troubleshooting for VLDBs / 1117 I/O

### DIFF
--- a/docs/relational-databases/backup-restore/sql-server-backup-to-url-best-practices-and-troubleshooting.md
+++ b/docs/relational-databases/backup-restore/sql-server-backup-to-url-best-practices-and-troubleshooting.md
@@ -87,6 +87,22 @@ manager: craigg
         -   **VERIFYONLY**  
   
     -   You can also find information by reviewing the Windows Event Log - Under Application logs with the name `SQLBackupToUrl`.  
+
+-   Consider COMPRESSION, MAXTRANSFERSIZE and BLOCKSIZE and multiple URL arguments when backing up large databases.  See [Backing up a VLDB to Azure Blob Storage](https://blogs.msdn.microsoft.com/sqlcat/2017/03/10/backing-up-a-vldb-to-azure-blob-storage/)
+
+    -   `Msg 3202, Level 16, State 1, Line 1
+Write on "https://mystorage.blob.core.windows.net/mycontainer/TestDbBackupSetNumber2_0.bak" failed: 1117(The request could not be performed because of an I/O device error.)
+Msg 3013, Level 16, State 1, Line 1
+BACKUP DATABASE is terminating abnormally.`  
+  
+    ```sql  
+    BACKUP DATABASE TestDb
+    TO URL = 'https://mystorage.blob.core.windows.net/mycontainer/TestDbBackupSetNumber2_0.bak',
+    URL = 'https://mystorage.blob.core.windows.net/mycontainer/TestDbBackupSetNumber2_1.bak',
+    URL = 'https://mystorage.blob.core.windows.net/mycontainer/TestDbBackupSetNumber2_2.bak'
+    WITH COMPRESSION, MAXTRANSFERSIZE = 4194304, BLOCKSIZE = 65536;  
+    ```  
+  
   
 -   When restoring from a compressed backup, you might see the following error:  
   

--- a/docs/relational-databases/backup-restore/sql-server-backup-to-url-best-practices-and-troubleshooting.md
+++ b/docs/relational-databases/backup-restore/sql-server-backup-to-url-best-practices-and-troubleshooting.md
@@ -24,7 +24,7 @@ manager: craigg
   
 -   [SQL Server Backup and Restore with Microsoft Azure Blob Storage Service](../../relational-databases/backup-restore/sql-server-backup-and-restore-with-microsoft-azure-blob-storage-service.md)  
   
--   [Tutorial: SQL Server Backup and Restore to Windows Azure Blob Storage Service](~/relational-databases/tutorial-sql-server-backup-and-restore-to-azure-blob-storage-service.md)  
+-   [Tutorial: SQL Server Backup and Restore to Windows Azure Blob Storage Service](../../relational-databases/tutorial-sql-server-backup-and-restore-to-azure-blob-storage-service.md)  
   
 ## Managing Backups  
  The following list includes general recommendations to manage backups:  
@@ -90,19 +90,21 @@ manager: craigg
 
     -   Consider COMPRESSION, MAXTRANSFERSIZE, BLOCKSIZE and multiple URL arguments when backing up large databases.  See [Backing up a VLDB to Azure Blob Storage](https://blogs.msdn.microsoft.com/sqlcat/2017/03/10/backing-up-a-vldb-to-azure-blob-storage/)
   
-```
-Msg 3202, Level 16, State 1, Line 1
-Write on "https://mystorage.blob.core.windows.net/mycontainer/TestDbBackupSetNumber2_0.bak" failed: 1117(The request could not be performed because of an I/O device error.)
-Msg 3013, Level 16, State 1, Line 1
-BACKUP DATABASE is terminating abnormally.
-```
-    ```sql  
-    BACKUP DATABASE TestDb
-    TO URL = 'https://mystorage.blob.core.windows.net/mycontainer/TestDbBackupSetNumber2_0.bak',
-    URL = 'https://mystorage.blob.core.windows.net/mycontainer/TestDbBackupSetNumber2_1.bak',
-    URL = 'https://mystorage.blob.core.windows.net/mycontainer/TestDbBackupSetNumber2_2.bak'
-    WITH COMPRESSION, MAXTRANSFERSIZE = 4194304, BLOCKSIZE = 65536;  
-    ```  
+		```
+		Msg 3202, Level 16, State 1, Line 1
+		Write on "https://mystorage.blob.core.windows.net/mycontainer/TestDbBackupSetNumber2_0.bak" failed: 1117(The request could not be performed because of an I/O device error.)
+		Msg 3013, Level 16, State 1, Line 1
+		BACKUP DATABASE is terminating abnormally.
+		```
+
+        ```sql  
+        BACKUP DATABASE TestDb
+        TO URL = 'https://mystorage.blob.core.windows.net/mycontainer/TestDbBackupSetNumber2_0.bak',
+        URL = 'https://mystorage.blob.core.windows.net/mycontainer/TestDbBackupSetNumber2_1.bak',
+        URL = 'https://mystorage.blob.core.windows.net/mycontainer/TestDbBackupSetNumber2_2.bak'
+        WITH COMPRESSION, MAXTRANSFERSIZE = 4194304, BLOCKSIZE = 65536;  
+        ```  
+
 -   When restoring from a compressed backup, you might see the following error:  
   
     -   `SqlException 3284 occurred. Severity: 16 State: 5  

--- a/docs/relational-databases/backup-restore/sql-server-backup-to-url-best-practices-and-troubleshooting.md
+++ b/docs/relational-databases/backup-restore/sql-server-backup-to-url-best-practices-and-troubleshooting.md
@@ -88,13 +88,14 @@ manager: craigg
   
     -   You can also find information by reviewing the Windows Event Log - Under Application logs with the name `SQLBackupToUrl`.  
 
--   Consider COMPRESSION, MAXTRANSFERSIZE and BLOCKSIZE and multiple URL arguments when backing up large databases.  See [Backing up a VLDB to Azure Blob Storage](https://blogs.msdn.microsoft.com/sqlcat/2017/03/10/backing-up-a-vldb-to-azure-blob-storage/)
-
-    -   `Msg 3202, Level 16, State 1, Line 1
+    -   Consider COMPRESSION, MAXTRANSFERSIZE, BLOCKSIZE and multiple URL arguments when backing up large databases.  See [Backing up a VLDB to Azure Blob Storage](https://blogs.msdn.microsoft.com/sqlcat/2017/03/10/backing-up-a-vldb-to-azure-blob-storage/)
+  
+```
+Msg 3202, Level 16, State 1, Line 1
 Write on "https://mystorage.blob.core.windows.net/mycontainer/TestDbBackupSetNumber2_0.bak" failed: 1117(The request could not be performed because of an I/O device error.)
 Msg 3013, Level 16, State 1, Line 1
-BACKUP DATABASE is terminating abnormally.`  
-  
+BACKUP DATABASE is terminating abnormally.
+```
     ```sql  
     BACKUP DATABASE TestDb
     TO URL = 'https://mystorage.blob.core.windows.net/mycontainer/TestDbBackupSetNumber2_0.bak',
@@ -102,8 +103,6 @@ BACKUP DATABASE is terminating abnormally.`
     URL = 'https://mystorage.blob.core.windows.net/mycontainer/TestDbBackupSetNumber2_2.bak'
     WITH COMPRESSION, MAXTRANSFERSIZE = 4194304, BLOCKSIZE = 65536;  
     ```  
-  
-  
 -   When restoring from a compressed backup, you might see the following error:  
   
     -   `SqlException 3284 occurred. Severity: 16 State: 5  


### PR DESCRIPTION
Add Backup Troubleshooting tip for Large Databases, encountered with error 1117 / I/O Device Error.  Included link to blob for large DB backup.  Verified resolution against encountered 1117 error.