### PR TITLE
Minor grammer fix

### DIFF
--- a/docs/reporting-services/report-server/moving-the-report-server-databases-to-another-computer-ssrs-native-mode.md
+++ b/docs/reporting-services/report-server/moving-the-report-server-databases-to-another-computer-ssrs-native-mode.md
@@ -14,7 +14,7 @@ ms.author: maghan
 
 # Moving the Report Server Databases to Another Computer (SSRS Native Mode)
 
-  You can move the report server databases that are used in an installation [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] [!INCLUDE[ssDE](../../includes/ssde-md.md)] to an instance that is on a different computer. Both the reportserver and reportservertempdb databases must be moved or copied together. A [!INCLUDE[ssRSnoversion](../../includes/ssrsnoversion-md.md)] installation requires both databases; the reportservertempdb database must be related by name to the primary reportserver database you are moving.  
+  You can move the report server databases that are used in an installation of [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] [!INCLUDE[ssDE](../../includes/ssde-md.md)] to an instance that is on a different computer. Both the reportserver and reportservertempdb databases must be moved or copied together. A [!INCLUDE[ssRSnoversion](../../includes/ssrsnoversion-md.md)] installation requires both databases; the reportservertempdb database must be related by name to the primary reportserver database you are moving.  
   
  **[!INCLUDE[applies](../../includes/applies-md.md)]**  [!INCLUDE[ssRSnoversion](../../includes/ssrsnoversion-md.md)] Native mode.  
   


### PR DESCRIPTION
The very first sentence on this page seems to be missing a word.

"... that are used in an installation SQL Server Database Engine..."
versus
"... that are used in an installation of SQL Server Database Engine..."