### PR TITLE
Fix probable typo in FILESTREAM RAID documentation

### DIFF
--- a/docs/relational-databases/blob/enable-and-configure-filestream.md
+++ b/docs/relational-databases/blob/enable-and-configure-filestream.md
@@ -76,7 +76,7 @@ manager: craigg
 |RAID level|Write performance|Read performance|Fault tolerance|Remarks|  
 |RAID 5|Normal|Normal|Excellent|Performance is better than one disk or JBOD; and less than RAID 0 or RAID 5 with striping.|  
 |RAID 0|Excellent|Excellent|None||  
-|RAID 5 + stripping|Excellent|Excellent|Excellent|Most expensive option.|  
+|RAID 5 + striping|Excellent|Excellent|Excellent|Most expensive option.|  
   
   
 ###  <a name="database"></a> Physical database design  


### PR DESCRIPTION
As excellent as stripping may be, I don't think it's what the original author had in mind.