### PR TITLE
columns type length change/ change history deleted

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-xe-session-event-actions-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-xe-session-event-actions-transact-sql.md
@@ -29,9 +29,9 @@ manager: craigg
 |Column name|Data type|Description|  
 |-----------------|---------------|-----------------|  
 |event_session_address|**varbinary(8)**|The memory address of the event session. Is not nullable.|  
-|action_name|**nvarchar(60)**|The name of the action. Is not nullable.|  
+|action_name|**nvarchar(256)**|The name of the action. Is not nullable.|  
 |action_package_guid|**uniqueidentifier**|The GUID for the package that contains the action. Is not nullable.|  
-|event_name|**nvarchar(60)**|The name of the event that the action is bound to. Is not nullable.|  
+|event_name|**nvarchar(256)**|The name of the event that the action is bound to. Is not nullable.|  
 |event_package_guid|**uniqueidentifier**|The GUID for the package that contains the event. Is not nullable.|  
   
 ## Permissions  
@@ -44,12 +44,6 @@ manager: craigg
 |sys.dm_xe_session_event_actions.event_session_address|sys.dm_xe_sessions.address|Many-to-one|  
 |sys.dm_xe_session_event_actions.action_name<br /><br /> sys.dm_xe_session_event_actions.action_package_guid|sys.dm_xe_objects.name<br /><br /> sys.dm_xe_session_events.event_package_guid|Many-to-one|  
 |sys.dm_xe_session_event_actions.event_name<br /><br /> sys.dm_xe_session_event_actions.event_package_guid|sys.dm_xe_objects.name<br /><br /> sys.dm_xe_objects.package_guid|Many-to-one|  
-  
-## Change History  
-  
-|Updated content|  
-|---------------------|  
-|Updated "Relationship Cardinalities" table with the correct dynamic management view names and column names.|  
   
 ## See Also  
  [Dynamic Management Views and Functions &#40;Transact-SQL&#41;](~/relational-databases/system-dynamic-management-views/system-dynamic-management-views.md)  


### PR DESCRIPTION
We do not need a change history as we have git. Also, in the other extended events objects such are missing.
Column data types length change to match SQL Server 2017 ones.