### PR TITLE
Update implementing-lob-columns-in-a-memory-optimized-table.md

### DIFF
--- a/docs/2014/database-engine/implementing-lob-columns-in-a-memory-optimized-table.md
+++ b/docs/2014/database-engine/implementing-lob-columns-in-a-memory-optimized-table.md
@@ -12,7 +12,7 @@ ms.author: sstein
 manager: craigg
 ---
 # Implementing LOB Columns in a Memory-Optimized Table
-  Memory-optimized tables do not have off-row or large object (LOB) storage, and the row size limit is 8060 bytes. Storing large binary or character string values can be done in two ways:  
+  Memory-optimized tables do not have off-row or large object (LOB) storage (this limitation has been removed in SQL Server 2016 and above - see [Supported Data Types for In-Memory OLTP](../relational-databases/in-memory-oltp/supported-data-types-for-in-memory-oltp.md)), and the row size limit is 8060 bytes. Storing large binary or character string values can be done in two ways:  
   
 -   Split the LOB values into multiple rows.  
   


### PR DESCRIPTION
The page does not explicitly indicate anywhere that this is a restriction with the 2014 engine of SQL Server, nor does it indicate that it has been removed. I have added this fact and link to the 2016 web page.