### PR TITLE
Update the Visual Studio download link to VS2019

### DIFF
--- a/docs/ssdt/download-sql-server-data-tools-ssdt.md
+++ b/docs/ssdt/download-sql-server-data-tools-ssdt.md
@@ -31,7 +31,7 @@ If you already have a license to Visual Studio 2019:
 - For Analysis Services, Integration Services or Reporting Services projects, install the appropriate extension(s) from the marketplace
 
 If you don’t already have a license to Visual Studio 2019:
-- Install [Visual Studio 2019 Community](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com) 
+- Install [Visual Studio 2019 Community](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_content=sqlssdt) 
 - Install the Analysis Services, Integration Services or Reporting Services as appropriate
 
 ## Changes in SSDT for Visual Studio 2017 ##

--- a/docs/ssdt/download-sql-server-data-tools-ssdt.md
+++ b/docs/ssdt/download-sql-server-data-tools-ssdt.md
@@ -31,7 +31,7 @@ If you already have a license to Visual Studio 2019:
 - For Analysis Services, Integration Services or Reporting Services projects, install the appropriate extension(s) from the marketplace
 
 If you don’t already have a license to Visual Studio 2019:
-- Install [Visual Studio 2019 Community](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community&rel=15&utm_campaign=tailored+install&utm_source=docs.microsoft.com&utm_medium=microsoft&utm_content=sqlssdt&rid=35007) 
+- Install [Visual Studio 2019 Community](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com) 
 - Install the Analysis Services, Integration Services or Reporting Services as appropriate
 
 ## Changes in SSDT for Visual Studio 2017 ##


### PR DESCRIPTION
The link text indicated 2019 but was going to 2017.

Also changing link behavior to go to the download page instead of initiating the download directly.