### PR TITLE
Adding info about scale-out group

### DIFF
--- a/docs/relational-databases/polybase/polybase-configuration.md
+++ b/docs/relational-databases/polybase/polybase-configuration.md
@@ -22,7 +22,7 @@ manager: craigg
   
  You must configure SQL Server to connect to  either your Hadoop version or Azure Blob storage using **sp_configure**. PolyBase supports two Hadoop distributions: Hortonworks Data Platform (HDP) and Cloudera Distributed Hadoop (CDH).  For a complete list of supported external data sources, see [PolyBase Connectivity Configuration &#40;Transact-SQL&#41;](../../database-engine/configure-windows/polybase-connectivity-configuration-transact-sql.md).  
 
-Note, PolyBase supports Hadoop encryption zones starting with SQL Server 2016 SP1 CU7 and SQL Server 2017 CU3.
+Note, PolyBase supports Hadoop encryption zones starting with SQL Server 2016 SP1 CU7 and SQL Server 2017 CU3. If you are using [PolyBase scale-out groups;](../polybase-scale-out-groups.md), all compute nodes must also be on a build that includes support for Haddop encryption zones.
 
   
 ### Run sp_configure  


### PR DESCRIPTION
Added info that compute nodes must also be on build that supports Hadoop encryption zones