### PR TITLE
It is not necesary to declare the 'http://www.w3.org/2001/XMLSchema-i…

### DIFF
--- a/docs/t-sql/xml/with-xmlnamespaces.md
+++ b/docs/t-sql/xml/with-xmlnamespaces.md
@@ -81,11 +81,13 @@ DEFAULT <xml_namespace_uri>
 -   The XML namespace prefix `xml` cannot be overridden with a namespace, other than the namespaces URI `'http://www.w3.org/XML/1998/namespace'`, and this URI that cannot be assigned a different prefix.  
   
 -   The XML namespace prefix `xsi` cannot be redeclared when the ELEMENTS XSINIL directive is being used on the query.  
-  
+
+-   It is not necesary to declare the 'http://www.w3.org/2001/XMLSchema-instance' to use xsi standard namespace. It is implicitly added by the XML/XPATH processor if not specified and xpath expressions can use the xsi prefix as long as the 'http://www.w3.org/2001/XMLSchema-instance' schema is properly declared in the xml document.
+
 -   URI string values are encoded according to the current database collation code page and are internally translated to Unicode.  
   
 -   The XML namespace URI will be white-space collapsed following the XSD white-space collapse rules that are used for **xs:anyURI**. Also, note that no entitization or deentitization are performed on XML namespace URI values.  
-  
+
 -   The XML namespace URI will be checked for XML 1.0 characters that are not valid, and an error will be raised if one is found (such as, U+0007).  
   
 -   The XML namespace URI (after all white space is collapsed) cannot be a zero-length string or an "invalid empty namespace URI" error occurs.  


### PR DESCRIPTION
…nstance'

Apparently the xpath processor includes the http://www.w3.org/2001/XMLSchema-instance by default if not specified with the [WITH XMLNAMESPACES] clause. As long as the namespace is declared in the xml itself an implicit [WITH XMLNAMESPACES('http://www.w3.org/2001/XMLSchema-instance' AS xsi] will be issued.

For example:
DECLARE @doc as XML = CAST ('
&lt;?xml version="1.0"?&gt;
&lt;note xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"&gt;
&lt;name xsi:nil="true"&gt; &lt;/name&gt;
&lt;text&gt; hello &lt;/text&gt;
&lt;/note&gt;'
 AS XML);

SELECT @doc.query('note/name[@xsi:nil="true"]') as result;
Will return results even when the xsi namespace is not explicitly declared.

<name xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />

Changing the xml to not mach the standard namespace exactly causes it to not return results.

DECLARE @doc as XML = CAST ('
&lt;?xml version="1.0"?&gt;
&lt;note xmlns:xsi="http://www.w3.org/2001/XMLSchema-instanceXXX"&gt;
&lt;name xsi:nil="true"&gt; &lt;/name&gt;
&lt;text&gt; hello &lt;/text&gt;
&lt;/note&gt;
' AS XML);

SELECT @doc.query('note/name[@xsi:nil="true"]') as result;

This is not true for all xml processors and seems like a design decision. I tested similar scenarios using the .net processors and adding the namespace to the manager is always required.

I am trying to follow the same succinct style for the documentation, although I believe examples are required to better illustrate all these behaviors.

Thank you.