### PR TITLE
Update dma commandline doc

### DIFF
--- a/docs/dma/dma-commandline.md
+++ b/docs/dma/dma-commandline.md
@@ -29,6 +29,7 @@ With version 2.1 and above, when you install Data Migration Assistant, it will a
 ```
 DmaCmd.exe /AssessmentName="string"
 /AssessmentDatabases="connectionString1" \["connectionString2"\]
+\[/AssessmentSourcePlatform="SourcePlatform"]
 \[/AssessmentTargetPlatform="TargetPlatform"\]
 /AssessmentEvaluateRecommendations|/AssessmentEvaluateCompatibilityIssues
 \[/AssessmentOverwriteResult\]
@@ -40,8 +41,9 @@ DmaCmd.exe /AssessmentName="string"
 | `/help or /?`     | How to use dmacmd.exe help text        | N
 |`/AssessmentName`     |   Name of the assessment project   | Y
 |`/AssessmentDatabases`     | Space-delimited list of connection strings. Database name (Initial Catalog) is case-sensitive. | Y
-|`/AssessmentTargetPlatform`     | Target platform for the assessment, supported values: AzureSqlDatabase, ManagedSqlServer, SqlServer2012, SqlServer2014, SqlServer2016, SqlServerLinux2017 and SqlServerWindows2017. Default is SqlServerWindows2017   | N
-|`/AssessmentEvaluateFeatureParity`  | Run feature parity rules  | N
+|`/AssessmentSourcePlatform`     | Source platform for the assessment, supported values: SqlOnPrem, RdsSqlServer. Target Readiness Assessment also support Cassandra as source platform. Default is SqlOnPrem   | N
+|`/AssessmentTargetPlatform`     | Target platform for the assessment, supported values: AzureSqlDatabase, ManagedSqlServer, SqlServer2012, SqlServer2014, SqlServer2016, SqlServerLinux2017 and SqlServerWindows2017. Target Readiness Assessment also support CosmosDB as target platform. Default is SqlServerWindows2017   | N
+|`/AssessmentEvaluateFeatureParity`  | Run feature parity rules. If source platform is RdsSqlServer, feature parity evaluation is not supported for target platform AzureSqlDatabase  | N
 |`/AssessmentEvaluateCompatibilityIssues`     | Run compatibility rules  | Y <br> (Either AssessmentEvaluateCompatibilityIssues or AssessmentEvaluateRecommendations is required.)
 |`/AssessmentEvaluateRecommendations`     | Run feature recommendations        | Y <br> (Either AssessmentEvaluateCompatibilityIssues or AssessmentEvaluateRecommendationsis required)
 |`/AssessmentOverwriteResult`     | Overwrite the result file    | N
@@ -105,6 +107,34 @@ Catalog=DatabaseName;Integrated Security=true"
 /AssessmentResultJson="C:\\temp\\AssessmentReport.json"
 ```
 
+**Single-database assessment for source platform SQL Server and target platform SQL Azure Database, save results to .json and .csv file**
+
+```
+DmaCmd.exe /AssessmentName="TestAssessment" 
+/AssessmentDatabases="Server=SQLServerInstanceName;Initial
+Catalog=DatabaseName;Integrated Security=true"
+/AssessmentSourcePlatform="SqlOnPrem" 
+/AssessmentTargetPlatform="AzureSqlDatabaseV12"
+/AssessmentEvaluateCompatibilityIssues /AssessmentEvaluateFeatureParity
+/AssessmentOverwriteResult 
+/AssessmentResultCsv="C:\\temp\\AssessmentReport.csv" 
+/AssessmentResultJson="C:\\temp\\AssessmentReport.json"
+```
+
+**Single-database assessment for source platform RDS SQL Server and target platform SQL Azure Database, save results to .json and .csv file**
+
+```
+DmaCmd.exe /AssessmentName="TestAssessment" 
+/AssessmentDatabases="Server=SQLServerInstanceName;Initial
+Catalog=DatabaseName;Integrated Security=true"
+/AssessmentSourcePlatform="RdsSqlServer"
+/AssessmentTargetPlatform="AzureSqlDatabaseV12"
+/AssessmentEvaluateCompatibilityIssues /AssessmentEvaluateFeatureParity
+/AssessmentOverwriteResult 
+/AssessmentResultCsv="C:\\temp\\AssessmentReport.csv" 
+/AssessmentResultJson="C:\\temp\\AssessmentReport.json"
+```
+
 **Multiple-database assessment**
 
 ```
@@ -157,10 +187,13 @@ DmaCmd.exe /Action=AssessTargetReadiness
 ```
 DmaCmd.exe /Action=AssessTargetReadiness 
 /AssessmentName="TestAssessment" 
+/AssessmentSourcePlatform=SourcePlatform
+/AssessmentTargetPlatform=TargetPlatform
 /SourceConnections="Server=SQLServerInstanceName;Integrated Security=true" 
 /AssessmentOverwriteResult 
 /AssessmentResultJson="C:\temp\Results\AssessmentReport.json"
 
+/AssessmentSourcePlatform and /AssessmentTargetPlatform are optional.
 ```
 
 **Target Readiness assessment by importing feature discovery report created earlier**
@@ -186,6 +219,8 @@ Configuration file contents when using source connections:
 <?xml version="1.0" encoding="utf-8" ?>
 <TargetReadinessConfiguration xmlns="http://microsoft.com/schemas/SqlServer/Advisor/TargetReadinessConfiguration">
   <AssessmentName>name</AssessmentName>
+  <SourcePlatform>source platform</SourcePlatform> <!-- optional. The default is SqlOnPrem-->
+  <TargetPlatform>target platform</TargetPlatform> <!-- optional. The defatul is ManagedSqlServer>
   <SourceConnections>
     <SourceConnection>connection string 1</SourceConnection>
     <SourceConnection>connection string 2</SourceConnection>

--- a/docs/dma/dma-commandline.md
+++ b/docs/dma/dma-commandline.md
@@ -219,8 +219,8 @@ Configuration file contents when using source connections:
 <?xml version="1.0" encoding="utf-8" ?>
 <TargetReadinessConfiguration xmlns="http://microsoft.com/schemas/SqlServer/Advisor/TargetReadinessConfiguration">
   <AssessmentName>name</AssessmentName>
-  <SourcePlatform>source platform</SourcePlatform> <!-- optional. The default is SqlOnPrem-->
-  <TargetPlatform>target platform</TargetPlatform> <!-- optional. The defatul is ManagedSqlServer>
+  <SourcePlatform>source platform</SourcePlatform> <!-- optional. The default is SqlOnPrem -->
+  <TargetPlatform>target platform</TargetPlatform> <!-- optional. The defatul is ManagedSqlServer -->
   <SourceConnections>
     <SourceConnection>connection string 1</SourceConnection>
     <SourceConnection>connection string 2</SourceConnection>


### PR DESCRIPTION
Assessment command line supports RDS assessment. The command line add /AssessmentSourcePlatform setting input.

Target Readiness Assessment support RDS and Cassandra assessment. The command line add /AssessmentSourcePlatform and /AssessmentTargetPlatform. In config file, add <SourcePlatform> and <TargetPlatform> element.