### PR TITLE
thumbprint breaking change

### DIFF
--- a/docs/relational-databases/security/encryption/setup-steps-for-extensible-key-management-using-the-azure-key-vault.md
+++ b/docs/relational-databases/security/encryption/setup-steps-for-extensible-key-management-using-the-azure-key-vault.md
@@ -237,6 +237,9 @@ SQL Server Version  |Redistributable Install Link
 
 > [!NOTE]  
 >  Versions 1.0.0.440 and older have been replaced and are no longer supported in production environments. Upgrade to version 1.0.1.0 or later by visiting the [Microsoft Download Center](https://www.microsoft.com/download/details.aspx?id=45344) and using the instructions on the [SQL Server Connector Maintenance & Troubleshooting](../../../relational-databases/security/encryption/sql-server-connector-maintenance-troubleshooting.md) page under “Upgrade of SQL Server Connector.”
+
+> [!NOTE]  
+> There is a breaking change in 1.0.5.0 version, in terms of the thumbprint algorithm. You may experience database restore failure after upgrading to 1.0.5.0 version. Please refer KB aritcle [447099](https://support.microsoft.com/en-us/help/4470999/db-backup-problems-to-sql-server-connector-for-azure-1-0-5-0).
   
  ![ekm-connector-install](../../../relational-databases/security/encryption/media/ekm-connector-install.png "ekm-connector-install")  
   


### PR DESCRIPTION
An update was introduced in version 1.0.5.0 of SQL Server Connector for Microsoft Azure Key Vault that changes the way that the program calculates thumbprints. In version 1.0.5.0, this calculation matches the logic that is used by the program engine to support the following migration scenario.
 Because of this change, you may experience problems when you try to restore database backups from version 1.0.4.0 or an earlier version.