### PR TITLE
Update create-an-entity-master-data-services.md

### DIFF
--- a/docs/master-data-services/create-an-entity-master-data-services.md
+++ b/docs/master-data-services/create-an-entity-master-data-services.md
@@ -51,7 +51,9 @@ manager: craigg
      If you do not complete this field, the entity name is used.  
   
     > [!TIP]  
-    >  Use the model name as part of the staging table name, for example *Modelname_Entityname*. This makes the tables easier to find in the database. For more information about the staging tables, see [Overview: Importing Data from Tables &#40;Master Data Services&#41;](../master-data-services/overview-importing-data-from-tables-master-data-services.md).  
+    >  Use the model name as part of the staging table name, for example *Modelname_Entityname*. This makes the tables easier to find in the database. For more information about the staging tables, see [Overview: Importing Data from Tables &#40;Master Data Services&#41;](../master-data-services/overview-importing-data-from-tables-master-data-services.md).
+    > [!TIP]  
+    >  If using the default naming for Staging tables, MDS will automatically append identifiers (e.g. _1, _2) to the staging table names if an entity with same name exists in another Model.
   
 7.  For the **Transaction Log Type** field, choose the transaction log type in the drop-down list.  
   


### PR DESCRIPTION
Added a Tip, which was not specified in documentation earlier. In many cases, the Staging table names are not same as Entity name.
Text Added : 
If using the default naming for Staging tables, MDS will automatically append identifiers (e.g. _1, _2) to the staging table names if an entity with same name exists in another Model.