### PR TITLE
Update availability-group-lease-healthcheck-timeout.md

### DIFF
--- a/docs/database-engine/availability-groups/windows/availability-group-lease-healthcheck-timeout.md
+++ b/docs/database-engine/availability-groups/windows/availability-group-lease-healthcheck-timeout.md
@@ -145,7 +145,7 @@ ALTER AVAILABILITY GROUP AG1 SET (HEALTH_CHECK_TIMEOUT =60000);
 
   - SameSubnetThreshold \<= CrossSubnetThreshold 
 
-  - SameSubnetDelay \<= SameSubnetDelay 
+  - SameSubnetDelay \<= CrossSubnetDelay 
 
 ## See Also    
 


### PR DESCRIPTION
There was an error in which the cluster network thresholds were incorrectly listed.