### PR TITLE
Fixed table formatting in markdown.

### DIFF
--- a/docs/relational-databases/replication/non-sql/configure-an-oracle-publisher.md
+++ b/docs/relational-databases/replication/non-sql/configure-an-oracle-publisher.md
@@ -31,6 +31,7 @@ manager: craigg
 -   Publishing data from [!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)] to non-[!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)] Subscribers.  
 
 -   Publishing data to and from Oracle has the following restrictions:  
+
   | |2016 or earlier |2017 or later |
   |-------|-------|--------|
   |Replication from Oracle |Only support Oracle 10g or earlier |Only support Oracle 10g or earlier |

--- a/docs/relational-databases/replication/non-sql/heterogeneous-database-replication.md
+++ b/docs/relational-databases/replication/non-sql/heterogeneous-database-replication.md
@@ -24,6 +24,7 @@ manager: craigg
 -   Publishing data from [!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)] to non-[!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)] Subscribers.  
 
 -   Publishing data to and from Oracle has the following restrictions:  
+
   | |2016 or earlier |2017 or later |
   |-------|-------|--------|
   |Replication from Oracle |Only support Oracle 10g or earlier |Only support Oracle 10g or earlier |


### PR DESCRIPTION
The file `configure-an-oracle-publisher.md` had an error where the table was not formatted correctly because of a missing newline character.