### PR TITLE
Add reminder to specify HISTORY_TABLE

### DIFF
--- a/docs/relational-databases/tables/stopping-system-versioning-on-a-system-versioned-temporal-table.md
+++ b/docs/relational-databases/tables/stopping-system-versioning-on-a-system-versioned-temporal-table.md
@@ -58,7 +58,10 @@ DROP PERIOD FOR SYSTEM_TIME;
   
 -   Partition **SWITCH IN** into history table  
   
- This example temporarily stops SYSTEM_VERSIONING to allow you to perform specific maintenance operations. If you stop versioning temporarily as a prerequisite for table maintenance, we strongly recommend doing this inside a transaction to keep data consistency.  
+ This example temporarily stops SYSTEM_VERSIONING to allow you to perform specific maintenance operations. If you stop versioning temporarily as a prerequisite for table maintenance, we strongly recommend doing this inside a transaction to keep data consistency.
+ 
+> [!NOTE]  
+>  When turning system versioning back on, do not forget to specify the HISTORY_TABLE argument.  Failing to do so will result in a new history table being created and associated with the current table.  The original history table will still exist as a normal table, but won't be associated with the current table.  
   
 ```  
 BEGIN TRAN   


### PR DESCRIPTION
This is mentioned on the docs page for [ALTER TABLE](https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-table-transact-sql?view=sql-server-2017):

> If you don't use the HISTORY_TABLE argument, the system generates a new history table matching the schema of the current table, creates a link between the two tables, and enables the system to record the history of each record in the current table in the history table.

I think it warrants calling out here as well: [Stopping System-Versioning on a System-Versioned Temporal Table](https://docs.microsoft.com/en-us/sql/relational-databases/tables/stopping-system-versioning-on-a-system-versioned-temporal-table?view=sql-server-2017)

This came up because of a question on Database Administrators Stack Exchange where someone had lost their history because of disabling and enabling system versioning without specifying the HISTORY_TABLE argument: [SQL Server 2017 - Temporal table issues](https://dba.stackexchange.com/questions/231047/sql-server-2017-temporal-table-issues)

I considered using the "warning" formatting rather than "note," but decided against it since there may be legitimate cases where people want new history tables every time 🤷‍♂️