### PR TITLE
Update monitoring-performance-by-using-the-query-store.md

### DIFF
--- a/docs/relational-databases/performance/monitoring-performance-by-using-the-query-store.md
+++ b/docs/relational-databases/performance/monitoring-performance-by-using-the-query-store.md
@@ -554,8 +554,7 @@ OPTION (MERGE JOIN);
   
  You can also identify inconsistent query performance for a query with parameters (either auto- parameterized or manually parameterized). Among different plans you can identify the plan which is fast and optimal enough for all or most of the parameter values and force that plan, keeping predictable performance for the wider set of user scenarios.  
   
- **Force or a plan for a query (apply forcing policy).** When a plan is forced for a certain query, every time a query comes to execution it will be executed with the plan that is forced.  
-  
+ **Force or a plan for a query (apply forcing policy).** When a plan is forced for a certain query, [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] tries to force the plan in the optimizer. If plan forcing fails, an XEvent is fired and the optimizer is instructed to optimize in the normal way. 
 ```sql  
 EXEC sp_query_store_force_plan @query_id = 48, @plan_id = 49;  
 ```  


### PR DESCRIPTION
the same change proposed and accepted in Update best-practice-with-the-query-store.md   , forcing a plan via sp_query_store_force_plan is not deterministic. in order to always have the forced plan we need a plan guide.