### PR TITLE
Swap failure diagrams

### DIFF
--- a/docs/linux/tutorial-sql-server-containers-kubernetes.md
+++ b/docs/linux/tutorial-sql-server-containers-kubernetes.md
@@ -35,11 +35,11 @@ In the preceding diagram, `mssql-server` is a container in a [pod](https://kuber
 
 In the following diagram, the `mssql-server` container has failed. As the orchestrator, Kubernetes guarantees the correct count of healthy instances in the replica set, and starts a new container according to the configuration. The orchestrator starts a new pod on the same node, and `mssql-server` reconnects to the same persistent storage. The service connects to the re-created `mssql-server`.
 
-![Diagram of Kubernetes SQL Server cluster](media/tutorial-sql-server-containers-kubernetes/kubernetes-sql-after-node-fail.png)
+![Diagram of Kubernetes SQL Server cluster](media/tutorial-sql-server-containers-kubernetes/kubernetes-sql-after-pod-fail.png)
 
 In the following diagram, the node hosting the `mssql-server` container has failed. The orchestrator starts the new pod on a different node, and `mssql-server` reconnects to the same persistent storage. The service connects to the re-created `mssql-server`.
 
-![Diagram of Kubernetes SQL Server cluster](media/tutorial-sql-server-containers-kubernetes/kubernetes-sql-after-pod-fail.png)
+![Diagram of Kubernetes SQL Server cluster](media/tutorial-sql-server-containers-kubernetes/kubernetes-sql-after-node-fail.png)
 
 ## Prerequisites
 


### PR DESCRIPTION
Swapped the order of the diagrams showing node and pod failure under the "HA solution on Kubernetes running in Azure Kubernetes Service" heading