### PR TITLE
missing "s" in the table name

### DIFF
--- a/docs/relational-databases/polybase/polybase-queries.md
+++ b/docs/relational-databases/polybase/polybase-queries.md
@@ -106,7 +106,7 @@ WITH (
 );  
   
 -- Export data: Move old data to Hadoop while keeping it query-able via an external table.  
-INSERT INTO dbo.FastCustomer2009  
+INSERT INTO dbo.FastCustomers2009  
 SELECT T.* FROM Insured_Customers T1 JOIN CarSensor_Data T2  
 ON (T1.CustomerKey = T2.CustomerKey)  
 WHERE T2.YearMeasured = 2009 and T2.Speed > 40;  


### PR DESCRIPTION
We have the name in plural during create:
CREATE EXTERNAL TABLE [dbo].[FastCustomers2009]
But in the insert statement the name is single
INSERT INTO dbo.FastCustomer2009