### PR TITLE
List Verbage Change

### DIFF
--- a/docs/t-sql/functions/datalength-transact-sql.md
+++ b/docs/t-sql/functions/datalength-transact-sql.md
@@ -52,9 +52,6 @@ An [expression](../../t-sql/language-elements/expressions-transact-sql.md) of an
 - **nvarchar**
 - **text**
 - **varbinary**
-
-and
-
 - **varchar**
 
 data types, because these data types can store variable-length data.


### PR DESCRIPTION
Removed the **and** in the list of datatypes as it's a list so adding a random and in there doesn't make sense and kills readability.