### PR TITLE
TRANSLATE vs REPLACE

### DIFF
--- a/docs/t-sql/functions/translate-transact-sql.md
+++ b/docs/t-sql/functions/translate-transact-sql.md
@@ -52,10 +52,12 @@ The behavior of the `TRANSLATE` function is similar to using multiple [REPLACE](
 SELECT TRANSLATE('abcdef','abc','bcd') AS Translated,
        REPLACE(REPLACE(REPLACE('abcdef','a','b'),'b','c'),'c','d') AS Replaced;
 ```
+
 The results are:
-Translated  |Replaced |  
----------|--------- |
-bcddef |ddddef |
+
+| Translated | Replaced |  
+| ---------|--------- |
+| bcddef | ddddef |
 
 `TRANSLATE` is always SC collation aware.
 

--- a/docs/t-sql/functions/translate-transact-sql.md
+++ b/docs/t-sql/functions/translate-transact-sql.md
@@ -46,7 +46,16 @@ Returns a character expression of the same data type as `inputString` where char
 
 `TRANSLATE` will return an error if *characters* and *translations* expressions have different lengths. `TRANSLATE` will return NULL if any of the arguements are NULL.  
 
-The behavior of the `TRANSLATE` function is equivalent to using multiple [REPLACE](../../t-sql/functions/replace-transact-sql.md) functions.
+The behavior of the `TRANSLATE` function is similar to using multiple [REPLACE](../../t-sql/functions/replace-transact-sql.md) functions. `TRANSLATE` does not, however, replace a character more than once. This is disimilar to multiple `REPLACE` functions, as each use would replace all relevant characters. For example:
+
+```sql
+SELECT TRANSLATE('abcdef','abc','bcd') AS Translated,
+       REPLACE(REPLACE(REPLACE('abcdef','a','b'),'b','c'),'c','d') AS Replaced;
+```
+The results are:
+Translated  |Replaced |  
+---------|--------- |
+bcddef |ddddef |
 
 `TRANSLATE` is always SC collation aware.
 


### PR DESCRIPTION
I realised, after making a now accepted change, that actually `TRANSLATE` and multiple `REPLACE` statements are not equivalent. If a character is replaced to one that is also appears later in the translatations character string, the character will not be replaced. For `REPLACE`, however, this is not true. `REPLACE` will replace all instances of that character, including those that were replaced in one of the nested functions. I have therefore added this information in the Remarks section.