### PR TITLE
PARSENAME return type correction

### DIFF
--- a/docs/t-sql/functions/parsename-transact-sql.md
+++ b/docs/t-sql/functions/parsename-transact-sql.md
@@ -56,7 +56,7 @@ PARSENAME ( 'object_name' , object_piece )
  4 = Server name  
   
 ## Return Types  
- **nchar**  
+ **sysname**  
   
 ## Remarks  
  PARSENAME returns NULL if one of the following conditions is true:  


### PR DESCRIPTION
The documentation advises that the return type is an `nchar` (with no length declared). This isn't true, it returns the `sysname` datatype; which is a synonym for `nvarchar(128)` (which is a different datatype to `nchar` as well).