### PR TITLE
chore: Add Docs Authoring Pack suggestions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ _themes.MSDN.Modern/
 _themes.VS.Modern/
 
 .openpublishing.buildcore.ps1
+
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "docsmsft.docs-authoring-pack"
+    ]
+}


### PR DESCRIPTION
This will suggest the Docs Authoring pack when editors are using VS Code to modify the repo