### PR TITLE
Fixed error in example

### DIFF
--- a/docs/t-sql/language-elements/throw-transact-sql.md
+++ b/docs/t-sql/language-elements/throw-transact-sql.md
@@ -106,7 +106,7 @@ END CATCH;
  [!INCLUDE[ssResult](../../includes/ssresult-md.md)]  
   
  ```
- PRINT 'In catch block.';  
+ In catch block. 
  Msg 2627, Level 14, State 1, Line 1  
  Violation of PRIMARY KEY constraint 'PK__TestReth__3214EC272E3BD7D3'. Cannot insert duplicate key in object 'dbo.TestRethrow'.  
  The statement has been terminated.


### PR DESCRIPTION
The result window should show "In catch block." as opposed to "PRINT 'In catch block.';"  which is the command itself.