### PR TITLE
Add a note that Microsoft uses the in place upgrade approach on their…

### DIFF
--- a/docs/database-engine/install-windows/choose-a-database-engine-upgrade-method.md
+++ b/docs/database-engine/install-windows/choose-a-database-engine-upgrade-method.md
@@ -41,7 +41,8 @@ There are several approaches to consider when you are planning to upgrade the [!
 -   A non-mission critical production environment that can tolerate downtime and that is running on a recent hardware and software. The amount of downtime is dependent upon the size of your database and the speed of your I/O subsystem. Upgrading SQL Server 2014 when memory-optimized tables are in use will take some extra time. For more information, see [Plan and Test the Database Engine Upgrade Plan](../../database-engine/install-windows/plan-and-test-the-database-engine-upgrade-plan.md).  
 
 > [!NOTE]
-> We at Microsoft have been [using this method](https://azure.microsoft.com/blog/azure-sql-server-to-upgrade-or-not-to-upgrade-that-is-the-question/) on at least 40 of our production databases on a monthly basis in our Azure IAAS offering with no downtime since 11/10/2014. 
+> For an example of how Microsoft has used this strategy, see the following blog post: [To upgrade or not to upgrade](https://azure.microsoft.com/blog/azure-sql-server-to-upgrade-or-not-to-upgrade-that-is-the-question/). 
+
 
 > [!WARNING]  
 >  When running the [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] setup program, the [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] instance is stopped and restarted as part of running the pre-upgrade checks.  

--- a/docs/database-engine/install-windows/choose-a-database-engine-upgrade-method.md
+++ b/docs/database-engine/install-windows/choose-a-database-engine-upgrade-method.md
@@ -39,7 +39,10 @@ There are several approaches to consider when you are planning to upgrade the [!
 -   A development environment without a high-availability (HA) configuration.  
   
 -   A non-mission critical production environment that can tolerate downtime and that is running on a recent hardware and software. The amount of downtime is dependent upon the size of your database and the speed of your I/O subsystem. Upgrading SQL Server 2014 when memory-optimized tables are in use will take some extra time. For more information, see [Plan and Test the Database Engine Upgrade Plan](../../database-engine/install-windows/plan-and-test-the-database-engine-upgrade-plan.md).  
-  
+
+> [!NOTE]
+> We at Microsoft have been [using this method](https://azure.microsoft.com/en-us/blog/azure-sql-server-to-upgrade-or-not-to-upgrade-that-is-the-question/) on at least 40 of our production databases on a monthly basis in our Azure IAAS offering with no downtime since 11/10/2014. 
+
 > [!WARNING]  
 >  When running the [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] setup program, the [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] instance is stopped and restarted as part of running the pre-upgrade checks.  
   

--- a/docs/database-engine/install-windows/choose-a-database-engine-upgrade-method.md
+++ b/docs/database-engine/install-windows/choose-a-database-engine-upgrade-method.md
@@ -41,7 +41,7 @@ There are several approaches to consider when you are planning to upgrade the [!
 -   A non-mission critical production environment that can tolerate downtime and that is running on a recent hardware and software. The amount of downtime is dependent upon the size of your database and the speed of your I/O subsystem. Upgrading SQL Server 2014 when memory-optimized tables are in use will take some extra time. For more information, see [Plan and Test the Database Engine Upgrade Plan](../../database-engine/install-windows/plan-and-test-the-database-engine-upgrade-plan.md).  
 
 > [!NOTE]
-> We at Microsoft have been [using this method](https://azure.microsoft.com/en-us/blog/azure-sql-server-to-upgrade-or-not-to-upgrade-that-is-the-question/) on at least 40 of our production databases on a monthly basis in our Azure IAAS offering with no downtime since 11/10/2014. 
+> We at Microsoft have been [using this method](https://azure.microsoft.com/blog/azure-sql-server-to-upgrade-or-not-to-upgrade-that-is-the-question/) on at least 40 of our production databases on a monthly basis in our Azure IAAS offering with no downtime since 11/10/2014. 
 
 > [!WARNING]  
 >  When running the [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] setup program, the [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] instance is stopped and restarted as part of running the pre-upgrade checks.  


### PR DESCRIPTION
… own Azure IAAS production databases

I took the time to suggest this edit because I'm encountering a lot of resistance to using in place upgrades for our production databases.  The people who are resistant point to this documentation which seems pretty out of date to me in light of the blog post 5 years ago indicating that Microsoft have switched to using the in place migration approach.