### PR TITLE
Updated sys-dm-os-wait-stats-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-os-wait-stats-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-os-wait-stats-transact-sql.md
@@ -136,7 +136,13 @@ This command resets all counters to 0.
 |BROKER_TRANSMISSION_OBJECT |TBD <br /> **Applies to**: [!INCLUDE[ssSQL12](../../includes/sssql11-md.md)] through [!INCLUDE[ssCurrent](../../includes/sscurrent-md.md)].| 
 |BROKER_TRANSMISSION_TABLE |TBD <br /> **Applies to**: [!INCLUDE[ssSQL12](../../includes/sssql11-md.md)] through [!INCLUDE[ssCurrent](../../includes/sscurrent-md.md)].| 
 |BROKER_TRANSMISSION_WORK |TBD <br /> **Applies to**: [!INCLUDE[ssSQL12](../../includes/sssql11-md.md)] through [!INCLUDE[ssCurrent](../../includes/sscurrent-md.md)].| 
-|BROKER_TRANSMITTER |Occurs when the Service Broker transmitter is waiting for work.| 
+|BROKER_TRANSMITTER |Occurs when the Service Broker transmitter is waiting for work. Service Broker has a component known as the Transmitter which schedules messages from multiple dialogs to be sent across the wire over one or more connection endpoints. The transmitter has 2 dedicated threads for this purpose.
+
+
+This wait type is charged when these transmitter threads are waiting for dialog messages to be sent using the transport connections.
+
+
+High values of waiting_tasks_count for this wait type point to intermittent work for these transmitter threads and are not indications of any performance problem. If service broker is not used at all, waiting_tasks_count should be 2 (for the 2 transmitter threads) and wait_time_ms should be twice the duration since instance startup. See <https://blogs.msdn.microsoft.com/sql_service_broker/2008/12/01/service-broker-wait-types/>| 
 |BUILTIN_HASHKEY_MUTEX |May occur after startup of instance, while internal data structures are initializing. Will not recur once data structures have initialized.| 
 |CHANGE_TRACKING_WAITFORCHANGES |TBD <br /> **Applies to**: [!INCLUDE[ssSQL12](../../includes/sssql11-md.md)] through [!INCLUDE[ssCurrent](../../includes/sscurrent-md.md)].| 
 |CHECK_PRINT_RECORD |Identified for informational purposes only. Not supported. Future compatibility is not guaranteed.| 


### PR DESCRIPTION
Added in more of a description from the old SQL Server Service Broker Team for BROKER_TRANSMITTER. This is more intuitive than the current description.