### PR TITLE
Add remark stating PATINDEX returns 1-based value

### DIFF
--- a/docs/t-sql/functions/patindex-transact-sql.md
+++ b/docs/t-sql/functions/patindex-transact-sql.md
@@ -49,7 +49,9 @@ PATINDEX ( '%pattern%' , expression )
   
 ## Remarks  
  If either *pattern* or *expression* is NULL, PATINDEX returns NULL.  
-  
+ 
+ The starting position returned is 1-based, not 0-based.
+ 
  PATINDEX performs comparisons based on the collation of the input. To perform a comparison in a specified collation, you can use COLLATE to apply an explicit collation to the input.  
   
 ## Supplementary Characters (Surrogate Pairs)  


### PR DESCRIPTION
While it can be inferred from the examples, it is not explicitly stated that PATINDEX is 1-based instead of 0-based; The inserted text is taken directly from the CHARINDEX page, another 1-based function.