### PR TITLE
Remove statement about aggregation in XE DMV

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-xe-session-event-actions-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-xe-session-event-actions-transact-sql.md
@@ -24,7 +24,7 @@ manager: craigg
 # sys.dm_xe_session_event_actions (Transact-SQL)
 [!INCLUDE[tsql-appliesto-ss2008-xxxx-xxxx-xxx-md](../../includes/tsql-appliesto-ss2008-xxxx-xxxx-xxx-md.md)]
 
-  Returns information about event session actions. Actions are executed when events are fired. This management view aggregates statistics about the number of times an action has run, and the total run time of the action.  
+  Returns information about event session actions. Actions are executed when events are fired.  
   
 |Column name|Data type|Description|  
 |-----------------|---------------|-----------------|  


### PR DESCRIPTION
There are no aggregations or statistics about runtime duration or execution count in this DMV.  Although it would be cool if there were 😄 

It almost sounds like this is describing the `execution_count` and `execution_duration_ms` columns from [`sys.dm_xe_session_targets`](https://docs.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-xe-session-targets-transact-sql?view=sql-server-2017), but I can't be sure.