### PR TITLE
Add missing limitation in sp_describe_undeclared_parameters

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-describe-undeclared-parameters-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-describe-undeclared-parameters-transact-sql.md
@@ -97,6 +97,8 @@ sp_describe_undeclared_parameters
 -   If the input [!INCLUDE[tsql](../../includes/tsql-md.md)] batch declares a local variable of the same name as a parameter declared in \@params.  
   
 - If the statement references temporary tables.
+
+- The query includes the creation of a permanent table that is then queried.
   
  If \@tsql has no parameters, other than those declared in \@params, the procedure returns an empty result set.  
   


### PR DESCRIPTION
The limitations for `sp_describe_undeclared_parameters` are the same as for `sp_describe_first_result_set` and this limitation is missing here.