### PR TITLE
Fix markdown syntax highlight in document

### DIFF
--- a/docs/t-sql/statements/set-ansi-nulls-transact-sql.md
+++ b/docs/t-sql/statements/set-ansi-nulls-transact-sql.md
@@ -155,7 +155,7 @@ GO
 Now set ANSI_NULLS to OFF and test.  
 
 ```sql
-PRINT 'Testing SET ANSI_NULLS OFF';  
+PRINT 'Testing ANSI_NULLS OFF';  
 SET ANSI_NULLS OFF;  
 GO  
 DECLARE @varname int;  


### PR DESCRIPTION
Remove SET in print statement to ensure  markdown syntax highlight is working properly.