### PR TITLE
Incorrect info for 2017 support

### DIFF
--- a/docs/relational-databases/polybase/polybase-configuration.md
+++ b/docs/relational-databases/polybase/polybase-configuration.md
@@ -22,7 +22,7 @@ manager: craigg
   
  You must configure SQL Server to connect to  either your Hadoop version or Azure Blob storage using **sp_configure**. PolyBase supports two Hadoop distributions: Hortonworks Data Platform (HDP) and Cloudera Distributed Hadoop (CDH).  For a complete list of supported external data sources, see [PolyBase Connectivity Configuration &#40;Transact-SQL&#41;](../../database-engine/configure-windows/polybase-connectivity-configuration-transact-sql.md).  
 
-Note, PolyBase supports Hadoop encryption zones starting with SQL Server 2016 SP1 CU7 and SQL Server 2017.
+Note, PolyBase supports Hadoop encryption zones starting with SQL Server 2016 SP1 CU7 and SQL Server 2017 CU3.
 
   
 ### Run sp_configure  


### PR DESCRIPTION
Support for Hadoop encryption zones wasn't available in SQL Server 2017 RTM, but was made available in CU3 after the following hotfix was released:
Hotfix 11176915:[Port to SQL17_RTM_QFE-CU] Add Polybase support for SSL-secured Hadoop clusters and Encryption Zones 
Iteration Path SQL Server\Releases\SQL17\CU\CU3