### PR TITLE
Fixed link in what-is-sql-server-machine-learning.md

### DIFF
--- a/docs/advanced-analytics/what-is-sql-server-machine-learning.md
+++ b/docs/advanced-analytics/what-is-sql-server-machine-learning.md
@@ -17,7 +17,7 @@ SQL Server 2017 Machine Learning Services is an add-on to a database engine inst
 
 If you previously used [SQL Server 2016 R Services](r/sql-server-r-services.md), Machine Learning Services in SQL Server 2017 is the next generation of R support, with updated versions of base R, RevoScaleR, MicrosoftML, and other libraries introduced in 2016. 
 
-In Azure SQL Database, [Machine Learning Services (with R)]((https://docs.microsoft.com/azure/sql-database/sql-database-connect-query-r)) is currently in public preview.
+In Azure SQL Database, [Machine Learning Services (with R)](https://docs.microsoft.com/azure/sql-database/sql-database-connect-query-r) is currently in public preview.
 
 The key value proposition of Machine Learning Services is the power of its enterprise R and Python packages to deliver advanced analytics at scale, and the ability to bring calculations and processing to where the data resides, eliminating the need to pull data across the network.
 


### PR DESCRIPTION
The link to "Machine Leanring Services (with R)" was broken because it had two sets of parathenses around it, removed one set of parentheses.