### PR TITLE
Missing GO statement in example O

### DIFF
--- a/docs/t-sql/statements/create-procedure-transact-sql.md
+++ b/docs/t-sql/statements/create-procedure-transact-sql.md
@@ -981,6 +981,7 @@ BEGIN
     ORDER BY AnnualSales DESC, ResellerName ASC;  
 END  
 ;  
+GO
   
 --Show 10 Top Resellers  
 EXEC Get10TopResellers;  


### PR DESCRIPTION
The example is missing a GO statement after the END of the intended procedure definition.
This causes an infinite loop because the EXEC statement is accidentally included in the procedure body.

This could be indicative of a wider problem with the syntax documentation. It states
CREATE PROCEDURE ... AS { [ BEGIN ] sql_statement [;] [ ...n ] [ END ] }  
which implies that if you put a BEGIN immediately after the AS, any statements after the END will not be in the procedure body.
This isn't the case at all - SQL Server must be considering the BEGIN/END as being within sql_statement instead.

You can do
CREATE PROCEDURE dbo.test2
AS
BEGIN
    SELECT 1
END
;

SELECT 2

GO

EXEC dbo.test2

Will print 1 then 2.