### PR TITLE
Updated sp-helptracertokens-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-helptracertokens-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-helptracertokens-transact-sql.md
@@ -29,8 +29,8 @@ manager: craigg
 ```  
   
 sp_helptracertokens [ @publication = ] 'publication'   
-    [ , [ @publisher = ] 'publisher' ]   
-    [ , [ @publisher_db = ] 'publisher_db' ]  
+     , [ @publisher = ] 'publisher'    
+     , [ @publisher_db = ] 'publisher_db'   
 ```  
   
 ## Arguments  


### PR DESCRIPTION
Corrected the syntax which mistakenly marked parameters @publisher and @publisher_db as optional.