### PR TITLE
Update always-encrypted-api-reference-for-the-jdbc-driver.md

### DIFF
--- a/docs/connect/jdbc/always-encrypted-api-reference-for-the-jdbc-driver.md
+++ b/docs/connect/jdbc/always-encrypted-api-reference-for-the-jdbc-driver.md
@@ -36,6 +36,7 @@ manager: craigg
 |`public void setSendTimeAsDatetime(boolean sendTimeAsDateTimeValue)`|Modifies the setting of the sendTimeAsDatetime connection property.|
 
  **SQLServerConnectionPoolProxy Class**
+ 
 |Name|Description|  
 |----------|-----------------|  
 |`public final boolean getSendTimeAsDatetime()` | Returns the setting of the sendTimeAsDatetime connection property.|
@@ -146,6 +147,7 @@ manager: craigg
 
   
 New types in **microsoft.sql.Types** class
+
 |Name|Description|  
 |----------|-----------------|  
 |DATETIME, SMALLDATETIME, MONEY, SMALLMONEY, GUID|Use these types as the target SQL types when sending parameter values to **encrypted** datetime, smalldatetime, money, smallmoney, uniqueidentifier columns using `setObject()/updateObject()` API methods.|  


### PR DESCRIPTION
There are a couple of broken tables in the **Always Encrypted API Reference for the JDBC Driver** page.

![image](https://user-images.githubusercontent.com/1854768/51274059-cf480000-1993-11e9-9a8e-50f4b83c97a2.png)
