### PR TITLE
Correct sys.periods table column description

### DIFF
--- a/docs/relational-databases/system-catalog-views/sys-periods-transact-sql.md
+++ b/docs/relational-databases/system-catalog-views/sys-periods-transact-sql.md
@@ -21,9 +21,9 @@ manager: craigg
   
 |Column header|Data type|Description|  
 |-------------------|---------------|-----------------|  
-|period_type|**sysname**|Name of the period|  
-|period_type_desc|**tinyint**|The numeric value representing the type of period:<br /><br /> 1 = system-time period|  
-|object_id|**nvarchar(60)**|The text description of the type of column:<br /><br /> SYSTEM_TIME_PERIOD|  
+|name|**sysname**|Name of the period|  
+|period_type|**tinyint**|The numeric value representing the type of period:<br /><br /> 1 = system-time period|  
+|period_type_desc|**nvarchar(60)**|The text description of the type of column:<br /><br /> SYSTEM_TIME_PERIOD|  
 |object_id|**int**|The id of the table containing the period_type column|  
 |start_column_id|**int**|The id of the column that defines the lower period boundary|  
 |end_column_id|**int**|The id of the column that defines the upper period boundary|  


### PR DESCRIPTION
The column name and description are mismatched and I have corrected this in the pull request.