### PR TITLE
fixed a bad alias that gave wrong [Parameter-Name]

### DIFF
--- a/docs/relational-databases/extended-events/selects-and-joins-from-system-views-for-extended-events-in-sql-server.md
+++ b/docs/relational-databases/extended-events/selects-and-joins-from-system-views-for-extended-events-in-sql-server.md
@@ -246,7 +246,7 @@ SELECT
 		s.name              AS [Session-Name],
 		'3_EVENT_ACTION'    AS [Clause-Type],
 
-		e.package + '.' + a.name
+		a.package + '.' + a.name
 		                    AS [Parameter-Name],
 
 		'(Not_Applicable)'  AS [Parameter-Value]


### PR DESCRIPTION
The extended event action join was referencing the event package and not the action package, which is different then what you get when you script out the extended event.