### PR TITLE
Fix parameter name in syntax section

### DIFF
--- a/docs/integration-services/system-stored-procedures/catalog-set-environment-variable-protection-ssisdb-database.md
+++ b/docs/integration-services/system-stored-procedures/catalog-set-environment-variable-protection-ssisdb-database.md
@@ -23,7 +23,7 @@ manager: craigg
 catalog.set_environment_variable_protection [ @folder_name = ] folder_name  
     , [ @environment_name = ] environment_name  
     , [ @variable_name = ] variable_name  
-    , [ @is_sensitive = ] is_sensitive  
+    , [ @sensitive = ] sensitive  
 ```  
   
 ## Arguments  


### PR DESCRIPTION
The @sensitive parameter was incorrectly listed as @is_sensitive in the syntax section.