### PR TITLE
Update dbcc-checktable-transact-sql.md

### DIFF
--- a/docs/t-sql/database-console-commands/dbcc-checktable-transact-sql.md
+++ b/docs/t-sql/database-console-commands/dbcc-checktable-transact-sql.md
@@ -46,7 +46,7 @@ DBCC CHECKTABLE
     ]     
 )    
     [ WITH     
-        { ALL_ERRORMSGS ]    
+        { [ ALL_ERRORMSGS ]    
           [ , EXTENDED_LOGICAL_CHECKS ]     
           [ , NO_INFOMSGS ]    
           [ , TABLOCK ]     


### PR DESCRIPTION
A `[` was missing from the syntax diagram.