### PR TITLE
Update to meta failure-timeout=60s when creating cluster

### DIFF
--- a/docs/linux/sql-server-linux-availability-group-cluster-rhel.md
+++ b/docs/linux/sql-server-linux-availability-group-cluster-rhel.md
@@ -156,7 +156,7 @@ For information on Pacemaker cluster properties, see [Pacemaker Clusters Propert
 To create the availability group resource, use `pcs resource create` command and set the resource properties. The following command creates a `ocf:mssql:ag` master/slave type resource for availability group with name `ag1`.
 
 ```bash
-sudo pcs resource create ag_cluster ocf:mssql:ag ag_name=ag1 meta failure-timeout=30s master notify=true
+sudo pcs resource create ag_cluster ocf:mssql:ag ag_name=ag1 meta failure-timeout=60s master notify=true
 ``` 
 
 [!INCLUDE [required-synchronized-secondaries-default](../includes/ss-linux-cluster-required-synchronized-secondaries-default.md)]


### PR DESCRIPTION
Updating the statement that creates the Pacemaker cluster to reflect the recommended failure-timeout value to "60s". The prior statement had this value set at "30s".