### PR TITLE
Correct the placement of a ')'

### DIFF
--- a/docs/t-sql/database-console-commands/dbcc-clonedatabase-transact-sql.md
+++ b/docs/t-sql/database-console-commands/dbcc-clonedatabase-transact-sql.md
@@ -52,8 +52,8 @@ DBCC CLONEDATABASE
 (  
     source_database_name
     ,  target_database_name
-    [ WITH { [ NO_STATISTICS ] [ , NO_QUERYSTORE ] [ , VERIFY_CLONEDB | SERVICEBROKER ] [ , BACKUP_CLONEDB ] } ]   
-)  
+)
+    [ WITH { [ NO_STATISTICS ] [ , NO_QUERYSTORE ] [ , VERIFY_CLONEDB | SERVICEBROKER ] [ , BACKUP_CLONEDB ] } ]     
 ```  
   
 ## Arguments  


### PR DESCRIPTION
The placement of `)` in the syntax diagram is incorrect in that it specifies the WITH clause should go between the parenthesis. The WITH clause should be outside of the parenthesis.