### PR TITLE
Fix missing / misleading statements, and formatting for BACKUP CERTIFICATE

### DIFF
--- a/docs/t-sql/statements/backup-certificate-transact-sql.md
+++ b/docs/t-sql/statements/backup-certificate-transact-sql.md
@@ -1,7 +1,7 @@
 ---
 title: "BACKUP CERTIFICATE (Transact-SQL) | Microsoft Docs"
 ms.custom: ""
-ms.date: "10/04/2018"
+ms.date: "04/23/2019"
 ms.prod: sql
 ms.prod_service: "sql-data-warehouse, pdw, sql-database"
 ms.reviewer: ""
@@ -64,24 +64,34 @@ BACKUP CERTIFICATE certname TO FILE ='path_to_file'
 ```  
   
 ## Arguments  
- *path_to_file*  
- Specifies the complete path, including file name, of the file in which the certificate is to be saved. This path can be a local path or a UNC path to a network location. The default is the path of the [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] DATA folder.  
-  
- *path_to_private_key_file*  
- Specifies the complete path, including file name, of the file in which the private key is to be saved. This path can be a local path or a UNC path to a network location. The default is the path of the [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] DATA folder.  
+ *certname*  
+ Is the name of the certificate to backup.
 
- *encryption_password*  
+ TO FILE = '*path_to_file*'  
+ Specifies the complete path, including file name, of the file in which the certificate is to be saved. This path can be a local path or a UNC path to a network location. If only a file name is specified, the file will be saved in the instance's default user data folder (which may or may not be the [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] DATA folder). For SQL Server Express LocalDB, the instance's default user data folder is the path specified by the `%USERPROFILE%` environment variable for the account that created the instance.  
+
+ WITH PRIVATE KEY
+ Specifies that the private key of the certificate is to be saved to a file. This clause is optional.
+
+ FILE = '*path_to_private_key_file*'  
+ Specifies the complete path, including file name, of the file in which the private key is to be saved. This path can be a local path or a UNC path to a network location. If only a file name is specified, the file will be saved in the instance's default user data folder (which may or may not be the [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] DATA folder). For SQL Server Express LocalDB, the instance's default user data folder is the path specified by the `%USERPROFILE%` environment variable for the account that created the instance.  
+
+ ENCRYPTION BY PASSWORD = '*encryption_password*'  
  Is the password that is used to encrypt the private key before writing the key to the backup file. The password is subject to complexity checks.  
   
- *decryption_password*  
+ DECRYPTION BY PASSWORD = '*decryption_password*'  
  Is the password that is used to decrypt the private key before backing up the key. This argument is not necessary if the certificate is encrypted by the master key. 
   
 ## Remarks  
  If the private key is encrypted with a password in the database, the decryption password must be specified.  
   
- When you back up the private key to a file, encryption is required. The password used to protect the certificate is not the same password that is used to encrypt the private key of the certificate.  
-  
- To restore a backed up certificate, use the [CREATE CERTIFICATE](../../t-sql/statements/create-certificate-transact-sql.md)statement.
+ When you back up the private key to a file, encryption is required. The password used to protect the private key in the file is not the same password that is used to encrypt the private key of the certificate in the database.  
+
+ Private keys are saved in the PVK file format.
+
+ To restore a backed up certificate, with or without the private key, use the [CREATE CERTIFICATE](../../t-sql/statements/create-certificate-transact-sql.md) statement.
+ 
+ To restore a private key to an existing certificate in the database, use the [ALTER CERTIFICATE](../../t-sql/statements/alter-certificate-transact-sql.md) statement.
  
  When performing a backup, the files will be ACLd to the service account of the SQL Server instance. If you need to restore the certificate to a server running under a different account, you will need to adjust the permissions on the files so that they are able to be read by the new account. 
   
@@ -123,6 +133,10 @@ GO
  [CREATE CERTIFICATE &#40;Transact-SQL&#41;](../../t-sql/statements/create-certificate-transact-sql.md)   
  [ALTER CERTIFICATE &#40;Transact-SQL&#41;](../../t-sql/statements/alter-certificate-transact-sql.md)   
  [DROP CERTIFICATE &#40;Transact-SQL&#41;](../../t-sql/statements/drop-certificate-transact-sql.md)  
+ [CERTENCODED &#40;Transact-SQL&#41;](../../t-sql/functions/certencoded-transact-sql.md)  
+ [CERTPRIVATEKEY &#40;Transact-SQL&#41;](../../t-sql/functions/certprivatekey-transact-sql.md)  
+ [CERT_ID &#40;Transact-SQL&#41;](../../t-sql/functions/cert-id-transact-sql.md)  
+ [CERTPROPERTY &#40;Transact-SQL&#41;](../../t-sql/functions/certproperty-transact-sql.md)  
   
   
 


### PR DESCRIPTION
1. Updated "Arguments" section to conform to most other pages:
    1. Added "certname" argument.
    2. Added argument name to each option.
    3. Added "WITH PRIVATE KEY" argument as it mirrors `CREATE CERTIFICATE`.
    4. Corrected default path description (tested in SQL Server 2017 CU14 and 2019 CTP 2.4).
    5. Added LocalDB info to path description (tested in SQL Server Express LocalDB 2012 SP4).

2. Updated "Remarks" section:
    1. Passwords are to protect private keys, not certificates.
    2. Added info about private key file format.
    3. Clarified that restoring a certificate does not require the private key.
    4. Added info about restoring a private key to an existing certificate via `ALTER CERTIFICATE`.

3. Added links to CERTENCODED, CERTPRIVATEKEY, CERT_ID, and CERTPROPERTY functions in "See Also" section.


These updates are related to updates proposed for `CREATE CERTIFICATE` and `ALTER CERTIFICATE` via #1972 , and to the following post: https://sqlquantumleap.com/2019/04/22/can-a-certificates-private-key-be-imported-restored-from-a-binary-literal-hex-bytes/