### PR TITLE
Correcting language

### DIFF
--- a/docs/t-sql/functions/error-procedure-transact-sql.md
+++ b/docs/t-sql/functions/error-procedure-transact-sql.md
@@ -43,7 +43,7 @@ ERROR_PROCEDURE ( )
 **nvarchar(128)**  
   
 ## Return Value  
-When called in a stored procedure CATCH block where an error occurs, `ERROR_PROCEDURE` returns the name of that stored procedure.  
+When called in a CATCH block, `ERROR_PROCEDURE` returns the name of the stored procedure in which the error originated.  
   
 `ERROR_PROCEDURE` returns NULL if the error did not occur within a stored procedure or trigger.  
   

--- a/docs/t-sql/functions/error-procedure-transact-sql.md
+++ b/docs/t-sql/functions/error-procedure-transact-sql.md
@@ -43,7 +43,7 @@ ERROR_PROCEDURE ( )
 **nvarchar(128)**  
   
 ## Return Value  
-When called in a CATCH block, `ERROR_PROCEDURE` returns the name of the stored procedure in which the error originated.  
+When called within a CATCH block in a stored procedure or trigger, `ERROR_PROCEDURE` returns the name of the stored procedure or trigger in which the error originated. 
   
 `ERROR_PROCEDURE` returns NULL if the error did not occur within a stored procedure or trigger.  
   


### PR DESCRIPTION
The existing language suggests 1) that ERROR_PROCEDURE can only be called in a stored procedure, and 2) that it always returns the name of the current procedure.