### PR TITLE
Trivial typo that breaks sample code

### DIFF
--- a/docs/relational-databases/tables/create-foreign-key-relationships.md
+++ b/docs/relational-databases/tables/create-foreign-key-relationships.md
@@ -102,7 +102,8 @@ monikerRange: "=azuresqldb-current||>=sql-server-2016||=sqlallproducts-allversio
         REFERENCES Sales.SalesReason (SalesReasonID)     
         ON DELETE CASCADE    
         ON UPDATE CASCADE    
-    );GO    
+    );
+    GO    
     
     ```    
     


### PR DESCRIPTION
The "GO" statement must be on its own line, at least in SSMS.

    USE AdventureWorks2012;    
    GO    
    CREATE TABLE Sales.TempSalesReason (TempID int NOT NULL, Name nvarchar(50),     
    CONSTRAINT PK_TempSales PRIMARY KEY NONCLUSTERED (TempID),     
    CONSTRAINT FK_TempSales_SalesReason FOREIGN KEY (TempID)     
        REFERENCES Sales.SalesReason (SalesReasonID)     
        ON DELETE CASCADE    
        ON UPDATE CASCADE    
    );GO   

Should be:

    );
    GO