### PR TITLE
fixed issues with code sample

### DIFF
--- a/docs/t-sql/language-elements/reconfigure-transact-sql.md
+++ b/docs/t-sql/language-elements/reconfigure-transact-sql.md
@@ -58,10 +58,10 @@ RECONFIGURE [ WITH OVERRIDE ]
  RECONFIGURE permissions default to grantees of the ALTER SETTINGS permission. The **sysadmin** and **serveradmin** fixed server roles implicitly hold this permission.    
     
 ## Examples    
- The following example sets the upper limit for the `recovery interval` configuration option to `75` minutes and uses `RECONFIGURE WITH OVERRIDE` to install it. Recovery intervals greater than 60 minutes are not recommended and disallowed by default. However, because the `WITH OVERRIDE` option is specified, [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] does not check whether the value specified (`90`) is a valid value for the `recovery interval` configuration option.    
+ The following example sets the upper limit for the `recovery interval` configuration option to `75` minutes and uses `RECONFIGURE WITH OVERRIDE` to install it. Recovery intervals greater than 60 minutes are not recommended and disallowed by default. However, because the `WITH OVERRIDE` option is specified, [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] does not check whether the value specified (`75`) is a valid value for the `recovery interval` configuration option.    
     
 ```    
-EXEC sp_configure 'recovery interval', 75'    
+EXEC sp_configure 'recovery interval', 75    
 RECONFIGURE WITH OVERRIDE;    
 GO    
 ```    


### PR DESCRIPTION
fixed code sample, removed extra ' at the end of the statement. Updated the example notes to match the code as well. (90 and 75 were mismatched.)