### PR TITLE
Removing references to Docker Store

### DIFF
--- a/docs/linux/sql-server-linux-configure-docker.md
+++ b/docs/linux/sql-server-linux-configure-docker.md
@@ -61,7 +61,7 @@ The quickstart in the previous section runs the free Developer edition of SQL Se
 
 - The Developer container image can be configured to run the production editions as well. Use the following steps to run production editions:
 
-Review the requirements and run procedures in the [quickstart](quickstart-install-connect-docker.md) and you must specify your production edition with the **MSSQL_PID** environment variable. The following example shows how to run the latest SQL Server 2017 container image for the Enterprise Edition:
+Review the requirements and run procedures in the [quickstart](quickstart-install-connect-docker.md). You must specify your production edition with the **MSSQL_PID** environment variable. The following example shows how to run the latest SQL Server 2017 container image for the Enterprise Edition:
 
       ```bash
       docker run --name sqlenterprise \

--- a/docs/linux/sql-server-linux-configure-docker.md
+++ b/docs/linux/sql-server-linux-configure-docker.md
@@ -58,19 +58,10 @@ The quickstart in the previous section runs the free Developer edition of SQL Se
 
 - You can only use SQL Server in a production environment if you have a valid license. You can obtain a free SQL Server Express production license [here](https://go.microsoft.com/fwlink/?linkid=857693). SQL Server Standard and Enterprise Edition licenses are available through [Microsoft Volume Licensing](https://www.microsoft.com/licensing/default.aspx).
 
-- Production SQL Server container images must be pulled from [Docker Store](https://store.docker.com). If you don't already have one, create an account on Docker Store.
 
-- The Developer container image on Docker Store can be configured to run the production editions as well. Use the following steps to run production editions:
+- The Developer container image can be configured to run the production editions as well. Use the following steps to run production editions:
 
-   1. First, log in to your docker id from the command line.
-
-      ```bash
-      docker login
-      ```
-
-   2. Next, you need to obtain the free Developer container image on Docker Store. Go to [https://store.docker.com/images/mssql-server-linux](https://store.docker.com/images/mssql-server-linux), click **Proceed to Checkout**, and follow the instructions.
-
-   3. Review the requirements and run procedures in the [quickstart](quickstart-install-connect-docker.md). But there are two differences. You must pull the image **store/microsoft/mssql-server-linux:\<tag-name\>** from Docker Store. And you must specify your production edition with the **MSSQL_PID** environment variable. The following example shows how to run the latest SQL Server 2017 container image for the Enterprise Edition:
+Review the requirements and run procedures in the [quickstart](quickstart-install-connect-docker.md) and you must specify your production edition with the **MSSQL_PID** environment variable. The following example shows how to run the latest SQL Server 2017 container image for the Enterprise Edition:
 
       ```bash
       docker run --name sqlenterprise \


### PR DESCRIPTION
Docker store no longer exists. Updating instructions to reflect this change.