### PR TITLE
Update create-symmetric-key-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/create-symmetric-key-transact-sql.md
+++ b/docs/t-sql/statements/create-symmetric-key-transact-sql.md
@@ -39,11 +39,8 @@ manager: craigg
 CREATE SYMMETRIC KEY key_name   
     [ AUTHORIZATION owner_name ]  
     [ FROM PROVIDER provider_name ]  
-    WITH 
-      [
-          <key_options> [ , ... n ]  
-        | ENCRYPTION BY <encrypting_mechanism> [ , ... n ] 
-      ]
+    WITH <key_options> [ , ... n ]
+    ENCRYPTION BY <encrypting_mechanism> [ , ... n ] 
   
 <key_options> ::=  
       KEY_SOURCE = 'pass_phrase'  


### PR DESCRIPTION
Incorrect syntax description for "Create symmetric key". Examples contradict the syntax.