### PR TITLE
removed the warning that CREATE DATABASE must be the only statement i…

### DIFF
--- a/docs/t-sql/statements/create-database-transact-sql.md
+++ b/docs/t-sql/statements/create-database-transact-sql.md
@@ -1073,10 +1073,7 @@ The name of the database that is to be copied.
 Databases in [!INCLUDE[ssSDSfull](../../includes/sssdsfull-md.md)] have several default settings that are set when the database is created. For more information about these default settings, see the list of values in [DATABASEPROPERTYEX](../../t-sql/functions/databasepropertyex-transact-sql.md).  
   
 MAXSIZE provides the ability to limit the size of the database. If the size of the database reaches its MAXSIZE, you receive error code 40544. When this occurs, you cannot insert or update data, or create new objects (such as tables, stored procedures, views, and functions). However, you can still read and delete data, truncate tables, drop tables and indexes, and rebuild indexes. You can then update MAXSIZE to a value larger than your current database size or delete some data to free storage space. There may be as much as a fifteen-minute delay before you can insert new data.  
-  
-> [!IMPORTANT]  
->  The `CREATE DATABASE` statement must be the only statement in a [!INCLUDE[tsql](../../includes/tsql-md.md)] batch. 
-  
+   
 To change the size, edition, or service objective values later, use [ALTER DATABASE &#40;Azure SQL Database&#41;](../../t-sql/statements/alter-database-transact-sql.md?&tabs=sqldbls).  
 
 The CATALOG_COLLATION argument is only available during database creation. 


### PR DESCRIPTION
…n the batch

Removed "The CREATE DATABASE statement must be the only statement in a [!INCLUDEtsql] batch." as this is not the case (at least any more).