### PR TITLE
Updating blog url for SSISDB on AG

### DIFF
--- a/docs/integration-services/catalog/ssis-catalog.md
+++ b/docs/integration-services/catalog/ssis-catalog.md
@@ -597,7 +597,7 @@ Do the following prerequisite steps before enabling Always On support for the SS
 > -   You must enable **SSIS support for Always On** *after* you add SSISDB to an Always On Availability Group.  
 
 > [!NOTE]
-> For more info about this procedure, see the following walkthrough with additional screen shots by SQL Server MVP Marcos Freccia: [Adding SSISDB to AG for SQL Server 2016](https://marcosfreccia.wordpress.com/2017/04/28/adding-ssisdb-to-ag-for-sql-server-2016/).
+> For more info about this procedure, see the following walkthrough with additional screen shots by Data Platform MVP Marcos Freccia: [Adding SSISDB to AG for SQL Server 2016](https://marcosfreccia.com/2017/04/28/adding-ssisdb-to-ag-for-sql-server-2016/).
 
 ####  <a name="Step1"></a> Step 1: Create Integration Services Catalog  
   


### PR DESCRIPTION
Updated Blog URL for SSISDB on AG, to reflect domain changing.
Updated from SQL Server MVP to Data Platform MVP