### PR TITLE
removed "with override" from reconfigure statement

### DIFF
--- a/docs/database-engine/configure-windows/view-or-configure-the-backup-compression-default-server-configuration-option.md
+++ b/docs/database-engine/configure-windows/view-or-configure-the-backup-compression-default-server-configuration-option.md
@@ -100,7 +100,7 @@ GO
   
 ```sql  
 EXEC sp_configure 'backup compression default', 1 ;  
-RECONFIGURE WITH OVERRIDE ;  
+RECONFIGURE;  
 GO 
 ```  
   


### PR DESCRIPTION
There is no reason to have the "with override" here, and having it may encourage people to use it everywhere, rather than only when it's necessary. Removed it so we aren't sending the wrong message on how to use the RECONFIGURE WITH OVERRIDE statement.