### PR TITLE
Fix incorrect "syntax for SQL Server" heading

### DIFF
--- a/docs/t-sql/database-console-commands/dbcc-pdw-showexecutionplan-transact-sql.md
+++ b/docs/t-sql/database-console-commands/dbcc-pdw-showexecutionplan-transact-sql.md
@@ -23,7 +23,7 @@ Once query performance problems are understood for SMP [!INCLUDE[ssNoVersion](..
 ![Topic link icon](../../database-engine/configure-windows/media/topic-link.gif "Topic link icon") [Transact-SQL Syntax Conventions &#40;Transact-SQL&#41;](../../t-sql/language-elements/transact-sql-syntax-conventions-transact-sql.md)
   
 ## Syntax  
-Syntax for SQL Server:
+Syntax for Azure SQL Data Warehouse:
 
 ```sql
 DBCC PDW_SHOWEXECUTIONPLAN ( distribution_id, spid )  


### PR DESCRIPTION
Heading incorrectly says "Syntax for SQL Server" when it should say "Syntax for Azure SQL Data Warehouse". This article does not apply to SQL Server, which is correctly marked with the checkboxes under the main title.