### PR TITLE
Fixed permissions requirements

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-oacreate-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-oacreate-transact-sql.md
@@ -78,7 +78,7 @@ sp_OACreate { progid | clsid } , objecttoken OUTPUT [ , context ]
  The created OLE object is automatically destroyed at the end of the [!INCLUDE[tsql](../../includes/tsql-md.md)] statement batch.  
   
 ## Permissions  
- Requires membership in the **sysadmin** fixed server role.  
+ Requires membership in the **sysadmin** fixed server role or execute permission directly on this Stored Procedure. `Ole Automation Procedures` configuration must be **enabled** to use any system procedure related to OLE Automation.  
   
 ## Examples  
   


### PR DESCRIPTION
## Permissions  
 Requires membership in the **sysadmin** fixed server role or execute permission directly on this Stored Procedure. `Ole Automation Procedures` configuration must be **enabled** to use any system procedure related to OLE Automation.