### PR TITLE
Fix syntax error due to a missing comma

### DIFF
--- a/docs/t-sql/functions/compress-transact-sql.md
+++ b/docs/t-sql/functions/compress-transact-sql.md
@@ -77,7 +77,7 @@ This statement first deletes old player records from the `player` table. To save
 ```sql
 DELETE player  
 WHERE datemodified < @startOfYear  
-OUTPUT id, name, surname datemodifier, COMPRESS(info)   
+OUTPUT id, name, surname, datemodifier, COMPRESS(info)   
 INTO dbo.inactivePlayers ;  
 ```  
   


### PR DESCRIPTION
Column names in OUTPUT clause should be separated by comma