### PR TITLE
Update create-type-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/create-type-transact-sql.md
+++ b/docs/t-sql/statements/create-type-transact-sql.md
@@ -43,7 +43,7 @@ manager: craigg
 ## Syntax  
   
 ```  
--- Disk-Based Type Syntax  
+-- User-defined Data Type Syntax    
 CREATE TYPE [ schema_name. ] type_name  
 {   
     FROM base_type   
@@ -109,7 +109,7 @@ column_name AS computed_column_expression
 ```  
   
 ```  
--- Memory-Optimized Table Type Syntax  
+-- User-defined Table Types Syntax  
 CREATE TYPE [schema_name. ] type_name  
 AS TABLE ( { <column_definition> }  
     |  [ <table_constraint> ] [ ,... n ]    


### PR DESCRIPTION
The comment before the 2 examples appears to be wrong. it's not the case of "disk-based table" vs "memory-optimized table".
the 2 examples show 
1) how to define a user-defined datatype 
2) how to create a table-valued parameter type using the AS TABLE option. in this case you have 
<table_option> ::=  
{  
    [MEMORY_OPTIMIZED = {ON | OFF}]  
}  
Indicates whether the table type is memory optimized. This option is off by default; the table (type) is not a memory optimized table (type). 
So i propose the new comments . Thanks