### PR TITLE
Changed "marks" to "euros" in one place

### DIFF
--- a/docs/analysis-services/multidimensional-models/create-calculated-members.md
+++ b/docs/analysis-services/multidimensional-models/create-calculated-members.md
@@ -14,7 +14,7 @@ manager: kfile
 [!INCLUDE[ssas-appliesto-sqlas](../../includes/ssas-appliesto-sqlas.md)]
   You can create customized measures or dimension members, called calculated members, by combining cube data, arithmetic operators, numbers, and functions. For example, you can create a calculated member named Euros that converts dollars to euros by multiplying an existing dollar measure by a conversion rate. Euros can then be displayed to end users in a separate row or column.  
   
- Calculated member definitions are stored, but their values exist only in memory. In the preceding example, values in marks are displayed to end users but are not stored as cube data.  
+ Calculated member definitions are stored, but their values exist only in memory. In the preceding example, values in euros are displayed to end users but are not stored as cube data.  
   
  You create calculated members in cubes. To create a calculated member, in Cube Designer, on the **Calculations** tab, click the **New Calculated Member** icon on the toolbar. This command displays a form to specify the following options for the calculated member:  
   


### PR DESCRIPTION
The example uses euros, but there was one sentence that referred to marks.  Changed "marks" to "euros" in that one place.