### PR TITLE
Minor fix: Place abbreviation directly after term

### DIFF
--- a/docs/relational-databases/security/dynamic-data-masking.md
+++ b/docs/relational-databases/security/dynamic-data-masking.md
@@ -17,7 +17,7 @@ monikerRange: "=azuresqldb-current||>=sql-server-2016||=sqlallproducts-allversio
 
 ![Dynamic data masking](../../relational-databases/security/media/dynamic-data-masking.png)
 
-Dynamic data masking limits (DDM) sensitive data exposure by masking it to non-privileged users. It can be used to greatly simplify the design and coding of security in your application.  
+Dynamic data masking (DDM) limits sensitive data exposure by masking it to non-privileged users. It can be used to greatly simplify the design and coding of security in your application.  
 
 Dynamic data masking helps prevent unauthorized access to sensitive data by enabling customers to designate how much of the sensitive data to reveal with minimal impact on the application layer. DDM can be configured on the database to hide sensitive data in the result sets of queries over designated database fields, while the data in the database is not changed. Dynamic data masking is easy to use with existing applications, since masking rules are applied in the query results. Many applications can mask sensitive data without modifying existing queries.
 


### PR DESCRIPTION
Was reading the docs and noticed this. It's a tiny tiny thing but I figured I'd submit because why not make things better? :)