### PR TITLE
Minor Change - Removing erroneous space in example

### DIFF
--- a/docs/relational-databases/backup-restore/disable-sql-server-managed-backup-to-microsoft-azure.md
+++ b/docs/relational-databases/backup-restore/disable-sql-server-managed-backup-to-microsoft-azure.md
@@ -151,7 +151,7 @@ Go
 ```  
 Use msdb;  
 Go  
-EXEC managed_backup. sp_backup_master_switch @new_state=1;  
+EXEC managed_backup.sp_backup_master_switch @new_state=1;  
 GO  
   
 ```  


### PR DESCRIPTION
Just removing an erroneous space in the stored procedure example.

Original: EXEC   managed_backup. sp_backup_master_switch @new_state=1;
Purposed: EXEC managed_backup.sp_backup_master_switch @new_state=1;