### PR TITLE
When connecting to a primary replica, data for secondaly may not be current

### DIFF
--- a/docs/database-engine/availability-groups/windows/use-the-always-on-dashboard-sql-server-management-studio.md
+++ b/docs/database-engine/availability-groups/windows/use-the-always-on-dashboard-sql-server-management-studio.md
@@ -319,9 +319,9 @@ The **Availability replica** pane displays the following columns:
  Indicates the time when the last log record was redone on the secondary database. This value is hidden by default.  
  
 
-    > [!NOTE]  
-    >  Most data is based on sys.dm_hadr_database_replica_states, so some restriction may apply. 
-    >  For more information, please see [sys.dm_hadr_database_replica_states (Transact-SQL)](../../../relational-databases/system-dynamic-management-views/sys-dm-hadr-database-replica-states-transact-sql.md).
+   > [!NOTE]  
+   >  Most data is based on sys.dm_hadr_database_replica_states, so some restriction may apply. 
+   >  For more information, please see [sys.dm_hadr_database_replica_states (Transact-SQL)](../../../relational-databases/system-dynamic-management-views/sys-dm-hadr-database-replica-states-transact-sql.md).
 
 
 ## Always On Availability Group latency reports

--- a/docs/database-engine/availability-groups/windows/use-the-always-on-dashboard-sql-server-management-studio.md
+++ b/docs/database-engine/availability-groups/windows/use-the-always-on-dashboard-sql-server-management-studio.md
@@ -319,6 +319,11 @@ The **Availability replica** pane displays the following columns:
  Indicates the time when the last log record was redone on the secondary database. This value is hidden by default.  
  
 
+    > [!NOTE]  
+    >  Most data is based on sys.dm_hadr_database_replica_states, so some restriction may apply. 
+    >  For more information, please see [sys.dm_hadr_database_replica_states (Transact-SQL)](../../../relational-databases/system-dynamic-management-views/sys-dm-hadr-database-replica-states-transact-sql.md).
+
+
 ## Always On Availability Group latency reports
 The availability group latency report is a reporting tool built into the availability group dashboard and available in the [SQL Server Management Studio 17.4](../../../ssms/download-sql-server-management-studio-ssms.md) release. This feature provides an easy-to-understand report detailing time spent during various phases of the log transport process. This provides a way to narrow down the potential cause of latency during the synchronization process. 
 


### PR DESCRIPTION
AG Dashboard should indicate same restriction, since the dashboard's information is based on sys.dm_hadr_database_replica_states with following restriction.

Important
Depending on the action and higher-level states, database-state information may be unavailable or out of date. Furthermore, the values have only local relevance. For example, on the primary replica, the value of the last_hardened_lsn column reflects the information about a given secondary database that is currently available to the primary replica, not the actual hardened LSN value that the secondary replica might have currently.