### PR TITLE
Remove lone quote & use conventional italics

### DIFF
--- a/docs/relational-databases/system-stored-procedures/filestream-and-filetable-sp-filestream-force-garbage-collection.md
+++ b/docs/relational-databases/system-stored-procedures/filestream-and-filetable-sp-filestream-force-garbage-collection.md
@@ -37,7 +37,7 @@ sp_filestream_force_garbage_collection
 ```  
   
 ## Arguments  
- **@dbname** = _database_name_**'**  
+ **@dbname** = *database_name*
  Signifies the name of the database to run the garbage collector on.  
   
 > [!NOTE]  


### PR DESCRIPTION
Currently this is rendering as ([link](https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/filestream-and-filetable-sp-filestream-force-garbage-collection?view=sql-server-2017#arguments)):

![image](https://user-images.githubusercontent.com/441085/54144171-8e9fbc80-4401-11e9-8c03-554af9966dfd.png)

This might also fix the subsequently messed up bolding syntax, although not sure about that