### PR TITLE
Update configure-http-access-to-analysis-services-on-iis-8-0.md

### DIFF
--- a/docs/analysis-services/instances/configure-http-access-to-analysis-services-on-iis-8-0.md
+++ b/docs/analysis-services/instances/configure-http-access-to-analysis-services-on-iis-8-0.md
@@ -105,6 +105,8 @@ manager: kfile
     -   \<drive>:\inetpub\wwwroot\OLAP\MSMDPUMP.ini  
   
     -   \<drive>:\inetpub\wwwroot\OLAP\Resources  
+> [!NOTE]  
+>  The IIS manager might not be able to connect to the Analysis Services in the current version if the Database is a backup from a previous one. This is caused by changes in the MSMDPUMP and should be solved by copying the msmdpump.dll file from the previous working version.
   
 ##  <a name="bkmk_appPool"></a> Step 2: Create an application pool and virtual directory in IIS  
  Next, create an application pool and an endpoint to the pump.  


### PR DESCRIPTION
Following this tutorial, had an 500 - Internal server error caused by not using the previous version of the .dll. 
In my case, it was from the 2012 to the 2017 but it was observed to be the same from 2016 version to 2017. Answer found here: https://social.technet.microsoft.com/Forums/en-US/8960e951-0e77-41a2-8225-863ac0c53b69/through-iis-manager-not-able-to-connect-to-analysis-services-in-2017-version?forum=sqlanalysisservices