### PR TITLE
Change Derived Hierarchies order from Code to ID

### DIFF
--- a/docs/master-data-services/derived-hierarchies-master-data-services.md
+++ b/docs/master-data-services/derived-hierarchies-master-data-services.md
@@ -67,7 +67,7 @@ manager: craigg
  This type of hierarchy prevents you from moving a member to a level that is not valid. For example, you can move the Road-650 bike from one subcategory, Road Bikes, to another, Mountain Bikes. You cannot move Road-650 directly under a category, like 1 {Bikes}. Each time you move a member in the hierarchy tree, the member's domain-based attribute value changes to reflect the move.  
   
 ## Notes  
- All members in a derived hierarchy tree are sorted by code. You cannot change the sort order.  
+ All members in a derived hierarchy tree are sorted by ID. You cannot change the sort order.  
   
  If a member's domain-based attribute is blank and the attribute is used for a derived hierarchy, the member is not displayed in the hierarchy. Create business rules to require attributes to be populated. For more information, see [Require Attribute Values &#40;Master Data Services&#41;](../master-data-services/require-attribute-values-master-data-services.md).  
   


### PR DESCRIPTION
A customer notice that the Derived Hierarchies is order by ID without Code. So I check the currently code and old SQL version code. It seems this is by design. So I changed this document. 