### PR TITLE
Update binary-checksum-transact-sql.md

### DIFF
--- a/docs/t-sql/functions/binary-checksum-transact-sql.md
+++ b/docs/t-sql/functions/binary-checksum-transact-sql.md
@@ -71,7 +71,7 @@ or
   
 For example, the strings "McCavity" and "Mccavity" have different BINARY_CHECKSUM values. In contrast, for a case-insensitive server, CHECKSUM returns the same checksum values for those strings. You should avoid comparison of CHECKSUM values with BINARY_CHECKSUM values.
  
-BINARY_CHECKSUM supports up to 8,000 characters of type **varbinary(max)** and up to 255 characters of type **nvarchar(max)**.
+BINARY_CHECKSUM supports any length of type **varbinary(max)** and up to 255 characters of type **nvarchar(max)**.
   
 ## Examples  
 This example uses `BINARY_CHECKSUM` to detect changes in a table row.


### PR DESCRIPTION
There seem to be a breaking change for BINARY_CHECKSUM (and CHECKSUM as well) when working on VARBINARY data.

Now the functions work on blocks of 8,000 bytes and each block is then XORed together.
See this repro

See this repro below.

DECLARE @Data VARCHAR(MAX) = REPLICATE(CAST('abcFED' AS VARCHAR(MAX)), 4500);

SELECT  DATALENGTH(@Data) AS BinaryLength,
        CHECKSUM(@Data) AS Original,
        CHECKSUM(SUBSTRING(@Data, 1, 8000)) ^ CHECKSUM(SUBSTRING(@Data, 8001, 8000)) ^ CHECKSUM(SUBSTRING(@Data, 16001, 8000)) ^ CHECKSUM(SUBSTRING(@Data, 24001, 8000)) AS Replacement,
        CHECKSUM(SUBSTRING(@Data,     1, 8000)) AS Part1,
        CHECKSUM(SUBSTRING(@Data,  8001, 8000)) AS Part2,
        CHECKSUM(SUBSTRING(@Data, 16001, 8000)) AS Part3,
        CHECKSUM(SUBSTRING(@Data, 24001, 8000)) AS Part4;
