### PR TITLE
Minor improvement in README file

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -12,7 +12,7 @@ You've found the GitHub repository that houses the source for the SQL Server tec
 Anyone can submit changes to the SQL Server documentation. For more information, see [How to contribute to SQL Server Documentation](https://aka.ms/editsqldocs).
 
 ### Minor corrections
-Minor corrections or clarifications you submit for documentation and code examples in this repo are covered by the [docs.microsoft.com Terms of Use](https://docs.microsoft.com/legal/termsofuse).
+Minor corrections or clarifications you submit for documentation and code examples in this repo are covered by the [docs.microsoft.com - Terms of Use](https://docs.microsoft.com/legal/termsofuse).
 
 ### Larger submissions
 If you submit a pull request with significant changes to documentation and code examples or new content, we'll send a comment in GitHub asking you to submit an online Contribution License Agreement (CLA) if you are not an employee of Microsoft. We need you to complete the online form before we can accept your pull request.


### PR DESCRIPTION
I think that `docs.microsoft.com - Terms of Use` is more suitable than the current `docs.microsoft.com Terms of Use`.