### PR TITLE
COMPRESS - Correct Archive SQL Syntax

### DIFF
--- a/docs/t-sql/functions/compress-transact-sql.md
+++ b/docs/t-sql/functions/compress-transact-sql.md
@@ -75,10 +75,10 @@ VALUES (N'Michael', N'Raheem', compress(@info));
 This statement first deletes old player records from the `player` table. To save space, it then stores the records in the `inactivePlayer` table, in a compressed format.
   
 ```sql
-DELETE player  
-WHERE datemodified < @startOfYear  
-OUTPUT id, name, surname, datemodifier, COMPRESS(info)   
-INTO dbo.inactivePlayers ;  
+DELETE FROM player  
+OUTPUT deleted.id, deleted.name, deleted.surname, deleted.datemodifier, COMPRESS(deleted.info)   
+INTO dbo.inactivePlayers
+WHERE datemodified < @startOfYear; 
 ```  
   
 ## See also


### PR DESCRIPTION
The syntax for the `DELETE` statement was vwrong. The `OUTPUT` clause was after the `WHERE`, and the prefix `deleted` was not specified for the columns; thus they wouldn't be recognised columns.  Updated to be correct syntax, as per [OUTPUT Clause (Transact-SQL) - Using OUTPUT with a DELETE statement](https://docs.microsoft.com/en-us/sql/t-sql/queries/output-clause-transact-sql?view=sql-server-2017#b-using-output-with-a-delete-statement).