### PR TITLE
Update sys-dm-exec-background-job-queue-stats-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-exec-background-job-queue-stats-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-exec-background-job-queue-stats-transact-sql.md
@@ -75,7 +75,7 @@ GO
 SELECT   
         CASE enqueued_count WHEN 0   
                 THEN 'No jobs posted'   
-                ELSE CAST((enqueue_failed_full_count + enqueue_failed_duplicate_count) / CAST(enqueued_count AS float) * 100 AS varchar(20))   
+                ELSE CAST((enqueue_failed_full_count + enqueue_failed_duplicate_count) / CAST(enqueued_count + enqueue_failed_full_count + enqueue_failed_duplicate_count AS float) * 100 AS varchar(20))   
         END AS [Percent Enqueue Failed]  
 FROM sys.dm_exec_background_job_queue_stats;  
 GO  


### PR DESCRIPTION
if we want to know how many failed attempts we got we must compare the set of "all the attempts".  but  the column "enqueued_count" is not the number of "all the attempts" but "Number of requests successfully posted to the queue", so to me it seems that if we want to calculate the set of "all the attempts" we must sum enqueued_count + enqueue_failed_full_count + enqueue_failed_duplicate_count (Number of requests successfully posted to the queue + Number of failed enqueue attempts because the queue is full + Number of duplicate enqueue attempts ) but actually i'm not sure about "Number of duplicate enqueue attempts" (these are to count or not in the set of all the attempts?). maybe a duplicated event raises only when the queue is full so we must exclude the  "Number of duplicate enqueue attempts"  from the set  "all the attempts".   thank you best regards