### PR TITLE
Add example and clarification on audit all users

### DIFF
--- a/docs/t-sql/statements/create-database-audit-specification-transact-sql.md
+++ b/docs/t-sql/statements/create-database-audit-specification-transact-sql.md
@@ -72,7 +72,7 @@ CREATE DATABASE AUDIT SPECIFICATION audit_specification_name
  Is the table, view, or other securable object in the database on which to apply the audit action or audit action group. For more information, see [Securables](../../relational-databases/security/securables.md).  
   
  *principal*  
- Is the name of database principal on which to apply the audit action or audit action group. For more information, see [Principals &#40;Database Engine&#41;](../../relational-databases/security/authentication-access/principals-database-engine.md).  
+ Is the name of database principal on which to apply the audit action or audit action group. To audit all database principals use the database principal `public`. For more information, see [Principals &#40;Database Engine&#41;](../../relational-databases/security/authentication-access/principals-database-engine.md).  
   
  WITH ( STATE = { ON | OFF } )  
  Enables or disables the audit from collecting records for this audit specification.  
@@ -85,8 +85,10 @@ CREATE DATABASE AUDIT SPECIFICATION audit_specification_name
   
  After a database audit specification is created, it can be viewed by principals with the `CONTROL SERVER`, `ALTER ANY DATABASE AUDIT` permissions, or the `sysadmin` account.  
   
-## Examples  
- The following example creates a server audit called `Payrole_Security_Audit` and then a database audit specification called `Payrole_Security_Audit` that audits `SELECT` and `INSERT` statements by the `dbo` user, for the `HumanResources.EmployeePayHistory` table in the `AdventureWorks2012` database.  
+## Examples
+
+### A. Audit SELECT and INSERT on a table for any user 
+ The following example creates a server audit called `Payrole_Security_Audit` and then a database audit specification called `Payrole_Security_Audit` that audits `SELECT` and `INSERT` statements by any user (`public`), for the `HumanResources.EmployeePayHistory` table in the `AdventureWorks2012` database.  
   
 ```  
 USE master ;  
@@ -110,8 +112,39 @@ ADD (SELECT , INSERT
      ON HumanResources.EmployeePayHistory BY dbo )  
 WITH (STATE = ON) ;  
 GO  
-```  
+``` 
+
+### B. Audit any DML (INSERT, UPDATE or DELETE) on ALL tables in the sales schema for a specific database role  
+ The following example creates a server audit called `DataModification_Security_Audit` and then a database audit specification called `Audit_Data_Modification_On_All_Sales_Tables` that audits `INSERT`, `UPDATE` and `DELETE` statements by users in a new role `SalesUK`, for all objects in the `Sales` schema in the `AdventureWorks2012` database.  
   
+```  
+USE master ;  
+GO  
+-- Create the server audit.
+-- Change the path to a path that the SQLServer Service has access to. 
+CREATE SERVER AUDIT DataModification_Security_Audit  
+    TO FILE ( FILEPATH = 
+'C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\DATA' ) ; 
+GO  
+-- Enable the server audit.  
+ALTER SERVER AUDIT DataModification_Security_Audit   
+WITH (STATE = ON) ;  
+GO  
+-- Move to the target database.  
+USE AdventureWorks2012 ;  
+GO  
+CREATE ROLE SalesUK
+GO
+-- Create the database audit specification.  
+CREATE DATABASE AUDIT SPECIFICATION Audit_Data_Modification_On_All_Sales_Tables  
+FOR SERVER AUDIT DataModification_Security_Audit  
+ADD ( INSERT, UPDATE, DELETE  
+     ON Schema::Sales BY SalesUK )  
+WITH (STATE = ON) ;    
+GO  
+```  
+
+
 ## See Also  
  [CREATE SERVER AUDIT &#40;Transact-SQL&#41;](../../t-sql/statements/create-server-audit-transact-sql.md)   
  [ALTER SERVER AUDIT  &#40;Transact-SQL&#41;](../../t-sql/statements/alter-server-audit-transact-sql.md)   

--- a/docs/t-sql/statements/create-database-audit-specification-transact-sql.md
+++ b/docs/t-sql/statements/create-database-audit-specification-transact-sql.md
@@ -87,7 +87,7 @@ CREATE DATABASE AUDIT SPECIFICATION audit_specification_name
   
 ## Examples
 
-### A. Audit SELECT and INSERT on a table for any user 
+### A. Audit SELECT and INSERT on a table for any database principal 
  The following example creates a server audit called `Payrole_Security_Audit` and then a database audit specification called `Payrole_Security_Audit` that audits `SELECT` and `INSERT` statements by any user (`public`), for the `HumanResources.EmployeePayHistory` table in the `AdventureWorks2012` database.  
   
 ```  
@@ -114,8 +114,8 @@ WITH (STATE = ON) ;
 GO  
 ``` 
 
-### B. Audit any DML (INSERT, UPDATE or DELETE) on ALL tables in the sales schema for a specific database role  
- The following example creates a server audit called `DataModification_Security_Audit` and then a database audit specification called `Audit_Data_Modification_On_All_Sales_Tables` that audits `INSERT`, `UPDATE` and `DELETE` statements by users in a new role `SalesUK`, for all objects in the `Sales` schema in the `AdventureWorks2012` database.  
+### B. Audit any DML (INSERT, UPDATE or DELETE) on _all_ objects in the _sales_ schema for a specific database role  
+ The following example creates a server audit called `DataModification_Security_Audit` and then a database audit specification called `Audit_Data_Modification_On_All_Sales_Tables` that audits `INSERT`, `UPDATE` and `DELETE` statements by users in a new database role `SalesUK`, for all objects in the `Sales` schema in the `AdventureWorks2012` database.  
   
 ```  
 USE master ;  


### PR DESCRIPTION
Added a second example showing the options for a schema level audit. Amended the existing example to use public and explain this is used for ALL users.