### PR TITLE
Fix  bug in the linux doc

### DIFF
--- a/docs/linux/sql-server-linux-encrypted-connections.md
+++ b/docs/linux/sql-server-linux-encrypted-connections.md
@@ -42,7 +42,7 @@ TLS is used to encrypt connections from a client application to [!INCLUDE[ssNoVe
 
         openssl req -x509 -nodes -newkey rsa:2048 -subj '/CN=mssql.contoso.com' -keyout mssql.key -out mssql.pem -days 365 
         sudo chown mssql:mssql mssql.pem mssql.key 
-        sudo chmod 640 mssql.pem mssql.key   
+        sudo chmod 600 mssql.pem mssql.key   
         sudo mv mssql.pem /etc/ssl/certs/ 
         sudo mv mssql.key /etc/ssl/private/ 
 

--- a/docs/linux/sql-server-linux-encrypted-connections.md
+++ b/docs/linux/sql-server-linux-encrypted-connections.md
@@ -100,8 +100,8 @@ TLS is used to encrypt connections from a client application to [!INCLUDE[ssNoVe
 
         systemctl stop mssql-server 
         cat /var/opt/mssql/mssql.conf 
-        sudo /opt/mssql/bin/mssql-conf set network.tlscert /etc/ssl/certs/mssqlfqdn.pem 
-        sudo /opt/mssql/bin/mssql-conf set network.tlskey /etc/ssl/private/mssqlfqdn.key 
+        sudo /opt/mssql/bin/mssql-conf set network.tlscert /etc/ssl/certs/mssql.pem 
+        sudo /opt/mssql/bin/mssql-conf set network.tlskey /etc/ssl/private/mssql.key 
         sudo /opt/mssql/bin/mssql-conf set network.tlsprotocols 1.2 
         sudo /opt/mssql/bin/mssql-conf set network.forceencryption 1 
         

--- a/docs/linux/sql-server-linux-encrypted-connections.md
+++ b/docs/linux/sql-server-linux-encrypted-connections.md
@@ -42,7 +42,7 @@ TLS is used to encrypt connections from a client application to [!INCLUDE[ssNoVe
 
         openssl req -x509 -nodes -newkey rsa:2048 -subj '/CN=mssql.contoso.com' -keyout mssql.key -out mssql.pem -days 365 
         sudo chown mssql:mssql mssql.pem mssql.key 
-        sudo chmod 600 mssql.pem mssql.key   
+        sudo chmod 640 mssql.pem mssql.key   
         sudo mv mssql.pem /etc/ssl/certs/ 
         sudo mv mssql.key /etc/ssl/private/ 
 
@@ -50,8 +50,8 @@ TLS is used to encrypt connections from a client application to [!INCLUDE[ssNoVe
 
         systemctl stop mssql-server 
         cat /var/opt/mssql/mssql.conf 
-        sudo /opt/mssql/bin/mssql-conf set network.tlscert /etc/ssl/certs/mssqlfqdn.pem 
-        sudo /opt/mssql/bin/mssql-conf set network.tlskey /etc/ssl/private/mssqlfqdn.key 
+        sudo /opt/mssql/bin/mssql-conf set network.tlscert /etc/ssl/certs/mssql.pem 
+        sudo /opt/mssql/bin/mssql-conf set network.tlskey /etc/ssl/private/mssql.key 
         sudo /opt/mssql/bin/mssql-conf set network.tlsprotocols 1.2 
         sudo /opt/mssql/bin/mssql-conf set network.forceencryption 0 
 


### PR DESCRIPTION
After I followed the steps in this doc on a Auzre Ubuntu LTS 16, I found the file name mssqlfqdn should be mssql, because obviously it should be same as the file name specified in the previous command, generating these 2 files. 

