### PR TITLE
Description of os_thread_id to match PAL

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-os-threads-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-os-threads-transact-sql.md
@@ -34,7 +34,7 @@ monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-s
 |-----------------|---------------|-----------------|  
 |thread_address|**varbinary(8)**|Memory address (Primary Key) of the thread.|  
 |started_by_sqlservr|**bit**|Indicates the thread initiator.<br /><br /> 1 = [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] started the thread.<br /><br /> 0 = Another component started the thread, such as an extended stored procedure from within [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)].|  
-|os_thread_id|**int**|ID of the thread that is assigned by the operating system.|  
+|os_thread_id|**int**|ID of the thread that is assigned by the operating system|  
 |status|**int**|Internal status flag.|  
 |instruction_address|**varbinary(8)**|Address of the instruction that is currently being executed.|  
 |creation_time|**datetime**|Time when this thread was created.|  
@@ -64,6 +64,10 @@ monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-s
 
 On [!INCLUDE[ssNoVersion_md](../../includes/ssnoversion-md.md)], requires `VIEW SERVER STATE` permission.   
 On [!INCLUDE[ssSDS_md](../../includes/sssds-md.md)], requires the `VIEW DATABASE STATE` permission in the database.   
+
+## Notes on Linux version
+
+Due to way SQL engine works in Linux, some of these informations cannot match Linux diagnostics data. For example, `os_thread_id` not match the result of tools like `ps`,`top` or the procfs (/proc/`pid`).  This is due the SQLPAL, a layer between SQL Server components and the operating system.
 
 ## Examples  
  Upon startup, [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] starts threads and then associates workers with those threads. However, external components, such as an extended stored procedure, can start threads under the [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] process. [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] has no control of these threads. sys.dm_os_threads can provide information about rogue threads that consume resources in the [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] process.  

--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-os-threads-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-os-threads-transact-sql.md
@@ -34,7 +34,7 @@ monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-s
 |-----------------|---------------|-----------------|  
 |thread_address|**varbinary(8)**|Memory address (Primary Key) of the thread.|  
 |started_by_sqlservr|**bit**|Indicates the thread initiator.<br /><br /> 1 = [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] started the thread.<br /><br /> 0 = Another component started the thread, such as an extended stored procedure from within [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)].|  
-|os_thread_id|**int**|ID of the thread that is assigned by the operating system|  
+|os_thread_id|**int**|ID of the thread that is assigned by the operating system.|  
 |status|**int**|Internal status flag.|  
 |instruction_address|**varbinary(8)**|Address of the instruction that is currently being executed.|  
 |creation_time|**datetime**|Time when this thread was created.|  
@@ -67,7 +67,7 @@ On [!INCLUDE[ssSDS_md](../../includes/sssds-md.md)], requires the `VIEW DATABASE
 
 ## Notes on Linux version
 
-Due to way SQL engine works in Linux, some of these informations cannot match Linux diagnostics data. For example, `os_thread_id` not match the result of tools like `ps`,`top` or the procfs (/proc/`pid`).  This is due the SQLPAL, a layer between SQL Server components and the operating system.
+Due to how the SQL engine works in Linux, some of this information doesn't match Linux diagnostics data. For example, `os_thread_id` does not match the result of tools like `ps`,`top` or the procfs (/proc/`pid`).  This is due the Platform Abstraction Layer (SQLPAL), a layer between SQL Server components and the operating system.
 
 ## Examples  
  Upon startup, [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] starts threads and then associates workers with those threads. However, external components, such as an extended stored procedure, can start threads under the [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] process. [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] has no control of these threads. sys.dm_os_threads can provide information about rogue threads that consume resources in the [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] process.  


### PR DESCRIPTION
On linux, the os_thread_id (also, in the error log, when loggin message "Server process ID is") not show the thread id nor process id assigned by Linux OS, and it is another internal number, generated due to SQLPAL. Bob Dorr explain me in the comment in his blog post https://blogs.msdn.microsoft.com/bobsql/2018/07/18/sql-server-on-linux-why-do-i-have-two-sql-server-processes/

## Additional considerations

If there are a way to match os_thread_id with linux thread, then I guess it is very important add to the documentation also.  For advanced analysis, it can be useful to help troubleshooting and validating some theories!