### PR TITLE
Update polybase-configuration.md

### DIFF
--- a/docs/relational-databases/polybase/polybase-configuration.md
+++ b/docs/relational-databases/polybase/polybase-configuration.md
@@ -29,6 +29,8 @@ A common way to secure communication in a hadoop cluster is by changing the hado
    </property> 
 ```
 
+To use 'Privacy' or 'Integrity' for hadoop.rpc.protection, SQL Server must be at least SQL Server 2016 SP1 CU7, SQL Server 2016 SP2, or SQL Server 2017 CU3.
+
 ## Example XML files for CDH 5.X cluster
 
 Yarn-site.xml with yarn.application.classpath and mapreduce.application.classpath configuration.


### PR DESCRIPTION
Adding content showing the minimum version of SQL Server needed to use 'Privacy' or 'Integrity' setting for Hadoop.rpc.protection.