### PR TITLE
Add See Also-links between LIKE and PATINDEX

### DIFF
--- a/docs/t-sql/functions/patindex-transact-sql.md
+++ b/docs/t-sql/functions/patindex-transact-sql.md
@@ -141,6 +141,7 @@ WHERE DocumentNode = 0x7B40;
 
   
 ## See Also  
+ [LIKE &#40;Transact-SQL&#41;](../../t-sql/language-elements/like-transact-sql.md)   
  [CHARINDEX &#40;Transact-SQL&#41;](../../t-sql/functions/charindex-transact-sql.md)  
  [LEN &#40;Transact-SQL&#41;](../../t-sql/functions/len-transact-sql.md)  
  [Data Types &#40;Transact-SQL&#41;](../../t-sql/data-types/data-types-transact-sql.md)   

--- a/docs/t-sql/language-elements/like-transact-sql.md
+++ b/docs/t-sql/language-elements/like-transact-sql.md
@@ -351,6 +351,7 @@ ORDER by LastName;
 ```  
   
 ## See Also  
+ [PATINDEX &#40;Transact-SQL&#41;](../../t-sql/functions/patindex-transact-sql.md)   
  [Expressions &#40;Transact-SQL&#41;](../../t-sql/language-elements/expressions-transact-sql.md)   
  [Built-in Functions &#40;Transact-SQL&#41;](~/t-sql/functions/functions.md)   
  [SELECT &#40;Transact-SQL&#41;](../../t-sql/queries/select-transact-sql.md)   

--- a/docs/t-sql/language-elements/like-transact-sql.md
+++ b/docs/t-sql/language-elements/like-transact-sql.md
@@ -31,8 +31,8 @@ helpviewer_keywords:
   - "NOT LIKE keyword"
 ms.assetid: 581fb289-29f9-412b-869c-18d33a9e93d5
 caps.latest.revision: 50
-author: "douglaslMS"
-ms.author: "douglasl"
+author: douglaslMS
+ms.author: douglasl
 manager: craigg
 monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-server-2016||=sqlallproducts-allversions||>=sql-server-linux-2017||=azuresqldb-mi-current"
 ---


### PR DESCRIPTION
The text contains references between both and I remember looking for the name of PATINDEX inside LIKE. Adding a See Also-link should be appropriate and lists the relation in an easy to find spot.