### PR TITLE
Fix change of directory for logfiles folder

### DIFF
--- a/docs/reporting-services/report-server/reporting-services-log-files-and-sources.md
+++ b/docs/reporting-services/report-server/reporting-services-log-files-and-sources.md
@@ -1,6 +1,6 @@
 ---
 title: "Reporting Services Log Files and Sources | Microsoft Docs"
-ms.date: 03/16/2017
+ms.date: 01/05/2018
 ms.prod: reporting-services
 ms.prod_service: "reporting-services-sharepoint, reporting-services-native"
 ms.technology: report-server
@@ -29,7 +29,7 @@ ms.author: maghan
 |---------|-----------------|  
 |[Report Server ExecutionLog and the ExecutionLog3 View](../../reporting-services/report-server/report-server-executionlog-and-the-executionlog3-view.md)|The execution log is a SQL Server view stored in the report server database.<br /><br /> The report server execution log contains data about specific reports, including when a report was run, who ran it, where it was delivered, and which rendering format was used.|  
 |SharePoint trace log|For report servers running in SharePoint, the SharePoint trace logs contains [!INCLUDE[ssRSnoversion](../../includes/ssrsnoversion-md.md)] information. You can also configure [!INCLUDE[ssRS](../../includes/ssrs.md)] specific information for the SharePoint Unified Logging service. For more information, see [Turn on Reporting Services events for the SharePoint trace log &#40;ULS&#41;](../../reporting-services/report-server/turn-on-reporting-services-events-for-the-sharepoint-trace-log-uls.md)|  
-|[Report Server Service Trace Log](../../reporting-services/report-server/report-server-service-trace-log.md)|The service trace log contains very detailed information that is useful if you are debugging an application or investigating an issue or event. The trace log files are ReportServerService_\<timestamp>.log and are located in the following folder:<br /><br /> `C:\Program Files\Microsoft SQL Server\MSRS13.MSSQLSERVER\Reporting Services\LogFiles`|  
+|[Report Server Service Trace Log](../../reporting-services/report-server/report-server-service-trace-log.md)|The service trace log contains very detailed information that is useful if you are debugging an application or investigating an issue or event. The trace log files are ReportServerService_\<timestamp>.log and are located in the following folder:<br /><br /> In SQL Server Reporting Services 2016 or earlier: `C:\Program Files\Microsoft SQL Server\MSRS13.MSSQLSERVER\Reporting Services\LogFiles`<br /><br /> In SQL Server Reporting Services 2017: `C:\Program Files\Microsoft SQL Server Reporting Services\SSRS\LogFiles`|  
 |[Report Server HTTP Log](../../reporting-services/report-server/report-server-http-log.md)|The HTTP log file contains a record of all HTTP requests and responses handled by the Report Server Web service and Report Manager.|  
 |[Windows Application Log](../../reporting-services/report-server/windows-application-log.md)|The Microsoft Windows Application log contains information about report server events.|  
 |Windows Performance logs|The Windows Performance logs contain report server performance data. You can create performance logs, and then choose counters that determine which data to collect. For more information, see [Monitoring Report Server Performance](../../reporting-services/report-server/monitoring-report-server-performance.md).|  


### PR DESCRIPTION
Set up a SSRS 2017 instance today and had an error; log was in wrong location based on directions on this page.

The product error was "An internal error occurred on the report server. See the error log for more details.", which occurred on http://dev.reporting.example.local/Reports_DEV/manage/catalogitem/addrole/Alpha while I was setting up our Alpha environments.