### PR TITLE
Need some fix for versions

### DIFF
--- a/docs/advanced-analytics/install/sql-ml-cab-downloads.md
+++ b/docs/advanced-analytics/install/sql-ml-cab-downloads.md
@@ -86,10 +86,11 @@ For SQL Server 2016 R Services, baseline releases are either the RTM version or 
 
 |Release  |Download link  |
 |---------|---------------|
-|**SQL Server 2016 SP2 CU1-CU2**     |
-|Microsoft R Open     |[SRO_3.2.2.20000_1033.cab](https://go.microsoft.com/fwlink/?LinkId=866039)|
+|**SQL Server 2016 SP2 CU1-CU4**     |
+|Microsoft R Open     |[SRO_3.2.2.16000_1033.cab](https://go.microsoft.com/fwlink/?LinkId=836819)|
 |Microsoft R Server    |[SRS_8.0.3.20000_1033.cab](https://go.microsoft.com/fwlink/?LinkId=866038)|
 |**SQL Server 2016 SP1 CU4-CU10**     |
+|**SQL Server 2016 SP2**     |
 |Microsoft R Open     |[SRO_3.2.2.16000_1033.cab](https://go.microsoft.com/fwlink/?LinkId=836819)|
 |Microsoft R Server    |[SRS_8.0.3.17000_1033.cab](https://go.microsoft.com/fwlink/?LinkId=850317)|
 |**SQL Server 2016 SP1 CU1-CU3**     |


### PR DESCRIPTION
It is missin SQL Server 2006 SP2, and for SQL Server 2016 SP2 CU1 - CU2, for CU 4 and CU5 reference the same file, so I add CU5.

Moreover, when I download SRO_3.2.2.20000_1033.cab, the file name is SRO_3.2.2.16000_1033.cab. 
Also, the link ID 866039 is not referenced by the setups instead setups are referencing 836819.

You also need to change it on following Docs;
https://docs.microsoft.com/en-us/sql/advanced-analytics/install/sql-ml-component-install-without-internet-access?view=sql-server-2017