### PR TITLE
Changed verbiage around rolling updates an AGs

### DIFF
--- a/docs/database-engine/availability-groups/windows/upgrading-always-on-availability-group-replica-instances.md
+++ b/docs/database-engine/availability-groups/windows/upgrading-always-on-availability-group-replica-instances.md
@@ -33,7 +33,7 @@ Before you begin, review the following important information:
 - [Check if change data capture  or replication is used for any AG databases](#special-steps-for-change-data-capture-or-replication): If any databases in the AG are enabled for change data capture (CDC), complete these [instructions](#special-steps-for-change-data-capture-or-replication).
 
 >[!NOTE]  
->Mixing versions of SQL Server instances in the same AG is not supported outside of a rolling upgrade, which upgrades the replicas in place. A higher version of a SQL Server instance cannot be added as a new replica to an existing AG. For example, a SQL Server 2017 replica cannot be added to an existing SQL Server 2016 AG. To migrate to a new version of the SQL Server instance using AGs, the only supported method is a distributed AG, which is in SQL Server 2016 Enterprise Edition or later.
+>Mixing versions of SQL Server instances in the same AG is not supported outside of a rolling upgrade and should not exist in that state for extended periods of time as the upgrade should take place quickly. The other option for upgrading SQL Server 2016 and later is through the use of a distributed availability groups.
 
 ## Rolling Upgrade Basics for Always On AGs  
 Observe the following guidelines when performing server upgrades or updates in order to minimize downtime and data loss for your AGs:  

--- a/docs/database-engine/availability-groups/windows/upgrading-always-on-availability-group-replica-instances.md
+++ b/docs/database-engine/availability-groups/windows/upgrading-always-on-availability-group-replica-instances.md
@@ -33,7 +33,7 @@ Before you begin, review the following important information:
 - [Check if change data capture  or replication is used for any AG databases](#special-steps-for-change-data-capture-or-replication): If any databases in the AG are enabled for change data capture (CDC), complete these [instructions](#special-steps-for-change-data-capture-or-replication).
 
 >[!NOTE]  
->Mixing versions of SQL Server instances in the same AG is not supported outside of a rolling upgrade and should not exist in that state for extended periods of time as the upgrade should take place quickly. The other option for upgrading SQL Server 2016 and later is through the use of a distributed availability groups.
+>Mixing versions of SQL Server instances in the same AG is not supported outside of a rolling upgrade and should not exist in that state for extended periods of time as the upgrade should take place quickly. The other option for upgrading SQL Server 2016 and later is through the use of a distributed availability group.
 
 ## Rolling Upgrade Basics for Always On AGs  
 Observe the following guidelines when performing server upgrades or updates in order to minimize downtime and data loss for your AGs:  


### PR DESCRIPTION
The current verbiage is causing many support calls due to the odd nature of the explanation. Changed it to be much more straight forward and technically correct, while it wasn't fully correct on the previous version.