### PR TITLE
Added CLR data type limitation

### DIFF
--- a/docs/relational-databases/indexes/create-filtered-indexes.md
+++ b/docs/relational-databases/indexes/create-filtered-indexes.md
@@ -67,7 +67,9 @@ monikerRange: "=azuresqldb-current||>=sql-server-2016||=sqlallproducts-allversio
   
 ###  <a name="Restrictions"></a> Limitations and Restrictions  
   
--   You cannot create a filtered index on a view. However, the query optimizer can benefit from a filtered index defined on a table that is referenced in a view. The query optimizer considers a filtered index for a query that selects from a view if the query results will be correct.  
+-   You cannot create a filtered index on a view. However, the query optimizer can benefit from a filtered index defined on a table that is referenced in a view. The query optimizer considers a filtered index for a query that selects from a view if the query results will be correct.
+
+-   You cannot create a filtered index on a table when the column accessed in the filter expression is of a CLR data type.
   
 -   Filtered indexes have the following advantages over indexed views:  
   


### PR DESCRIPTION
Trying to add a filter expression containing a column of data type hierarchyid to a NONCLUSTERED INDEX yields in the following error message:
Filtered index '...' cannot be created on table '...' because the column '...' in the filter expression is of a CLR data type. Rewrite the filter expression so that it does not include this column.