### PR TITLE
CHAR / VARCHAR typo

### DIFF
--- a/docs/sql-server/what-s-new-in-sql-server-ver15.md
+++ b/docs/sql-server/what-s-new-in-sql-server-ver15.md
@@ -157,7 +157,7 @@ Full support for the widely used UTF-8 character encoding as an import or export
 
 For example,`LATIN1_GENERAL_100_CI_AS_SC` to `LATIN1_GENERAL_100_CI_AS_SC_UTF8`. UTF-8 is only available to Windows collations that support supplementary characters, as introduced in SQL Server 2012. `NCHAR` and `NVARCHAR` allow UTF-16 encoding only, and remain unchanged.
 
-This feature may provide significant storage savings, depending on the character set in use. For example, changing an existing column data type with Latin strings from `NCHAR(10)` to `CHAR(10)` using an UTF-8 enabled collation, translates into nearly 50% reduction in storage requirements. This reduction is because `NCHAR(10)` requires 22 bytes for storage, whereas `CHAR(10)` requires 12 bytes for the same Unicode string.
+This feature may provide significant storage savings, depending on the character set in use. For example, changing an existing column data type with Latin strings from `NVARCHAR(10)` to `VARCHAR(10)` using an UTF-8 enabled collation, translates into nearly 50% reduction in storage requirements. This reduction is because `NVARCHAR(10)` requires 22 bytes for storage, whereas `VARCHAR(10)` requires 12 bytes for the same Unicode string.
 
 ### Resumable online index create (CTP 2.0)
 


### PR DESCRIPTION
A CHAR(10) takes up 10 bytes but a VARCHAR(10) takes 12 bytes.