### PR TITLE
Corrected grammar

### DIFF
--- a/docs/t-sql/data-types/bit-transact-sql.md
+++ b/docs/t-sql/data-types/bit-transact-sql.md
@@ -29,7 +29,7 @@ monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-s
   An integer data type that can take a value of 1, 0, or NULL.  
   
 ## Remarks  
-The [!INCLUDE[ssDEnoversion](../../includes/ssdenoversion-md.md)] optimizes storage of **bit** columns. If there are 8 or less **bit** columns in a table, the columns are stored as 1 byte. If there are from 9 up to 16 **bit** columns, the columns are stored as 2 bytes, and so on.
+The [!INCLUDE[ssDEnoversion](../../includes/ssdenoversion-md.md)] optimizes storage of **bit** columns. If there are 8 or fewer **bit** columns in a table, the columns are stored as 1 byte. If there are from 9 up to 16 **bit** columns, the columns are stored as 2 bytes, and so on.
   
 The string values TRUE and FALSE can be converted to **bit** values: TRUE is converted to 1 and FALSE is converted to 0.
   


### PR DESCRIPTION
"8 or less bit columns" is incorrect. It should read "8 or fewer bit columns" since column is a count noun, not a mass noun.