### PR TITLE
Update replication-with-sql-database-managed-instance.md

### DIFF
--- a/docs/relational-databases/replication/replication-with-sql-database-managed-instance.md
+++ b/docs/relational-databases/replication/replication-with-sql-database-managed-instance.md
@@ -109,7 +109,7 @@ Supports:
 
    Replace `\\<STORAGE_ACCOUNT>.file.core.windows.net\<SHARE>` with the value for your storage account. 
 
-   Replace `<STORAGE_CONNECTION_STRING>` with the value for your access keys.
+   Replace `<STORAGE_CONNECTION_STRING>` with connection string from access keys tab of Microsoft Azure storage account.
 
    After you update the following query, run it. 
 


### PR DESCRIPTION
We need to address documentation discrepancy,  leading to misconfiguration, when customers using Access Key instead of Connection String.