### PR TITLE
add FCI requirements for domain joined cluster

### DIFF
--- a/docs/sql-server/failover-clusters/install/before-installing-failover-clustering.md
+++ b/docs/sql-server/failover-clusters/install/before-installing-failover-clustering.md
@@ -140,6 +140,12 @@ manager: craigg
 -   Review content in [Security Considerations for a SQL Server Installation](../../../sql-server/install/security-considerations-for-a-sql-server-installation.md).  
   
 -   To enable Kerberos authentication with [!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)], see [How to use Kerberos authentication in SQL Server](https://support.microsoft.com/kb/319723) in the [!INCLUDE[msCoName](../../../includes/msconame-md.md)] Knowledge Base.  
+
+-   SQL Server failover cluster instance requires the cluster nodes to be domain joined.
+    1.	SQL FCI on workgroup clusters is not supported. 
+    2.	SQL FCI on Multi-Domain cluster is also not supported.  
+    3.	SQL FCI on Domain + Workgroup Clusters is not supported.
+
   
 ##  <a name="Network"></a> Review Network, Port, and Firewall Considerations  
   

--- a/docs/sql-server/failover-clusters/install/before-installing-failover-clustering.md
+++ b/docs/sql-server/failover-clusters/install/before-installing-failover-clustering.md
@@ -141,10 +141,10 @@ manager: craigg
   
 -   To enable Kerberos authentication with [!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)], see [How to use Kerberos authentication in SQL Server](https://support.microsoft.com/kb/319723) in the [!INCLUDE[msCoName](../../../includes/msconame-md.md)] Knowledge Base.  
 
--   SQL Server failover cluster instance requires the cluster nodes to be domain joined.
-    1.	SQL FCI on workgroup clusters is not supported. 
-    2.	SQL FCI on Multi-Domain cluster is also not supported.  
-    3.	SQL FCI on Domain + Workgroup Clusters is not supported.
+-   SQL Server failover cluster instance (FCI) requires the cluster nodes to be domain joined. The following configurations are **not supported**: 
+    *	SQL FCI on workgroup clusters. 
+    *	SQL FCI on Multi-Domain cluster.   
+    *	SQL FCI on Domain + Workgroup Clusters. 
 
   
 ##  <a name="Network"></a> Review Network, Port, and Firewall Considerations  


### PR DESCRIPTION
Per discussion with Sourabh Agarwal we need to document the domain join vs workgroup cluster requirement for SQL FCI.
Adding the following statement:
-   SQL Server failover cluster instance requires the cluster nodes to be domain joined.
    1.	SQL FCI on workgroup clusters is not supported. 
    2.	SQL FCI on Multi-Domain cluster is also not supported.  
    3.	SQL FCI on Domain + Workgroup Clusters is not supported.