### PR TITLE
Corrected query

### DIFF
--- a/docs/relational-databases/indexes/columnstore-indexes-data-loading-guidance.md
+++ b/docs/relational-databases/indexes/columnstore-indexes-data-loading-guidance.md
@@ -62,7 +62,7 @@ These scenarios describe when loaded rows go directly to the columnstore or when
   
 ```sql  
 SELECT object_id, index_id, partition_number, row_group_id, delta_store_hobt_id, 
-  state state_desc, total_rows, deleted_rows, size_in_bytes   
+  state, state_desc, total_rows, deleted_rows, size_in_bytes   
 FROM sys.dm_db_column_store_row_group_physical_stats  
 ```  
   


### PR DESCRIPTION
Added comma between state and state_desc so that the state_desc column value is returned instead of being interpreted as an alias for the preceding state column.