### PR TITLE
Pull READ_COMMITTED_SNAPSHOT ON out of note

### DIFF
--- a/docs/t-sql/statements/set-transaction-isolation-level-transact-sql.md
+++ b/docs/t-sql/statements/set-transaction-isolation-level-transact-sql.md
@@ -1,7 +1,7 @@
 ---
 title: "SET TRANSACTION ISOLATION LEVEL (Transact-SQL) | Microsoft Docs"
 ms.custom: ""
-ms.date: "12/04/2017"
+ms.date: "10/22/2018"
 ms.prod: sql
 ms.prod_service: "database-engine, sql-database, sql-data-warehouse, pdw"
 ms.reviewer: ""
@@ -66,7 +66,7 @@ SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
   
 -   The READ COMMITTED isolation level with the READ_COMMITTED_SNAPSHOT database option set to ON.  
   
--   The SNAPSHOT isolation level.  
+-   The SNAPSHOT isolation level. For more information about snapshot isolation, see [Snapshot Isolation in SQL Server](https://docs.microsoft.com/dotnet/framework/data/adonet/sql/snapshot-isolation-in-sql-server). 
   
  READ COMMITTED  
  Specifies that statements cannot read data that has been modified but not committed by other transactions. This prevents dirty reads. Data can be changed by other transactions between individual statements within the current transaction, resulting in nonrepeatable reads or phantom data. This option is the [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] default.  

--- a/docs/t-sql/statements/set-transaction-isolation-level-transact-sql.md
+++ b/docs/t-sql/statements/set-transaction-isolation-level-transact-sql.md
@@ -75,10 +75,10 @@ SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
   
 -   If READ_COMMITTED_SNAPSHOT is set to OFF (the default), the [!INCLUDE[ssDE](../../includes/ssde-md.md)] uses shared locks to prevent other transactions from modifying rows while the current transaction is running a read operation. The shared locks also block the statement from reading rows modified by other transactions until the other transaction is completed. The shared lock type determines when it will be released. Row locks are released before the next row is processed. Page locks are released when the next page is read, and table locks are released when the statement finishes.  
   
-    > [!NOTE]  
-    >  If READ_COMMITTED_SNAPSHOT is set to ON, the [!INCLUDE[ssDE](../../includes/ssde-md.md)] uses row versioning to present each statement with a transactionally consistent snapshot of the data as it existed at the start of the statement. Locks are not used to protect the data from updates by other transactions.  
-    >   
-    >  Snapshot isolation supports FILESTREAM data. Under snapshot isolation mode, FILESTREAM data read by any statement in a transaction will be the transactionally consistent version of the data that existed at the start of the transaction.  
+-   If READ_COMMITTED_SNAPSHOT is set to ON, the [!INCLUDE[ssDE](../../includes/ssde-md.md)] uses row versioning to present each statement with a transactionally consistent snapshot of the data as it existed at the start of the statement. Locks are not used to protect the data from updates by other transactions.  
+
+> [!NOTE]  
+>  Snapshot isolation supports FILESTREAM data. Under snapshot isolation mode, FILESTREAM data read by any statement in a transaction will be the transactionally consistent version of the data that existed at the start of the transaction.  
   
  When the READ_COMMITTED_SNAPSHOT database option is ON, you can use the READCOMMITTEDLOCK table hint to request shared locking instead of row versioning for individual statements in transactions running at the READ COMMITTED isolation level.  
   


### PR DESCRIPTION
The "If READ_COMMITTED_SNAPSHOT is set to ON" paragraph appears to have been intended as its own bullet, not a note. This PR fixes that.

Note that this PR does not fix the problem that although the page's markdown renders correctly in GitHub, its indentations render incorrectly on docs.microsoft.com. This is a problem with several pages - any time a paragraph follows a bullet. For this page, the problem first shows for the "READ COMMITTED" section. The section is indented, even though it shouldn't be. The incorrect indenting makes the structure of the page difficult for the reader to follow.