### PR TITLE
Add documentation to install SQL Server on Linux (Debian based distribution)

### DIFF
--- a/docs/linux/quickstart-install-connect-debian.md
+++ b/docs/linux/quickstart-install-connect-debian.md
@@ -1,0 +1,152 @@
+---
+title: Get started with SQL Server on Debian
+titleSuffix: SQL Server
+description: This quickstart shows how to install SQL Server 2017 or SQL Server 2019 on Debian 9 and then create and query a database with sqlcmd.
+author: ChristianGrimberg
+ms.author:
+manager:
+ms.date: 04/02/2019
+ms.topic: conceptual
+ms.prod: sql
+ms.custom: "sql-linux, seodec18"
+ms.technology: linux
+ms.assetid:
+---
+# Quickstart: Install SQL Server and create a database on Debian
+[!INCLUDE[appliesto-ss-xxxx-xxxx-xxx-md-linuxonly](../includes/appliesto-ss-xxxx-xxxx-xxx-md-linuxonly.md)]
+
+
+<!--SQL Server 2017 on Linux-->
+::: moniker range="= sql-server-linux-2017 || = sql-server-2017"
+
+In this quickstart, you install SQL Server 2017 or SQL Server 2019 preview on Debian 9. You then connect with **sqlcmd** to create your first database and run queries.
+
+::: moniker-end
+<!--SQL Server 2019 on Linux-->
+::: moniker range=">= sql-server-linux-ver15 || >= sql-server-ver15 || =sqlallproducts-allversions"
+
+In this quickstart, you install SQL Server 2019 preview on Debian 9. You then connect with **sqlcmd** to create your first database and run queries.
+
+::: moniker-end
+
+> [!TIP]
+> This tutorial requires user input and an internet connection. If you are interested in the [unattended](sql-server-linux-setup.md#unattended) or [offline](sql-server-linux-setup.md#offline) installation procedures, see [Installation guidance for SQL Server on Linux](sql-server-linux-setup.md).
+
+## Prerequisites
+
+You must have a Debian 9 machine with **at least 2 GB** of memory.
+
+To install Debian 9 on your own machine, go to [https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/](https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/). You can also create Ubuntu virtual machines in Azure. See [Create and Manage Linux VMs with the Azure CLI](https://docs.microsoft.com/azure/virtual-machines/linux/tutorial-manage-vm).
+
+> [!NOTE]
+> At this time, the [Windows Subsystem for Linux](https://msdn.microsoft.com/commandline/wsl/about) for Windows 10 is not supported as an installation target.
+
+For other system requirements, see [System requirements for SQL Server on Linux](sql-server-linux-setup.md#system).
+
+<!--SQL Server 2017 on Linux-->
+::: moniker range="= sql-server-linux-2017 || = sql-server-2017"
+
+## <a id="install"></a>Install SQL Server
+
+To configure SQL Server on Ubuntu, run the following commands in a terminal to install the **mssql-server** package.
+
+1. Import the public repository GPG keys:
+
+   ```bash
+   wget -qO- https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+   ```
+
+2. Register the Microsoft SQL Server Ubuntu repository:
+
+   ```bash
+   curl https://packages.microsoft.com/config/ubuntu/16.04/mssql-server-2017.list | sudo tee /etc/apt/sources.list.d/mssql-server.list
+   ```
+
+   > [!TIP]
+   > If you want to try SQL Server 2019 , you must instead register the **Preview (2019)** repository. Use the following command for SQL Server 2019 installations:
+   >
+   > ```bash
+   > curl https://packages.microsoft.com/config/ubuntu/16.04/mssql-server-preview.list | sudo tee /etc/apt/sources.list.d/mssql-server-preview.list
+   > ```
+
+3. Run the following commands to install SQL Server:
+
+   ```bash
+   sudo apt-get update
+   sudo apt-get install mssql-server -y
+   ```
+
+4. After the package installation finishes, run **mssql-conf setup** and follow the prompts to set the SA password and choose your edition.
+
+   ```bash
+   sudo /opt/mssql/bin/mssql-conf setup
+   ```
+
+   > [!TIP]
+   > The following SQL Server 2017 editions are freely licensed: Evaluation, Developer, and Express.
+
+   > [!NOTE]
+   > Make sure to specify a strong password for the SA account (Minimum length 8 characters, including uppercase and lowercase letters, base 10 digits and/or non-alphanumeric symbols).
+
+5. Once the configuration is done, verify that the service is running:
+
+   ```bash
+   systemctl status mssql-server
+   ```
+
+6. If you plan to connect remotely, you might also need to open the SQL Server TCP port (default 1433) on your firewall.
+
+At this point, SQL Server is running on your Ubuntu machine and is ready to use!
+
+::: moniker-end
+<!--SQL Server 2019 on Linux-->
+::: moniker range=">= sql-server-linux-ver15 || >= sql-server-ver15 || =sqlallproducts-allversions"
+
+## <a id="tools"></a>Install the SQL Server command-line tools
+
+To create a database, you need to connect with a tool that can run Transact-SQL statements on the SQL Server. The following steps install the SQL Server command-line tools: [sqlcmd](../tools/sqlcmd-utility.md) and [bcp](../tools/bcp-utility.md).
+
+Use the following steps to install the **mssql-tools** on Ubuntu. 
+
+1. Import the public repository GPG keys:
+
+   ```bash
+   wget -qO- https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+   ```
+
+2. Register the Microsoft SQL Server Ubuntu repository:
+
+   ```bash
+   curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | sudo tee /etc/apt/sources.list.d/msprod.list
+   ```
+
+3. Update the sources list and run the installation command with the unixODBC developer package.
+
+   ```bash
+   sudo apt-get update 
+   sudo apt-get install mssql-tools unixodbc-dev
+   ```
+
+   > [!Note] 
+   > To update to the latest version of **mssql-tools** run the following commands:
+   >    ```bash
+   >   sudo apt-get update 
+   >   sudo apt-get install mssql-tools 
+   >   ```
+
+4. **Optional**: Add `/opt/mssql-tools/bin/` to your **PATH** environment variable in a bash shell.
+
+   To make **sqlcmd/bcp** accessible from the bash shell for login sessions, modify your **PATH** in the **~/.bash_profile** file with the following command:
+
+   ```bash
+   echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile
+   ```
+
+   To make **sqlcmd/bcp** accessible from the bash shell for interactive/non-login sessions, modify the **PATH** in the **~/.bashrc** file with the following command:
+
+   ```bash
+   echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
+   source ~/.bashrc
+   ```
+
+[!INCLUDE [Connect, create, and query data](../includes/sql-linux-quickstart-connect-query.md)]


### PR DESCRIPTION
Hello and nice to meet you.

I write this documentation to install SQL Server in Linux into Debian based distributions.
> I copy the content of the documentation of Ubuntu instalation guide, and changes the comands (_there are some changes_) and I change each point from Ubuntu to Debian 9 reference.

I hope you check this before, and please share with all the community.

> Thanks for all, and sorry for my english :pray: 
> Microsoft :heart: Linux and SQL Server Rocks :muscle: