### PR TITLE
Change release note for SSDT 15.8.1

### DIFF
--- a/docs/ssdt/download-sql-server-data-tools-ssdt.md
+++ b/docs/ssdt/download-sql-server-data-tools-ssdt.md
@@ -44,7 +44,6 @@ The installer lists available Visual Studio instances to add the SSDT tools to. 
 > [!IMPORTANT]
 > - Before installing SSDT for Visual Studio 2017 (15.8.1), uninstall *Analysis Services Projects* and *Reporting Services Projects* extensions if they are already installed, and close all VS instances.
 > - When installing SSDT on Windows 10 1803 and choosing to install SSIS, you may meet an unexpected reboot. You can launch the installer again and continue the installation after the reboot.
-> - SSDT 15.8.1 does not currently support Windows 7 SP1, so remain on 15.8.0 if you are using Windows 7 SP1.
 
 
 


### PR DESCRIPTION
SSDT 15.8.1 does support Windows 7 SP1, so remove the comment from release note section.