### PR TITLE
Fix copy-paste, replace primary with secondary

### DIFF
--- a/docs/t-sql/statements/alter-database-scoped-configuration-transact-sql.md
+++ b/docs/t-sql/statements/alter-database-scoped-configuration-transact-sql.md
@@ -406,7 +406,7 @@ This example sets PARAMETER_SNIFFING to OFF for a primary database in a geo-repl
 ALTER DATABASE SCOPED CONFIGURATION SET PARAMETER_SNIFFING = OFF ;
 ```
 
-This example sets PARAMETER_SNIFFING to OFF for a primary database in a geo-replication scenario.
+This example sets PARAMETER_SNIFFING to OFF for a secondary database in a geo-replication scenario.
 
 ```sql
 ALTER DATABASE SCOPED CONFIGURATION FOR SECONDARY SET PARAMETER_SNIFFING = OFF ;


### PR DESCRIPTION
Per Issue 1905. The plain text line above the following code line, needs its word 'primary' changed to 'secondary', in example D.
ALTER DATABASE SCOPED CONFIGURATION FOR SECONDARY SET PARAMETER_SNIFFING = OFF ;