### PR TITLE
Update AUTOMATIC FAILOVER_MODE for 2016+

### DIFF
--- a/docs/t-sql/statements/alter-availability-group-transact-sql.md
+++ b/docs/t-sql/statements/alter-availability-group-transact-sql.md
@@ -301,7 +301,10 @@ ALTER AVAILABILITY GROUP group_name
  Specifies the failover mode of the availability replica that you are defining.  
   
  AUTOMATIC  
- Enables automatic failover. AUTOMATIC is supported only if you also specify AVAILABILITY_MODE = SYNCHRONOUS_COMMIT. You can specify AUTOMATIC for two availability replicas, including the primary replica.  
+ Enables automatic failover. AUTOMATIC is supported only if you also specify AVAILABILITY_MODE = SYNCHRONOUS_COMMIT. You can specify AUTOMATIC for three availability replicas, including the primary replica.  
+  
+> [!NOTE]  
+>  Prior to SQL Server 2016, you were limited to two automatic failover replicas, including the primary replica
   
 > [!NOTE]  
 >  SQL Server Failover Cluster Instances (FCIs) do not support automatic failover by availability groups, so any availability replica that is hosted by an FCI can only be configured for manual failover.  


### PR DESCRIPTION
SQL Server 2016 and 2017 allow up to three automatic failover replicas (including the primary).  Updating this page to match up with [Availability Modes (Always On Availability Groups) - Synchronous-Commit Mode with Automatic Failover](https://docs.microsoft.com/en-us/sql/database-engine/availability-groups/windows/availability-modes-always-on-availability-groups?view=sql-server-2016#SyncCommitWithAuto), which says:

> To configure an availability group for automatic failover, you need to set both the current primary replica and at least one secondary replica to synchronous-commit mode with automatic failover. You can have up to three automatic failover replicas.

It was two replicas (including the primary) on SQL Server 2012 and 2014.  There isn't a 2014 version of this page, so I added a "Note" section to indicate old versions were more restrictive.