### PR TITLE
change the place of partition_number description

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-db-index-operational-stats-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-db-index-operational-stats-transact-sql.md
@@ -79,9 +79,9 @@ sys.dm_db_index_operational_stats (
 |-----------------|---------------|-----------------|    
 |**database_id**|**smallint**|Database ID.|    
 |**object_id**|**int**|ID of the table or view.|    
-|**index_id**|**int**|ID of the index or heap.<br /><br /> 0 = Heap|    
-|**hobt_id**|**bigint**|**Applies to**: [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] ([!INCLUDE[ssSQL15](../../includes/sssql15-md.md)] through [current version](https://go.microsoft.com/fwlink/p/?LinkId=299658)), [!INCLUDE[ssSDSfull](../../includes/sssdsfull-md.md)].<br /><br /> ID of the data heap or B-tree rowset that tracks internal data for a columnstore index.<br /><br /> NULL - this is not an internal columnstore rowset.<br /><br /> For more details, see [sys.internal_partitions &#40;Transact-SQL&#41;](../../relational-databases/system-catalog-views/sys-internal-partitions-transact-sql.md)|    
-|**partition_number**|**int**|1-based partition number within the index or heap.|    
+|**index_id**|**int**|ID of the index or heap.<br /><br /> 0 = Heap| 
+|**partition_number**|**int**|1-based partition number within the index or heap.| 
+|**hobt_id**|**bigint**|**Applies to**: [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] ([!INCLUDE[ssSQL15](../../includes/sssql15-md.md)] through [current version](https://go.microsoft.com/fwlink/p/?LinkId=299658)), [!INCLUDE[ssSDSfull](../../includes/sssdsfull-md.md)].<br /><br /> ID of the data heap or B-tree rowset that tracks internal data for a columnstore index.<br /><br /> NULL - this is not an internal columnstore rowset.<br /><br /> For more details, see [sys.internal_partitions &#40;Transact-SQL&#41;](../../relational-databases/system-catalog-views/sys-internal-partitions-transact-sql.md)|       
 |**leaf_insert_count**|**bigint**|Cumulative count of leaf-level inserts.|    
 |**leaf_delete_count**|**bigint**|Cumulative count of leaf-level deletes. leaf_delete_count is only incremented for deleted records that are not marked as ghost first. For deleted records that are ghosted first, **leaf_ghost_count** is incremented instead.|    
 |**leaf_update_count**|**bigint**|Cumulative count of leaf-level updates.|    


### PR DESCRIPTION
The `partition_number` column comes before the `hobt_id` one.