### PR TITLE
Update sys-dm-io-pending-io-requests-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-io-pending-io-requests-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-io-pending-io-requests-transact-sql.md
@@ -33,14 +33,15 @@ monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-s
 |Column name|Data type|Description|  
 |-----------------|---------------|-----------------|  
 |**io_completion_request_address**|**varbinary(8)**|Memory address of the IO request. Is not nullable.|  
-|**io_type**|**varchar(7)**|Type of pending I/O request. Is not nullable.|  
+|**io_type**|**nvarchar(120)**|Type of pending I/O request. Is not nullable.|  
+|**io_pending_ms_ticks**|**bigint**|Internal use only. Is not nullable.| 
 |**io_pending**|**int**|Indicates whether the I/O request is pending or has been completed by Windows. An I/O request can still be pending even when Windows has completed the request, but [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] has not yet performed a context switch in which it would process the I/O request and remove it from this list. Is not nullable.|  
 |**io_completion_routine_address**|**varbinary(8)**|Internal function to call when the I/O request is completed. Is nullable.|  
 |**io_user_data_address**|**varbinary(8)**|Internal use only. Is nullable.|  
 |**scheduler_address**|**varbinary(8)**|Scheduler on which this I/O request was issued. The I/O request will appear on the pending I/O list of the scheduler. For more information, see [sys.dm_os_schedulers &#40;Transact-SQL&#41;](../../relational-databases/system-dynamic-management-views/sys-dm-os-schedulers-transact-sql.md). Is not nullable.|  
 |**io_handle**|**varbinary(8)**|File handle of the file that is used in the I/O request. Is nullable.|  
 |**io_offset**|**bigint**|Offset of the I/O request. Is not nullable.|  
-|**io_pending_ms_ticks**|**int**|Internal use only. Is not nullable.|  
+|**io_handle_path**|**nvarchar(512)**| Path of file that is used in the I/O request. Is nullable.|
 |**pdw_node_id**|**int**|**Applies to**: [!INCLUDE[ssSDWfull](../../includes/sssdwfull-md.md)], [!INCLUDE[ssPDW](../../includes/sspdw-md.md)]<br /><br /> The identifier for the node that this distribution is on.|  
   
 ## Permissions  

--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-io-pending-io-requests-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-io-pending-io-requests-transact-sql.md
@@ -33,7 +33,7 @@ monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-s
 |Column name|Data type|Description|  
 |-----------------|---------------|-----------------|  
 |**io_completion_request_address**|**varbinary(8)**|Memory address of the IO request. Is not nullable.|  
-|**io_type**|**nvarchar(120)**|Type of pending I/O request. Is not nullable.|  
+|**io_type**|**nvarchar(60)**|Type of pending I/O request. Is not nullable.|  
 |**io_pending_ms_ticks**|**bigint**|Internal use only. Is not nullable.| 
 |**io_pending**|**int**|Indicates whether the I/O request is pending or has been completed by Windows. An I/O request can still be pending even when Windows has completed the request, but [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] has not yet performed a context switch in which it would process the I/O request and remove it from this list. Is not nullable.|  
 |**io_completion_routine_address**|**varbinary(8)**|Internal function to call when the I/O request is completed. Is nullable.|  
@@ -41,7 +41,7 @@ monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-s
 |**scheduler_address**|**varbinary(8)**|Scheduler on which this I/O request was issued. The I/O request will appear on the pending I/O list of the scheduler. For more information, see [sys.dm_os_schedulers &#40;Transact-SQL&#41;](../../relational-databases/system-dynamic-management-views/sys-dm-os-schedulers-transact-sql.md). Is not nullable.|  
 |**io_handle**|**varbinary(8)**|File handle of the file that is used in the I/O request. Is nullable.|  
 |**io_offset**|**bigint**|Offset of the I/O request. Is not nullable.|  
-|**io_handle_path**|**nvarchar(512)**| Path of file that is used in the I/O request. Is nullable.|
+|**io_handle_path**|**nvarchar(256)**| Path of file that is used in the I/O request. Is nullable.|
 |**pdw_node_id**|**int**|**Applies to**: [!INCLUDE[ssSDWfull](../../includes/sssdwfull-md.md)], [!INCLUDE[ssPDW](../../includes/sspdw-md.md)]<br /><br /> The identifier for the node that this distribution is on.|  
   
 ## Permissions  


### PR DESCRIPTION
from  SQL Server 2014 CTP1  sys.dm_io_pending_io_requests has been added by a new column "io_handle_path": it was missing in this documentation. i fixed the order of the columns  and i fixed some datatype/maxlenght that was updated in mssql 2016.
you can check with 
select q.column_id, q.name, t.name, q.max_length  from sys.all_columns  q
inner join sys.types t 
on t.system_type_id = q.system_type_id 
and t.user_type_id= q.user_type_id
where object_id=object_id('sys.dm_io_pending_io_requests')
order by column_id