### PR TITLE
Fix syntax error in example and fix queries

### DIFF
--- a/docs/t-sql/functions/sysdatetimeoffset-transact-sql.md
+++ b/docs/t-sql/functions/sysdatetimeoffset-transact-sql.md
@@ -65,12 +65,12 @@ SYSDATETIMEOFFSET ( )
  The following example shows the different formats that are returned by the date and time functions.  
   
 ```  
-SELECT SYSDATETIME() AS SYSDATETIME  
-    ,SYSDATETIMEOFFSET() AS SYSDATETIMEOFFSET  
-    ,SYSUTCDATETIME() AS SYSUTCDATETIME  
+SELECT SYSDATETIME() AS [SYSDATETIME()]  
+    ,SYSDATETIMEOFFSET() AS [SYSDATETIMEOFFSET()]  
+    ,SYSUTCDATETIME() AS [SYSUTCDATETIME()]  
     ,CURRENT_TIMESTAMP AS [CURRENT_TIMESTAMP]  
-    ,GETDATE() AS GETDATE  
-    ,GETUTCDATE() AS GETUTCDATE;  
+    ,GETDATE() AS [GETDATE()]  
+    ,GETUTCDATE() AS [GETUTCDATE()];  
 ```  
   
  [!INCLUDE[ssResult](../../includes/ssresult-md.md)]  
@@ -111,12 +111,12 @@ SELECT CONVERT (date, SYSDATETIME())
  The following example shows you how to convert date and time values to `time`.  
   
 ```  
-SELECT CONVERT (time, SYSDATETIME()) AS SYSDATETIME()  
-    ,CONVERT (time, SYSDATETIMEOFFSET()) AS SYSDATETIMEOFFSET()  
-    ,CONVERT (time, SYSUTCDATETIME()) AS SYSUTCDATETIME()  
-    ,CONVERT (time, CURRENT_TIMESTAMP) AS CURRENT_TIMESTAMP  
-    ,CONVERT (time, GETDATE()) AS GETDATE()  
-    ,CONVERT (time, GETUTCDATE()) AS GETUTCDATE();  
+SELECT CONVERT (time, SYSDATETIME()) AS [SYSDATETIME()]  
+    ,CONVERT (time, SYSDATETIMEOFFSET()) AS [SYSDATETIMEOFFSET()]  
+    ,CONVERT (time, SYSUTCDATETIME()) AS [SYSUTCDATETIME()]  
+    ,CONVERT (time, CURRENT_TIMESTAMP) AS [CURRENT_TIMESTAMP]  
+    ,CONVERT (time, GETDATE()) AS [GETDATE()]  
+    ,CONVERT (time, GETUTCDATE()) AS [GETUTCDATE()];  
 ```  
   
  [!INCLUDE[ssResult](../../includes/ssresult-md.md)]  


### PR DESCRIPTION
A column alias can not be `SYSDATETIME()` but `[SYSDATETIME()]`, otherwise it's an error: [S0001][102] Incorrect syntax near ')'.
Also update queries to match results