### PR TITLE
Update sys-time-zone-info-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-catalog-views/sys-time-zone-info-transact-sql.md
+++ b/docs/relational-databases/system-catalog-views/sys-time-zone-info-transact-sql.md
@@ -21,7 +21,7 @@ manager: craigg
 monikerRange: "=azure-sqldw-latest||>=sql-server-2016||=sqlallproducts-allversions||>=sql-server-linux-2017||=azuresqldb-mi-current"
 ---
 # sys.time_zone_info (Transact-SQL)
-[!INCLUDE[tsql-appliesto-ss2014-asdb-asdw-xxx-md](../../includes/tsql-appliesto-ss2014-asdb-asdw-xxx-md.md)]
+[!INCLUDE[tsql-appliesto-ss2016-asdb-asdw-xxx-md](../../includes/tsql-appliesto-ss2016-asdb-asdw-xxx-md.md)]
 
   Returns information about supported time zones. All time zones installed on the computer are stored in the following registry hive:  
 `KEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Time Zones`.  


### PR DESCRIPTION
Change the Applies to to indicate SQL Server 2016, not 2014. this view did not exist in SQL Server 2014