### PR TITLE
Impacts of CDC when patching SQL server

### DIFF
--- a/docs/relational-databases/track-changes/administer-and-monitor-change-data-capture-sql-server.md
+++ b/docs/relational-databases/track-changes/administer-and-monitor-change-data-capture-sql-server.md
@@ -172,7 +172,7 @@ The [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] data collector let
   
 ## <a name="ScriptUpgrade"></a> Script upgrade mode
 
-When your apply cumulatives updates or service packs to a instance, at restart, the instance can enter in Script Upgrade mode. In this mode, the process wil run a step to analyze and upgrade CDC internals tables. This upgrade can cause recreating of objects like indexes on capture tables. If you have data on these tables, depending on amount of data, it can spend lot of minutes in script ugprade mode. Note that, due to modifications, you can note high transaction log usage for enabled CDC databases!
+When you apply cumulatives updates or service packs to an instance, at restart, the instance can enter in Script Upgrade mode. In this mode, SQL Server may run a step to analyze and upgrade internal CDC tables, which could result in recreating objects like indexes on capture tables. Depending on the amount of data involved, this step might take some time or cause high transaction log usage for enabled CDC databases.
 
 
 ## See Also

--- a/docs/relational-databases/track-changes/administer-and-monitor-change-data-capture-sql-server.md
+++ b/docs/relational-databases/track-changes/administer-and-monitor-change-data-capture-sql-server.md
@@ -170,6 +170,11 @@ The [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] data collector let
   
 4. In the data warehouse you configured in step 1, locate the table custom_snapshots.cdc_log_scan_data. This table provides a historical snapshot of data from log scan sessions. This data can be used to analyze latency, throughput, and other performance measures over time.  
   
+## <a name="ScriptUpgrade"></a> Script upgrade mode
+
+When your apply cumulatives updates or service packs to a instance, at restart, the instance can enter in Script Upgrade mode. In this mode, the process wil run a step to analyze and upgrade CDC internals tables. This upgrade can cause recreating of objects like indexes on capture tables. If you have data on these tables, depending on amount of data, it can spend lot of minutes in script ugprade mode. Note that, due to modifications, you can note high transaction log usage for enabled CDC databases!
+
+
 ## See Also
 
 - [Track Data Changes &#40;SQL Server&#41;](../../relational-databases/track-changes/track-data-changes-sql-server.md)


### PR DESCRIPTION
Add a topic about impacts of CDC when patching instance. If instance enters on script upgrade mode, it will runs proc sp_vupgrade_replication, which runs sp_cdc_vupgrade. In this proc, it can rebuild indexes. I wokred on company that experinced this problem in SQL Server 2008 R2, and after talking with support, it was fixed, but current code (checked on version 2016), can trigger these rebuilds yet. BEcause this, i guess is important alert readers for they plan instance patching.