### PR TITLE
Create Linked Servers after adding a replica

### DIFF
--- a/docs/relational-databases/replication/configure-distribution-availability-group.md
+++ b/docs/relational-databases/replication/configure-distribution-availability-group.md
@@ -187,13 +187,15 @@ This example adds a new distributor to an existing replication configuration wit
    sp_adddistributiondb 'distribution'
    ```
 
-1. On DIST3, run: 
+4. On DIST3, run: 
 
    ```sql
    sp_adddistpublisher @publisher= 'PUB', @distribution_db= 'distribution', @working_directory= '<network path>'
    ```
 
    The value of `@working_directory` should be the same as what was specified for DIST1 and DIST2.
+
+4. On DIST3, you must recreate Linked Servers to the subscribers.
 
 ## Remove a replica from distribution database AG
 


### PR DESCRIPTION
After adding a replica to distribution database AG, we must also create linked servers to all subscribers to avoid Agent message code 20053. Server 'YYY' is not registered at server 'XXX'.