### PR TITLE
Update overview to clarify PowerShell provider changes

### DIFF
--- a/docs/powershell/sql-server-powershell.md
+++ b/docs/powershell/sql-server-powershell.md
@@ -27,9 +27,11 @@ To ship SQL PowerShell updates, we had to change the identity of the SQL PowerSh
 
 **Update your PowerShell scripts if they import the SQLPS module.**
 
-If you have any PowerShell scripts that run `Import-Module -Name SQLPS`, and you want to take advantage of the new provider functionality and new cmdlets, you must change them to `Import-Module -Name SqlServer`. The new module is installed to `%ProgramFiles%\WindowsPowerShell\Modules\SqlServer` folder. Therefore, you do not have to update the $env:PSModulePath variable. If you have scripts that use a third-party or community version of a module named **SqlServer**, use of the Prefix parameter to avoid name collisions. There is no change to the module used by SQL Server Agent. 
+If you have any PowerShell scripts that run `Import-Module -Name SQLPS`, and you want to take advantage of the new provider functionality and new cmdlets, you must change them to `Import-Module -Name SqlServer`. The new module is installed to `%ProgramFiles%\WindowsPowerShell\Modules\SqlServer` folder. Therefore, you do not have to update the $env:PSModulePath variable. If you have scripts that use a third-party or community version of a module named **SqlServer**, use the Prefix parameter to avoid name collisions.
 
-  
+There is no change to the module used by SQL Server Agent. Therefore, job steps of the type PowerShell use the SQLPS module. For more information, see [How to run PowerShell with SQL Server Agent](run-windows-powershell-steps-in-sql-server-agent.md).
+
+
 ## SQL Server PowerShell Components  
 The **SqlServer** module loads two Windows PowerShell snap-ins:  
   


### PR DESCRIPTION
Explicitly state that SQL Server Agent job steps use the SQLPS provider for steps of the PowerShell scripts and fix a grammatical error on line 30.