### PR TITLE
Add file shrinks / growths info to FGCB_ADD_REMOVE

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-os-latch-stats-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-os-latch-stats-transact-sql.md
@@ -120,7 +120,7 @@ GO
 |FCB|Used to synchronize access to the file control block.|  
 |FCB_REPLICA|Internal use only.|  
 |FGCB_ALLOC|Use to synchronize access to round robin allocation information within a filegroup.|  
-|FGCB_ADD_REMOVE|Use to synchronize access to filegroups for ADD and DROP file operations.|  
+|FGCB_ADD_REMOVE|Use to synchronize access to filegroups for add, drop, grow, and shrink file operations.|  
 |FILEGROUP_MANAGER|Internal use only.|  
 |FILE_MANAGER|Internal use only.|  
 |FILESTREAM_FCB|Internal use only.|  


### PR DESCRIPTION
The description for the FGCB_ADD_REMOVE latch class only mentions ADD / DROP file operations, but these latch waits also accumulate during growth and shrink operations.  This is mentioned in Paul Randal's latch class library entry: [SQL Server FGCB_ADD_REMOVE Latch](https://www.sqlskills.com/help/latches/fgcb_add_remove/)