### PR TITLE
Inaccurate path for location of yarn-site.xml file

### DIFF
--- a/docs/relational-databases/polybase/polybase-configure-hadoop.md
+++ b/docs/relational-databases/polybase/polybase-configure-hadoop.md
@@ -68,7 +68,7 @@ To improve query performance, enable pushdown computation to your Hadoop cluster
 1. Find the file **yarn-site.xml** in the installation path of SQL Server. Typically, the path is:  
 
    ```xml  
-   C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Binn\PolyBaseHadoopconf  
+   C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Binn\Polybase\Hadoop\conf\  
    ```  
 
 1. On the Hadoop machine, find the analogous file in the Hadoop configuration directory. In the file, find and copy the value of the configuration key yarn.application.classpath.  


### PR DESCRIPTION
The path shown for the location of yarn-site.xml was incorrect (missing backslashes)