### PR TITLE
Update the description of post config step 1

### DIFF
--- a/docs/linux/sql-server-linux-setup-machine-learning.md
+++ b/docs/linux/sql-server-linux-setup-machine-learning.md
@@ -234,7 +234,7 @@ sudo zypper install mssql-server-extensibility-java
 Additional configuration is primarily through the [mssql-conf tool](sql-server-linux-configure-mssql-conf.md).
 
 
-1. Add the mssql user account used to run the SQL Server Launchpad service.
+1. Add the mssql user account used to run the SQL Server service. This is required if you haven't run the setup previously.
 
   ```bash
   sudo /opt/mssql/bin/mssql-conf setup


### PR DESCRIPTION
mssql user account is created so that it can be used to run SQL Server service not the launchpad service. Hence, the correction. Also, this setup step is needed only if the user hasnt run it when they installed SQL Server.