### PR TITLE
Update the-memory-optimized-filegroup.md

### DIFF
--- a/docs/relational-databases/in-memory-oltp/the-memory-optimized-filegroup.md
+++ b/docs/relational-databases/in-memory-oltp/the-memory-optimized-filegroup.md
@@ -40,7 +40,7 @@ manager: craigg
   
 The following limitations apply to a memory-optimized filegroup:  
   
--   Once you create a memory-optimized filegroup, you can only remove it by dropping the database. In a production environment, it is unlikely that you will need to remove the memory-optimized filegroup.  
+-   Once you use a memory-optimized filegroup, you can only remove it by dropping the database. In a production environment, it is unlikely that you will need to remove the memory-optimized filegroup.  
   
 -   You cannot drop a non-empty container or move data and delta file pairs to another container in the memory-optimized filegroup.  
   


### PR DESCRIPTION
after creation (before using it) the container and the filegroup can be removed, once used is not possibile.