### PR TITLE
Update scale-out-support-for-high-availability.md

### DIFF
--- a/docs/integration-services/scale-out/scale-out-support-for-high-availability.md
+++ b/docs/integration-services/scale-out/scale-out-support-for-high-availability.md
@@ -37,7 +37,7 @@ This account must be able to access SSISDB on the secondary node in the Windows 
 
 ### 2.2 Include the DNS host name for the Scale Out Master service in the CNs of the Scale Out Master certificate
 
-This host name is used in the Scale Out Master endpoint. (Be sure to provide a DNS host name and not a server name.)
+This host name is the Scale Out Master endpoint, which is created as a clustered Generic Service in the failover cluster (see Step 7).   (Be sure to provide a DNS host name and not a server name.)
 
 ![HA master configuration](media/ha-master-config.PNG)
 


### PR DESCRIPTION
I thought this would be helpful to prevent having to recreate certificates. I wrongly assumed this was the availability group endpoint when I initially configured the master server. It was only when I got to step 7 that I realised that the master service endpoint is a separate computer object with a unique IP address. 

Incidentally, it appears you can just use the availability group endpoint for the master service to get around this. Presumably that reduces some level of HA though, as the endpoint will be abstracted from the clustered service itself.