### PR TITLE
Event session inconsistency

### DIFF
--- a/docs/database-engine/availability-groups/windows/automatic-seeding-secondary-replicas.md
+++ b/docs/database-engine/availability-groups/windows/automatic-seeding-secondary-replicas.md
@@ -202,7 +202,7 @@ Automatic seeding adds new extended events for tracking state change, failures, 
 For example, the following script creates an extended events session that captures events related to automatic seeding.
 
 ```sql
-CREATE EVENT SESSION [AG_autoseed] ON SERVER 
+CREATE EVENT SESSION [AlwaysOn_autoseed] ON SERVER 
     ADD EVENT sqlserver.hadr_automatic_seeding_state_transition,
     ADD EVENT sqlserver.hadr_automatic_seeding_timeout,
     ADD EVENT sqlserver.hadr_db_manager_seeding_request_msg,


### PR DESCRIPTION
The script to create AG_autoseed session is followed by alter event session on AlwaysOn_autoseed. Different name. I thought AlwaysOn_autoseed was better name so changed create event session to that.