### PR TITLE
Fixed minor typo on Line 135

### DIFF
--- a/docs/relational-databases/native-client-odbc-date-time/data-type-support-for-odbc-date-and-time-improvements.md
+++ b/docs/relational-databases/native-client-odbc-date-time/data-type-support-for-odbc-date-and-time-improvements.md
@@ -132,7 +132,7 @@ typedef struct tagSS_TIMESTAMPOFFSET_STRUCT {
 } SQL_SS_TIMESTAMPOFFSET_STRUCT;  
 ```  
   
- If the **timezone_hour** is negative, the **timezone_minute** must be negative or zero. If the **timezone_hour** is positive, the **timezone_minute** must be positive or zero. If the **timezone_hour** is zero, the s**timezone_minute** may have any value in the range -59 through +59.  
+ If the **timezone_hour** is negative, the **timezone_minute** must be negative or zero. If the **timezone_hour** is positive, the **timezone_minute** must be positive or zero. If the **timezone_hour** is zero, the **timezone_minute** may have any value in the range -59 through +59.  
   
 ## See Also  
  [Date and Time Improvements &#40;ODBC&#41;](../../relational-databases/native-client-odbc-date-time/date-and-time-improvements-odbc.md)  


### PR DESCRIPTION
Fixed minor typo on Line 135, there was an extra char `s` before timezone_minute.

### Before
```
If the **timezone_hour** is zero, the s**timezone_minute** may have any value in the range -59 through +59.  
```

### After
```
If the **timezone_hour** is zero, the **timezone_minute** may have any value in the range -59 through +59.  
```