### PR TITLE
ALTER CERTIFICATE supports BINARY private key

### DIFF
--- a/docs/t-sql/statements/alter-certificate-transact-sql.md
+++ b/docs/t-sql/statements/alter-certificate-transact-sql.md
@@ -39,13 +39,21 @@ monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-s
   
 ALTER CERTIFICATE certificate_name   
       REMOVE PRIVATE KEY  
-    | WITH PRIVATE KEY ( <private_key_spec> [ ,... ] )  
+    | WITH PRIVATE KEY ( <private_key_options> )  
     | WITH ACTIVE FOR BEGIN_DIALOG = [ ON | OFF ]  
   
-<private_key_spec> ::=   
-      FILE = 'path_to_private_key'   
-    | DECRYPTION BY PASSWORD = 'key_password'   
-    | ENCRYPTION BY PASSWORD = 'password'   
+<private_key_options> ::=  
+      {   
+        FILE = 'path_to_private_key'  
+         [ , DECRYPTION BY PASSWORD = 'password' ]  
+         [ , ENCRYPTION BY PASSWORD = 'password' ]    
+      }  
+    |  
+      {   
+        BINARY = private_key_bits  
+         [ , DECRYPTION BY PASSWORD = 'password' ]  
+         [ , ENCRYPTION BY PASSWORD = 'password' ]    
+      }  
 ```  
   
 ```  
@@ -66,6 +74,11 @@ ALTER CERTIFICATE certificate_name
   
  FILE **='**_path\_to\_private\_key_**'**  
  Specifies the complete path, including file name, to the private key. This parameter can be a local path or a UNC path to a network location. This file will be accessed within the security context of the [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] service account. When you use this option, you must make sure that the service account has access to the specified file.  
+  
+ BINARY =*private_key_bits*  
+ **Applies to**: [!INCLUDE[ssSQL11](../../includes/sssql11-md.md)] through [!INCLUDE[ssCurrent](../../includes/sscurrent-md.md)].  
+  
+ Private key bits specified as binary constant. These bits can be in encrypted form. If encrypted, the user must provide a decryption password. Password policy checks are not performed on this password. The private key bits should be in a PVK file format.  
   
  DECRYPTION BY PASSWORD **='**_key\_password_**'**  
  Specifies the password that is required to decrypt the private key.  

--- a/docs/t-sql/statements/alter-certificate-transact-sql.md
+++ b/docs/t-sql/statements/alter-certificate-transact-sql.md
@@ -1,7 +1,7 @@
 ---
 title: "ALTER CERTIFICATE (Transact-SQL) | Microsoft Docs"
 ms.custom: ""
-ms.date: "06/18/2018"
+ms.date: "04/18/2019"
 ms.prod: sql
 ms.prod_service: "database-engine, sql-database, sql-data-warehouse, pdw"
 ms.reviewer: ""
@@ -39,21 +39,13 @@ monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-s
   
 ALTER CERTIFICATE certificate_name   
       REMOVE PRIVATE KEY  
-    | WITH PRIVATE KEY ( <private_key_options> )  
+    | WITH PRIVATE KEY ( <private_key_spec> [ ,... ] )  
     | WITH ACTIVE FOR BEGIN_DIALOG = [ ON | OFF ]  
   
-<private_key_options> ::=  
-      {   
-        FILE = 'path_to_private_key'  
-         [ , DECRYPTION BY PASSWORD = 'password' ]  
-         [ , ENCRYPTION BY PASSWORD = 'password' ]    
-      }  
-    |  
-      {   
-        BINARY = private_key_bits  
-         [ , DECRYPTION BY PASSWORD = 'password' ]  
-         [ , ENCRYPTION BY PASSWORD = 'password' ]    
-      }  
+<private_key_spec> ::=   
+    [ FILE = 'path_to_private_key' | BINARY = private_key_bits ]
+    | DECRYPTION BY PASSWORD = 'key_password'   
+    | ENCRYPTION BY PASSWORD = 'password'   
 ```  
   
 ```  

--- a/docs/t-sql/statements/alter-certificate-transact-sql.md
+++ b/docs/t-sql/statements/alter-certificate-transact-sql.md
@@ -67,7 +67,7 @@ ALTER CERTIFICATE certificate_name
  FILE **='**_path\_to\_private\_key_**'**  
  Specifies the complete path, including file name, to the private key. This parameter can be a local path or a UNC path to a network location. This file will be accessed within the security context of the [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] service account. When you use this option, you must make sure that the service account has access to the specified file.  
   
- BINARY =*private_key_bits*  
+ BINARY **='**_private\_key\_bits_**'**  
  **Applies to**: [!INCLUDE[ssSQL11](../../includes/sssql11-md.md)] through [!INCLUDE[ssCurrent](../../includes/sscurrent-md.md)].  
   
  Private key bits specified as binary constant. These bits can be in encrypted form. If encrypted, the user must provide a decryption password. Password policy checks are not performed on this password. The private key bits should be in a PVK file format.  


### PR DESCRIPTION
Hi there,

we recently had a case where we wanted to transfer a private key from one database to the other, but could not drop the certificate without previously dropping some other things. Turns out, that ALTER CERTIFICATE supports the same BINARY syntax as CREATE CERTIFICATE, it is just not documented. I want to fix this with this pull-request, but I am not 100% sure about all details. Feel free to polish as needed or get back to me so I can improve it myself.

Best Regards