### PR TITLE
Reintroduce error in example script which was there on purpose.

### DIFF
--- a/docs/2014/2014-toc/sql-server-transaction-locking-and-row-versioning-guide.md
+++ b/docs/2014/2014-toc/sql-server-transaction-locking-and-row-versioning-guide.md
@@ -146,7 +146,7 @@ CREATE TABLE TestBatch (Cola INT PRIMARY KEY, Colb CHAR(3));
 GO  
 INSERT INTO TestBatch VALUES (1, 'aaa');  
 INSERT INTO TestBatch VALUES (2, 'bbb');  
-INSERT INTO TestBatch VALUES (3, 'ccc');  -- Syntax error.  
+INSERT INTO TestBatch VALUSE (3, 'ccc');  -- Syntax error.  
 GO  
 SELECT * FROM TestBatch;  -- Returns no rows.  
 GO  


### PR DESCRIPTION
The error in the example script which was included to demonstrate a specific behavior of SQL Server was accidentally removed in a previous commit.