### PR TITLE
Update AKS version for Cluster Create Command

### DIFF
--- a/docs/linux/sql-server-linux-kubernetes-deploy.md
+++ b/docs/linux/sql-server-linux-kubernetes-deploy.md
@@ -33,7 +33,7 @@ On Kubernetes, the deployment includes a SQL Server operator, the SQL Server con
 > You can use any type of Kubernetes cluster. To create a Kubernetes cluster on Azure Kubernetes Service (AKS), see [Create an AKS cluster](https://docs.microsoft.com/azure/aks/create-cluster).
 > The following script creates a four-node Kubernetes cluster in Azure.
 > ```azure-cli
-> az aks create --resource-group myResourceGroup --name myAKSCluster --node-count 4 --kubernetes-version 1.11.3 --generate-ssh-keys
+> az aks create --resource-group myResourceGroup --name myAKSCluster --node-count 4 --kubernetes-version 1.11.6 --generate-ssh-keys
 > ```
 
 ## Deploy the operator, SQL Server containers, and load-balancing services


### PR DESCRIPTION
The minimum Kubernetes version available in AKS is 1.11.6. I've updated the "az aks create" command to reflect this.