### PR TITLE
Update datediff-big-transact-sql.md

### DIFF
--- a/docs/t-sql/functions/datediff-big-transact-sql.md
+++ b/docs/t-sql/functions/datediff-big-transact-sql.md
@@ -73,7 +73,7 @@ An expression that can resolve to one of the following values:
 + **smalldatetime**
 + **time**
 
-For *date*, `DATEDIFF_BIG` will accept a column expression, expression, string literal, or user-defined variable. A string literal value must resolve to a **datetime**. Use four-digit years to avoid ambiguity issues. `DATEDIFF_BIG` subtracts *enddate* from *startdate*. To avoid ambiguity, use four-digit years. See [Configure the two digit year cutoff Server Configuration Option](../../database-engine/configure-windows/configure-the-two-digit-year-cutoff-server-configuration-option.md) for information about two-digit years.
+For *date*, `DATEDIFF_BIG` will accept a column expression, expression, string literal, or user-defined variable. A string literal value must resolve to a **datetime**. Use four-digit years to avoid ambiguity issues. `DATEDIFF_BIG` subtracts *startdate* from *enddate*. To avoid ambiguity, use four-digit years. See [Configure the two digit year cutoff Server Configuration Option](../../database-engine/configure-windows/configure-the-two-digit-year-cutoff-server-configuration-option.md) for information about two-digit years.
   
 *enddate*  
 See *startdate*.
@@ -86,7 +86,7 @@ Signed **bigint**
 Returns the count (as a signed bigint value) of the specified datepart boundaries crossed between the specified startdate and enddate.
 -   Each specific *datepart* and the abbreviations for that *datepart* will return the same value.  
   
-For a return value out of range for **bigint** (-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807), `DATEDIFF_BIG` returns an error. For **millisecond**, the maximum difference between *startdate* and *enddate* is 24 days, 20 hours, 31 minutes and 23.647 seconds. For **second**, the maximum difference is 68 years.
+For a return value out of range for **bigint** (-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807), `DATEDIFF_BIG` returns an error. For **millisecond**, the maximum difference between *enddate* and *startdate* is 24 days, 20 hours, 31 minutes and 23.647 seconds. For **second**, the maximum difference is 68 years.
   
 If *startdate* and *enddate* are both assigned only a time value, and the *datepart* is not a time *datepart*, `DATEDIFF_BIG` returns 0.
   


### PR DESCRIPTION
Actually DATEDIFF_BIG subtracts startdate from end date. Please see the example 
```sql
/*
DATEDIFF_BIG ( datepart , startdate , enddate )  
Original wording : subtracts enddate from startdate
Correct wording : subtracts startdate from enddate 
*/
SELECT DATEDIFF_BIG(dd,'2018-09-01','2018-09-05')
-- Expected result as per original wording: -4
-- Actual result   : 4

```