### PR TITLE
Fix SQL example with incorrect syntax

### DIFF
--- a/docs/t-sql/statements/drop-schema-transact-sql.md
+++ b/docs/t-sql/statements/drop-schema-transact-sql.md
@@ -71,7 +71,7 @@ DROP SCHEMA schema_name
 CREATE SCHEMA Sprockets AUTHORIZATION Krishna   
     CREATE TABLE NineProngs (source int, cost int, partnumber int)  
     GRANT SELECT TO Anibal   
-    DENY SELECT TO Hung-Fu;  
+    DENY SELECT TO [Hung-Fu];  
 GO  
 ```  
   


### PR DESCRIPTION
Without brackets the character '-' cause the following error: [S0001][102] Incorrect syntax near '-'.