### PR TITLE
Correcting syntax

### DIFF
--- a/docs/relational-databases/system-stored-procedures/managed-backup-sp-backup-master-switch-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/managed-backup-sp-backup-master-switch-transact-sql.md
@@ -1,5 +1,5 @@
 ---
-title: "managed_backup.sp_ backup_master_switch (Transact-SQL) | Microsoft Docs"
+title: "managed_backup.sp_backup_master_switch (Transact-SQL) | Microsoft Docs"
 ms.custom: ""
 ms.date: "06/10/2016"
 ms.prod: sql
@@ -9,20 +9,20 @@ ms.technology: system-objects
 ms.topic: "language-reference"
 f1_keywords: 
   - "sp_ backup_master_switch"
-  - "smart_admin.sp_ backup_master_switch"
+  - "smart_admin.sp_backup_master_switch"
   - "sp_ backup_master_switch_TSQL"
-  - "smart_admin.sp_ backup_master_switch_TSQL"
+  - "smart_admin.sp_backup_master_switch_TSQL"
 dev_langs: 
   - "TSQL"
 helpviewer_keywords: 
   - "sp_ backup_master_switch"
-  - "smart_admin.sp_ backup_master_switch"
+  - "smart_admin.sp_backup_master_switch"
 ms.assetid: 1ed2b2b2-c897-41cc-bed5-1c6bc47b9dd2
 author: MikeRayMSFT
 ms.author: mikeray
 manager: craigg
 ---
-# managed_backup.sp_ backup_master_switch (Transact-SQL)
+# managed_backup.sp_backup_master_switch (Transact-SQL)
 [!INCLUDE[tsql-appliesto-ss2016-xxxx-xxxx-xxx-md](../../includes/tsql-appliesto-ss2016-xxxx-xxxx-xxx-md.md)]
 
   Pauses or resumes the [!INCLUDE[ss_smartbackup](../../includes/ss-smartbackup-md.md)].  
@@ -37,7 +37,7 @@ manager: craigg
   
 ```sql  
 EXEC managed_backup.sp_backup_master_switch   
-                     [@state = ] { 0 | 1}  
+                     [@new_state = ] { 0 | 1}  
 ```  
   
 ##  <a name="Arguments"></a> Arguments  
@@ -59,7 +59,7 @@ EXEC managed_backup.sp_backup_master_switch
 ```  
 Use msdb;  
 GO  
-EXEC managed_backup.sp_master_switch @state=0;  
+EXEC managed_backup.sp_backup_master_switch @new_state=0;  
 Go  
   
 ```  
@@ -69,7 +69,7 @@ Go
 ```  
 Use msdb;  
 GO  
-EXEC managed_backup.sp_master_switch @state=1;  
+EXEC managed_backup.sp_backup_master_switch @new_state=1;  
 Go  
   
 ```  


### PR DESCRIPTION
For the Syntax section, the @state parameter needs to be @new_state.

For the Example section, the stored procedure was missing the second "backup" for both examples, in addition to the @state issue.
e.g. Original:  EXEC managed_backup.sp_master_switch @state=1;  
Recommended Change: EXEC managed_backup.sp_backup_master_switch @new_state=1; 

Also removed several erroneous spaces throughout the article where "managed_backup.sp_backup_master_switch" is shown as "managed_backup.sp_ backup_master_switch"