### PR TITLE
Update dbcc-show-statistics-transact-sql.md

### DIFF
--- a/docs/t-sql/database-console-commands/dbcc-show-statistics-transact-sql.md
+++ b/docs/t-sql/database-console-commands/dbcc-show-statistics-transact-sql.md
@@ -119,7 +119,7 @@ The following table describes the columns returned in the result set when the HI
 |RANGE_ROWS|Estimated number of rows whose column value falls within a histogram step, excluding the upper bound.|  
 |EQ_ROWS|Estimated number of rows whose column value equals the upper bound of the histogram step.|  
 |DISTINCT_RANGE_ROWS|Estimated number of rows with a distinct column value within a histogram step, excluding the upper bound.|  
-|AVG_RANGE_ROWS|Average number of rows with duplicate column values within a histogram step, excluding the upper bound (RANGE_ROWS / DISTINCT_RANGE_ROWS for DISTINCT_RANGE_ROWS > 0).| 
+|AVG_RANGE_ROWS|Average number of rows with duplicate column values within a histogram step (RANGE_ROWS / DISTINCT_RANGE_ROWS excluding the upper bound for DISTINCT_RANGE_ROWS > 0, else 1).| 
   
 ## <a name="Remarks"></a> Remarks 
 

--- a/docs/t-sql/database-console-commands/dbcc-show-statistics-transact-sql.md
+++ b/docs/t-sql/database-console-commands/dbcc-show-statistics-transact-sql.md
@@ -119,7 +119,7 @@ The following table describes the columns returned in the result set when the HI
 |RANGE_ROWS|Estimated number of rows whose column value falls within a histogram step, excluding the upper bound.|  
 |EQ_ROWS|Estimated number of rows whose column value equals the upper bound of the histogram step.|  
 |DISTINCT_RANGE_ROWS|Estimated number of rows with a distinct column value within a histogram step, excluding the upper bound.|  
-|AVG_RANGE_ROWS|Average number of rows with duplicate column values within a histogram step (RANGE_ROWS / DISTINCT_RANGE_ROWS excluding the upper bound for DISTINCT_RANGE_ROWS > 0, else 1).| 
+|AVG_RANGE_ROWS|Average number of rows with duplicate column values within a histogram step, excluding the upper bound. When DISTINCT_RANGE_ROWS is greater than 0, AVG_RANGE_ROWS is calculated by dividing RANGE_ROWS by DISTINCT_RANGE_ROWS. When DISTINCT_RANGE_ROWS is 0, AVG_RANGE_ROWS returns 1 for the histogram step.| 
   
 ## <a name="Remarks"></a> Remarks 
 


### PR DESCRIPTION
the upper bound is excluded only if distinct_range_Rows and range_rows are > 0 , if in the step there is/are only row(s) from the upper bound's value (only 1 distinct value ) the DISTINCT_RANGE_ROWS is 1 not 0. So the upper bound is not always excluded, but the value 1 is set for it.