### PR TITLE
typo: Double word "about"

### DIFF
--- a/docs/2014/relational-databases/native-client-ole-db-table-valued-parameters/ole-db-table-valued-parameter-type-support.md
+++ b/docs/2014/relational-databases/native-client-ole-db-table-valued-parameters/ole-db-table-valued-parameter-type-support.md
@@ -51,7 +51,7 @@ CoType RowsetTVP
  For information about OLE DB methods that support table-valued parameters, see [OLE DB Table-Valued Parameter Type Support &#40;Methods&#41;](ole-db-table-valued-parameter-type-support-methods.md).  
   
 ## Properties  
- For infornation about about OLE DB properties that support table-valued parameters, see [OLE DB Table-Valued Parameter Type Support &#40;Properties&#41;](ole-db-table-valued-parameter-type-support-properties.md).  
+ For information about OLE DB properties that support table-valued parameters, see [OLE DB Table-Valued Parameter Type Support &#40;Properties&#41;](ole-db-table-valued-parameter-type-support-properties.md).  
   
 ## See Also  
  [Table-Valued Parameters &#40;OLE DB&#41;](table-valued-parameters-ole-db.md)   

--- a/docs/relational-databases/native-client-ole-db-table-valued-parameters/ole-db-table-valued-parameter-type-support.md
+++ b/docs/relational-databases/native-client-ole-db-table-valued-parameters/ole-db-table-valued-parameter-type-support.md
@@ -56,7 +56,7 @@ CoType RowsetTVP
  For information about OLE DB methods that support table-valued parameters, see [OLE DB Table-Valued Parameter Type Support &#40;Methods&#41;](../../relational-databases/native-client-ole-db-table-valued-parameters/ole-db-table-valued-parameter-type-support-methods.md).  
   
 ## Properties  
- For infornation about about OLE DB properties that support table-valued parameters, see [OLE DB Table-Valued Parameter Type Support &#40;Properties&#41;](../../relational-databases/native-client-ole-db-table-valued-parameters/ole-db-table-valued-parameter-type-support-properties.md).  
+ For information about OLE DB properties that support table-valued parameters, see [OLE DB Table-Valued Parameter Type Support &#40;Properties&#41;](../../relational-databases/native-client-ole-db-table-valued-parameters/ole-db-table-valued-parameter-type-support-properties.md).  
   
 ## See Also  
  [Table-Valued Parameters &#40;OLE DB&#41;](../../relational-databases/native-client-ole-db-table-valued-parameters/table-valued-parameters-ole-db.md)   


### PR DESCRIPTION
Fixed sibling "infornation" -> "information" at the same time