### PR TITLE
Update string-split-transact-sql.md

### DIFF
--- a/docs/t-sql/functions/string-split-transact-sql.md
+++ b/docs/t-sql/functions/string-split-transact-sql.md
@@ -61,6 +61,8 @@ STRING_SPLIT ( string , separator )
 |amet.|  
   
 If the input string is **NULL**, the **STRING_SPLIT** table-valued function returns an empty table.  
+
+If the input string is not **NULL**, the **STRING_SPLIT** table-valued function returns a result set in {the order of | no predetermined order} with respect to the delimited substrings as found in the input string
   
 **STRING_SPLIT** requires at least compatibility mode 130.  
   


### PR DESCRIPTION
I added a note in the remarks section discussing the order of the result set, which is not currently specified.  I give two options for the new sentence, depending on whether the function returns the results in order or not as indicated by the options in braces.  At the time of writing I do not know which version is correct but it should be stated one way or the other.