### PR TITLE
Fix docker image not available

### DIFF
--- a/docs/linux/tutorial-sql-server-containers-kubernetes.md
+++ b/docs/linux/tutorial-sql-server-containers-kubernetes.md
@@ -168,7 +168,7 @@ In this step, create a manifest to describe the container based on the SQL Serve
          terminationGracePeriodSeconds: 10
          containers:
          - name: mssql
-           image: mcr.microsoft.com/mssql/server/mssql-server-linux
+           image: mcr.microsoft.com/mssql/server
            ports:
            - containerPort: 1433
            env:


### PR DESCRIPTION
Changed `mcr.microsoft.com/mssql/server/mssql-server-linux` to `mcr.microsoft.com/mssql/server` because image is deprecated:
[We are moving to mcr.microsoft.com where you can pull SQL Server 2017 on Linux containers as well as SQL Server 2019 preview containers. SQL Server 2019 preview containers will only be available on mcr.microsoft.com. Overtime we will only publish to mcr.microsoft.com/mssql/server and eventually deprecate microsoft/mssql-server-linux.](https://hub.docker.com/r/microsoft/mssql-server-linux/)