### PR TITLE
docs: fix readability

### DIFF
--- a/docs/relational-databases/xml/example-constructing-siblings-with-explicit-mode.md
+++ b/docs/relational-databases/xml/example-constructing-siblings-with-explicit-mode.md
@@ -79,31 +79,21 @@ FOR XML EXPLICIT;
   
  This is the partial result:  
   
- `<OrderHeader SalesOrderID="43659" OrderDate="2005-07-01T00:00:00" CustomerID="676">`  
-  
- `<SalesPerson SalesPersonID="279" />`  
-  
- `<OrderDetail SalesOrderID="43659" LineTotal="10.373000" ProductID="712" OrderQty="2" />`  
-  
- `<OrderDetail SalesOrderID="43659" LineTotal="28.840400" ProductID="716" OrderQty="1" />`  
-  
- `<OrderDetail SalesOrderID="43659" LineTotal="34.200000" ProductID="709" OrderQty="6" />`  
-  
- `...`  
-  
- `</OrderHeader>`  
-  
- `<OrderHeader SalesOrderID="43661" OrderDate="2005-07-01T00:00:00" CustomerID="442">`  
-  
- `<SalesPerson SalesPersonID="282" />`  
-  
- `<OrderDetail SalesOrderID="43661" LineTotal="20.746000" ProductID="712" OrderQty="4" />`  
-  
- `<OrderDetail SalesOrderID="43661" LineTotal="40.373000" ProductID="711" OrderQty="2" />`  
-  
- `...`  
-  
- `</OrderHeader>`  
+```
+<OrderHeader SalesOrderID="43659" OrderDate="2005-07-01T00:00:00" CustomerID="676">
+  <SalesPerson SalesPersonID="279" />
+  <OrderDetail SalesOrderID="43659" LineTotal="10.373000" ProductID="712" OrderQty="2" />
+  <OrderDetail SalesOrderID="43659" LineTotal="28.840400" ProductID="716" OrderQty="1" />
+  <OrderDetail SalesOrderID="43659" LineTotal="34.200000" ProductID="709" OrderQty="6" />
+    ...
+</OrderHeader>
+<OrderHeader SalesOrderID="43661" OrderDate="2005-07-01T00:00:00" CustomerID="442">
+  <SalesPerson SalesPersonID="282" />
+  <OrderDetail SalesOrderID="43661" LineTotal="20.746000" ProductID="712" OrderQty="4" />
+  <OrderDetail SalesOrderID="43661" LineTotal="40.373000" ProductID="711" OrderQty="2" />
+  ...
+</OrderHeader>
+```
   
 ## See Also  
  [Use EXPLICIT Mode with FOR XML](../../relational-databases/xml/use-explicit-mode-with-for-xml.md)  


### PR DESCRIPTION
Changes the xml example into a code block instead of separate lines.