### PR TITLE
Fix "applies to" for sp_wait_for_database_copy_sync

### DIFF
--- a/docs/relational-databases/system-stored-procedures/active-geo-replication-sp-wait-for-database-copy-sync.md
+++ b/docs/relational-databases/system-stored-procedures/active-geo-replication-sp-wait-for-database-copy-sync.md
@@ -19,7 +19,7 @@ manager: craigg
 monikerRange: "=azuresqldb-current||>=sql-server-2016||=sqlallproducts-allversions||>=sql-server-linux-2017||=azuresqldb-mi-current"
 ---
 # Active Geo-Replication - sp_wait_for_database_copy_sync
-[!INCLUDE[tsql-appliesto-ss2016-asdb-xxxx-xxx-md](../../includes/tsql-appliesto-ss2016-asdb-xxxx-xxx-md.md)]
+[!INCLUDE[tsql-appliesto-xxxxxx-asdb-xxxx-xxx-md](../../includes/tsql-appliesto-xxxxxx-asdb-xxxx-xxx-md.md)]
 
   This procedure is scoped to an [!INCLUDE[ssGeoDR](../../includes/ssgeodr-md.md)] relationship between a primary and secondary. Calling the **sp_wait_for_database_copy_sync** causes the application to wait until all committed transactions are replicated and acknowledged by the active secondary database. Run **sp_wait_for_database_copy_sync** on only the primary database.  
   


### PR DESCRIPTION
`sp_wait_for_database_copy_sync` is only available on Azure SQL DB, but the documentation currently shows support in SQL Server 2016+. This change includes the appropriate file to accurately reflect support for the stored procedure.