### PR TITLE
Add MERGE in list of statements allowed with CTE

### DIFF
--- a/docs/t-sql/queries/with-common-table-expression-transact-sql.md
+++ b/docs/t-sql/queries/with-common-table-expression-transact-sql.md
@@ -35,7 +35,7 @@ monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-s
 > [!div class="nextstepaction"]
 > [Please share your feedback about the SQL Docs Table of Contents!](https://aka.ms/sqldocsurvey)
 
-Specifies a temporary named result set, known as a common table expression (CTE). This is derived from a simple query and defined within the execution scope of a single SELECT, INSERT, UPDATE, or DELETE statement. This clause can also be used in a CREATE VIEW statement as part of its defining SELECT statement. A common table expression can include references to itself. This is referred to as a recursive common table expression.  
+Specifies a temporary named result set, known as a common table expression (CTE). This is derived from a simple query and defined within the execution scope of a single SELECT, INSERT, UPDATE, DELETE or MERGE statement. This clause can also be used in a CREATE VIEW statement as part of its defining SELECT statement. A common table expression can include references to itself. This is referred to as a recursive common table expression.  
   
  ![Topic link icon](../../database-engine/configure-windows/media/topic-link.gif "Topic link icon") [Transact-SQL Syntax Conventions](../../t-sql/language-elements/transact-sql-syntax-conventions-transact-sql.md)  
   


### PR DESCRIPTION
CTE can also be used with MERGE statements.
Following snippet is valid:
```
WITH name_CTE (col1) AS (SELECT col1 FROM table1 WHERE col1 IS NOT NULL)
MERGE table2 AS target USING name_CTE AS source ON (target.col1 = source.col1) WHEN MATCHED THEN UPDATE SET col2 = '1';
```