### PR TITLE
Collation improvements: Part 1 of several

### DIFF
--- a/docs/t-sql/functions/collation-functions-collationproperty-transact-sql.md
+++ b/docs/t-sql/functions/collation-functions-collationproperty-transact-sql.md
@@ -24,7 +24,7 @@ monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-s
 # Collation Functions - COLLATIONPROPERTY (Transact-SQL)
 [!INCLUDE[tsql-appliesto-ss2008-all-md](../../includes/tsql-appliesto-ss2008-all-md.md)]
 
-This function returns the property of a specified collation in [!INCLUDE[ssCurrent](../../includes/sscurrent-md.md)].
+This function returns the requested property of a specified collation.
   
 ![Topic link icon](../../database-engine/configure-windows/media/topic-link.gif "Topic link icon") [Transact-SQL Syntax Conventions](../../t-sql/language-elements/transact-sql-syntax-conventions-transact-sql.md)
   
@@ -43,10 +43,10 @@ The collation property. The *property* argument has a **varchar(128)** data type
   
 |Property name|Description|  
 |---|---|
-|**CodePage**|Non-Unicode code page of the collation. See [Appendix G DBCS/Unicode Mapping Tables](https://msdn.microsoft.com/library/cc194886.aspx) and [Appendix H Code Pages](https://msdn.microsoft.com/library/cc195051.aspx) to translate these values, and to see their character mappings.|  
-|**LCID**|Windows LCID of the collation. See [LCID Structure](https://msdn.microsoft.com/library/cc233968.aspx) to translate these values (you will first need to convert to **varbinary**).|  
-|**ComparisonStyle**|Windows comparison style of the collation. Returns 0 for all binary collations - both (\_BIN) and (\_BIN2) - as well as when all properties are case sensitive. Bitmask values:<br /><br /> Ignore case : 1<br /><br /> Ignore accent : 2<br /><br /> Ignore Kana : 65536<br /><br /> Ignore width : 131072<br /><br /> Note: the variation-selector-sensitive (\_VSS) option is not represented in this value, even though it affects the comparison behavior.|  
-|**Version**|The version of the collation, derived from the collation ID version field. Returns an integer value between 0 and 3.<br /><br /> Collations with "140" in the name return 3.<br /><br /> Collations with "100" in the name return 2.<br /><br /> Collations with "90" in the name return 1.<br /><br /> All other collations return 0.|  
+|**CodePage**|Non-Unicode code page of the collation. This is the character set used for **varchar** data. See [Appendix G DBCS/Unicode Mapping Tables](https://msdn.microsoft.com/library/cc194886.aspx) and [Appendix H Code Pages](https://msdn.microsoft.com/library/cc195051.aspx) to translate these values, and to see their character mappings.<br /><br />Base data type: **int**|  
+|**LCID**|Windows locale ID of the collation. This is the culture used for sorting and comparison rules. See [LCID Structure](https://msdn.microsoft.com/library/cc233968.aspx) to translate these values (you will first need to convert to **varbinary**).<br /><br />Base data type: **int**|  
+|**ComparisonStyle**|Windows comparison style of the collation. Returns 0 for binary collations - both (\_BIN) and (\_BIN2) - as well as when all properties are sensitive - (\_CS\_AS\_KS\_WS) and (\_CS\_AS\_KS\_WS\_SC) and (\_CS\_AS\_KS\_WS\_VSS). Bitmask values:<br /><br /> Ignore case : 1<br /><br /> Ignore accent : 2<br /><br /> Ignore Kana : 65536<br /><br /> Ignore width : 131072<br /><br /> Note: the variation-selector-sensitive (\_VSS) option is not represented in this value, even though it affects the comparison behavior.<br /><br />Base data type: **int**|  
+|**Version**|The version of the collation. Returns a value between 0 and 3.<br /><br /> Collations with "140" in the name return 3.<br /><br /> Collations with "100" in the name return 2.<br /><br /> Collations with "90" in the name return 1.<br /><br /> All other collations return 0.<br /><br />Base data type: **tinyint**|  
   
 ## Return types
 **sql_variant**


### PR DESCRIPTION
This is the first in a series of PRs to correct and/or complete various pages related to collations and/or Unicode support. Some of the pages, such as the one for Windows Collations, were missing updates starting with SQL Server 2012.

The two pages updated in this PR will be updated again, sometime soon, to include the new UTF-8 collations introduced in SQL Server 2019.

### COLLATIONPROPERTY

1. Removed SQL Server version number from intro / summary. Behavior of this function does not vary between versions of SQL Server.

2. Improved wording of "LCID" definition: Defining LCID as LCID didn't give the reader any new information.

3. Improved wording of "Comparison" definition: A) Removed the word "case" (added by @fbsolo on 2018-04-23 via PR #566 ) as it should not have been added. Properties cannot be case-sensitive. "Case" is a property that can be either sensitive or insensitive. B) added collation variations that have all sensitivities enabled. Unique variations for "everything-sensitive" collations found using the following query:

    ```sql
    SELECT DISTINCT
           SUBSTRING(col.[name], PATINDEX(N'%[_][BC][IS]%', col.[name]), 100) AS [Sensitivities]
    FROM   sys.fn_helpcollations() col
    WHERE  CONVERT(INT, COLLATIONPROPERTY(col.[name], N'ComparisonStyle')) = 0
    ORDER BY [Sensitivities];
    /*
    _BIN
    _BIN2
    _CS_AS_KS_WS
    _CS_AS_KS_WS_SC
    _CS_AS_KS_WS_VSS
    */
    ```

4. Improved wording of "Version" definition. The "derived from the collation ID version field" clause is awkward and has meaning to so few people that it really just confuses people. 

5. Added "Base data type" to each property (based on format use in ( https://docs.microsoft.com/en-us/sql/t-sql/functions/serverproperty-transact-sql ). Data types discovered using the following query:

    ```sql
    SELECT SQL_VARIANT_PROPERTY(COLLATIONPROPERTY(N'Hebrew_100_CS_AS', N'CodePage'),
                                'basetype'),
           SQL_VARIANT_PROPERTY(COLLATIONPROPERTY(N'Hebrew_100_CS_AS', N'LCID'),
                                'basetype'),
           SQL_VARIANT_PROPERTY(COLLATIONPROPERTY(N'Hebrew_100_CS_AS', N'ComparisonStyle'),
                                'basetype'),
           SQL_VARIANT_PROPERTY(COLLATIONPROPERTY(N'Hebrew_100_CS_AS', N'Version'),
                                'basetype');
    -- int    int    int    tinyint
    ```

TO DO:
1. Update "CodePage" definition to account for UTF-8
2. Update "ComparisonStyle" definition to acknowledge that \_SC and \_UTF8 options are not included in this property.

### Windows Collations

1. Added **\_VariationSelectorSensitive** property (introduced in SQL Server 2017)

2. Changed wording related to code pages to be "**varchar**" instead of  "non-Unicode" since new UTF-8 collations in SQL Server 2019 use code page 65001 but are clearly not "non-Unicode" (this change will need to be made on several pages).

3. Better formatting in section describing the various sensitivities.

4. Updated wording and example code in **Remarks** section to make it clear that "undefined" in a particular collation does _not_ mean that the character does not exist.

5. Updated example Windows collations for correctness, consistency, and variety.

6.  Minor improvements to query to find Windows collations

TO DO:
1. Add info about \_SC collations (introduced in SQL Server 2012)
2. Add info about \_UTF8 collations (introduced in SQL Server 2019)
3. Add info about collation version numbers (is in some places, but not everywhere it should be ; introduced in SQL Server 2005)
All of that is waiting until binary UTF-8 collation(s) are settled as the introduction of it (so far `UTF8_BIN2`) changes the syntax description quite a bit, and will require careful thought about new wording since neither version number, nor \_SC, nor \_UTF8 apply to "CollationDesignator" or "&lt;ComparisonStyle&gt;".
