### PR TITLE
Update QDS metrics that now apply to on-prem

### DIFF
--- a/docs/relational-databases/system-catalog-views/sys-query-store-runtime-stats-transact-sql.md
+++ b/docs/relational-databases/system-catalog-views/sys-query-store-runtime-stats-transact-sql.md
@@ -83,11 +83,11 @@ monikerRange: "=azuresqldb-current||>=sql-server-2016||=sqlallproducts-allversio
 |**min_rowcount**|**bigint**|Minimum number of returned rows for the query plan within the aggregation interval.<br/>**Note:** Azure SQL Data Warehouse will always return zero (0).|
 |**max_rowcount**|**bigint**|Maximum number of returned rows for the query plan within the aggregation interval.|  
 |**stdev_rowcount**|**float**|Number of returned rows standard deviation for the query plan within the aggregation interval.|
-|**avg_log_bytes_used**|**float**|Average number of bytes in the database log used by the query plan, within the aggregation interval. Applies **only to Azure SQL Database**.<br/>**Note:** Azure SQL Data Warehouse will always return zero (0).|
-|**last_log_bytes_used**|**bigint**|Number of bytes in the database log used by the last execution of the query plan, within the aggregation interval. Applies **only to Azure SQL Database**.<br/>**Note:** Azure SQL Data Warehouse will always return zero (0).|
-|**min_log_bytes_used**|**bigint**|Minimum number of bytes in the database log used by the query plan, within the aggregation interval.  Applies **only to Azure SQL Database**.<br/>**Note:** Azure SQL Data Warehouse will always return zero (0).|
-|**max_log_bytes_used**|**bigint**|Maximum number of bytes in the database log used by the query plan, within the aggregation interval.  Applies **only to Azure SQL Database**.<br/>**Note:** Azure SQL Data Warehouse will always return zero (0).|
-|**stdev_log_bytes_used**|**float**|Standard deviation of the number of bytes in the database log used by a query plan, within the aggregation interval.  Applies **only to Azure SQL Database**.<br/>**Note:** Azure SQL Data Warehouse will always return zero (0).|
+|**avg_log_bytes_used**|**float**|Average number of bytes in the database log used by the query plan, within the aggregation interval.<br/>**Note:** Azure SQL Data Warehouse will always return zero (0).|
+|**last_log_bytes_used**|**bigint**|Number of bytes in the database log used by the last execution of the query plan, within the aggregation interval.<br/>**Note:** Azure SQL Data Warehouse will always return zero (0).|
+|**min_log_bytes_used**|**bigint**|Minimum number of bytes in the database log used by the query plan, within the aggregation interval.<br/>**Note:** Azure SQL Data Warehouse will always return zero (0).|
+|**max_log_bytes_used**|**bigint**|Maximum number of bytes in the database log used by the query plan, within the aggregation interval.<br/>**Note:** Azure SQL Data Warehouse will always return zero (0).|
+|**stdev_log_bytes_used**|**float**|Standard deviation of the number of bytes in the database log used by a query plan, within the aggregation interval.<br/>**Note:** Azure SQL Data Warehouse will always return zero (0).|
   
 ## Permissions  
  Requires the **VIEW DATABASE STATE** permission.  


### PR DESCRIPTION
The "*_log_bytes_used" columns in `sys.query_store_runtime_stats` appear to work correctly in SQL Server 2017 on-prem, so I've removed the "applies only to Azure" bit.

You can find a repro of those columns being populated here: https://dba.stackexchange.com/questions/231682/what-is-log-memory-in-query-store-2017