### PR TITLE
Update view-the-dependencies-of-a-stored-procedure.md

### DIFF
--- a/docs/relational-databases/stored-procedures/view-the-dependencies-of-a-stored-procedure.md
+++ b/docs/relational-databases/stored-procedures/view-the-dependencies-of-a-stored-procedure.md
@@ -151,7 +151,7 @@ monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-s
     SELECT referenced_schema_name, referenced_entity_name,  
     referenced_minor_name,referenced_minor_id, referenced_class_desc,  
     is_caller_dependent, is_ambiguous  
-    FROM sys.dm_sql_referencing_entities ('Purchasing.uspVendorAllInfo', 'OBJECT');  
+    FROM sys.dm_sql_referenced_entities ('Purchasing.uspVendorAllInfo', 'OBJECT');  
     GO  
     ```  
   


### PR DESCRIPTION
The script, in Step 5 of Using Transact SQL, should be using the function sys.dm_sql_referenced_entities instead of sys.dm_sql_referencing_entities.