### PR TITLE
"Default Language" slightly off - Fixing couple of terms

### DIFF
--- a/docs/database-engine/configure-windows/configure-the-default-language-server-configuration-option.md
+++ b/docs/database-engine/configure-windows/configure-the-default-language-server-configuration-option.md
@@ -55,9 +55,9 @@ manager: craigg
   
 1.  In Object Explorer, right-click a server and select **Properties**.  
   
-2.  Click the **General settings** node.  
+2.  Click the **Advanced** tab.  
   
-3.  In the **Default language for users** box, choose the language in which [!INCLUDE[msCoName](../../includes/msconame-md.md)] [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] should display system messages.  
+3.  In the **Default language** box, choose the language in which [!INCLUDE[msCoName](../../includes/msconame-md.md)] [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] should display system messages.  
   
      The default language is English.  
   


### PR DESCRIPTION
Adjusting some terms for the current ones.

To support the changes:
![image](https://user-images.githubusercontent.com/19521315/45310315-d068ac80-b51d-11e8-9ea6-7ef9135b4994.png)
