### PR TITLE
Update ss-linux-cluster-pacemaker-create-login.md

### DIFF
--- a/docs/includes/ss-linux-cluster-pacemaker-create-login.md
+++ b/docs/includes/ss-linux-cluster-pacemaker-create-login.md
@@ -8,14 +8,7 @@
    ALTER SERVER ROLE [sysadmin] ADD MEMBER [pacemakerLogin]
    ```
 
-   Alternatively, you can set the permissions at a more granular level. The Pacemaker login requires ALTER, CONTROL, and VIEW DEFINITION PERMISSION for managing the availability group as well as VIEW SERVER STATE for the login to be able to run sp_server_diagnostics. For more information, see [GRANT Availability Group Permissions (Transact-SQL)](http://msdn.microsoft.com/library/hh968934.aspx) and [sp_server_diagnostic permissions](https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-server-diagnostics-transact-sql#permissions).
-
-   The following Transact-SQL grants only the required permission to the Pacemaker login. In the statement below 'ag1' is the name of the availability group that will be added as a cluster resource.
-
-   ```Transact-SQL
-   GRANT ALTER, CONTROL, VIEW DEFINITION ON AVAILABILITY GROUP::ag1 TO pacemakerLogin
-   GRANT VIEW SERVER STATE TO pacemakerLogin
-   ```
+  At the time of availability group creation, the pacemaker user will require ALTER, CONTROL and VIEW DEFINITION permissions on the availability group, after it's created but before any nodes are added to it.
 
 1. **On all SQL Servers, save the credentials for the SQL Server login**.
 


### PR DESCRIPTION
The permissions for the pacemaker user in SQL need to be granted as the availability group is being created. At this point in time it is too soon. Working with @MikeRayMSFT.