### PR TITLE
minor additions, major updates

### DIFF
--- a/docs/linux/sql-server-linux-active-directory-authentication.md
+++ b/docs/linux/sql-server-linux-active-directory-authentication.md
@@ -125,7 +125,7 @@ Use the following steps to join a [!INCLUDE[ssNoVersion](../includes/ssnoversion
 
 1. Join the domain
 
-   Once you've confirmed that your DNS is configured properly, before joinging the domain you'll want to insure that you're Linux server is synched with a domain controller on the network. The simplest way to do this is to run the following:
+   Once you've confirmed that your DNS is configured properly, before joining the domain you'll want to insure that you're Linux server is synched with a domain controller on the network. The simplest way to do this is to run the following:
       
    ```ntpdate 1.2.3.4```
    Where 1.2.3.4 is the IP of your domain controller. You should also set that to run every 10 minutes to keep the clocks synchronized using the following command:


### PR DESCRIPTION
Added several packages for rhel that are required. Added information about the hostname of the server requirement to match service definition and be resolvable in dns. Added ntpdate time sync information so customers won't fail for skewed clocks. Added notes on keytab file so customers can remove correct entries and it'll be clearer. Removed redundant name server configuration on network interfaces, best practices for name server configuration is that they only be set in resolv.conf.

joinging should be corrected to joining in my changes.