### PR TITLE
Setting the real SSMS option value

### DIFF
--- a/docs/relational-databases/performance/monitoring-performance-by-using-the-query-store.md
+++ b/docs/relational-databases/performance/monitoring-performance-by-using-the-query-store.md
@@ -38,7 +38,7 @@ monikerRange: "=azuresqldb-current||>=sql-server-2016||=sqlallproducts-allversio
   
 2.  In the **Database Properties** dialog box, select the **Query Store** page.  
   
-3.  In the **Operation Mode (Requested)** box, select **On**.  
+3.  In the **Operation Mode (Requested)** box, select **Read Write**.  
   
 #### Use Transact-SQL Statements  
   
@@ -46,6 +46,7 @@ Use the **ALTER DATABASE** statement to enable the query store. For example:
   
 ```sql  
 ALTER DATABASE AdventureWorks2012 SET QUERY_STORE = ON;  
+ALTER DATABASE AdventureWorks2012 SET QUERY_STORE (OPERATION_MODE = READ_WRITE); 
 ```  
   
 For more syntax options related to the query store, see [ALTER DATABASE SET Options &#40;Transact-SQL&#41;](../../t-sql/statements/alter-database-transact-sql-set-options.md).  


### PR DESCRIPTION
In SSMS 17.9, the displayed options are `Read Write` and `Read Only`. As we are enabling for the first time, `Read Only` does not work for us, so it should be `Read Write`. I've updated the T-SQL statements, too.