### PR TITLE
Escaped an angle bracket

### DIFF
--- a/docs/integration-services/lesson-2-1-copying-the-lesson-1-package.md
+++ b/docs/integration-services/lesson-2-1-copying-the-lesson-1-package.md
@@ -33,7 +33,7 @@ In this task, you will create a copy of the Lesson 1.dtsx package that you creat
   
 7.  In the Properties window, update the **Name** property to **Lesson 2**.  
   
-8.  Click the box for the **ID** property, click the dropdown arrow and then click **\<Generate New ID>**.  
+8.  Click the box for the **ID** property, click the dropdown arrow and then click **\<Generate New ID\>**.  
   
 ### To add the completed Lesson 1 package  
   


### PR DESCRIPTION
Without this, the text "<Generate New ID>" is not shown in the docs.