### PR TITLE
Update unpack/install commands

### DIFF
--- a/docs/tools/sqlpackage-download.md
+++ b/docs/tools/sqlpackage-download.md
@@ -59,8 +59,9 @@ This release of sqlpackage includes a standard Windows installer experience, and
    ```bash
    cd ~
    mkdir sqlpackage
-   unzip ~/Downloads/sqlpackage-linux-<version string>.zip ~/sqlpackage 
-   echo 'export PATH="$PATH:~/sqlpackage"' >> ~/.bashrc
+   unzip ~/Downloads/sqlpackage-linux-<version string>.zip -d ~/sqlpackage 
+   echo "export PATH=\"\$PATH:$HOME/sqlpackage\"" >> ~/.bashrc
+   chmod a+x ~/sqlpackage/sqlpackage
    source ~/.bashrc
    sqlpackage
    ```


### PR DESCRIPTION
I had 3 issues when installing:
* The unzip command was incorrect as `-d` is needed to specify the extraction directory
* The `sqlpackage` executable file is not marked as executable and so it won't run without a chmod.
* The previous command to update .bashrc wrote a literal ~ into the file. This works for running the executable in the shell, but some tools (e.g. `which(1)`) do not understand it so running `which sqlpackage` didn't work.