### PR TITLE
Update alter-external-data-source-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/alter-external-data-source-transact-sql.md
+++ b/docs/t-sql/statements/alter-external-data-source-transact-sql.md
@@ -41,11 +41,9 @@ ALTER EXTERNAL DATA SOURCE data_source_name SET
 -- Modify an external data source pointing to Azure Blob storage
 -- Applies to: SQL Server (starting with 2017)
 ALTER EXTERNAL DATA SOURCE data_source_name
-    WITH (
-        TYPE = BLOB_STORAGE,
+    SET
         LOCATION = 'https://storage_account_name.blob.core.windows.net'
-        [, CREDENTIAL = credential_name ]
-    )  
+        [, CREDENTIAL = credential_name ] 
 ```  
   
 ## Arguments  


### PR DESCRIPTION
ALTER EXTERNAL DATA SOURCE is done using SET and not using WITH hint. There was a mistake in the document in the template of the query. The examples are OK.