### PR TITLE
Changing HTML entitiy (&#39;) to character (')

### DIFF
--- a/docs/ado/guide/ado-programmer-s-guide.md
+++ b/docs/ado/guide/ado-programmer-s-guide.md
@@ -1,5 +1,5 @@
 ---
-title: "ADO Programmer&#39;s Guide | Microsoft Docs"
+title: "ADO Programmer's Guide | Microsoft Docs"
 ms.custom: ""
 ms.date: "01/19/2017"
 ms.reviewer: ""
@@ -14,7 +14,7 @@ author: MightyPen
 ms.author: genemi
 manager: craigg
 ---
-# ADO Programmer&#39;s Guide for using ADO Objects
+# ADO Programmer's Guide for using ADO Objects
 This documentation provides an overview of how to use ADO objects to work with data from various data sources. First, the introduction summarizes the new features and the requirement for installing, using, and redistributing the ADO component. The next sections discuss the use of the various types of ADO objects. Finally, the appendixes discuss various Microsoft-supplied data and service providers, error messages, and tips about how to use ADO in several programming languages, in addition to samples and a glossary.
 
  This section contains the following topics.


### PR DESCRIPTION
Localization team has reported source content issue that causes localized version to have broken format compared to en-us version and display wrong content.

The request:

Changing HTML entitiy (&#39;) to character (') in titles (metadata and body)