### PR TITLE
syntax highlighting for code example

### DIFF
--- a/docs/odbc/reference/syntax/sqlbulkoperations-function.md
+++ b/docs/odbc/reference/syntax/sqlbulkoperations-function.md
@@ -30,7 +30,7 @@ manager: craigg
   
 ## Syntax  
   
-```  
+```cpp  
   
 SQLRETURN SQLBulkOperations(  
      SQLHSTMT       StatementHandle,  
@@ -255,7 +255,7 @@ SQLRETURN SQLBulkOperations(
 ## Code Example  
  The following example fetches 10 rows of data at a time from the Customers table. It then prompts the user for an action to take. To reduce network traffic, the example buffer updates, deletes, and inserts locally in the bound arrays, but at offsets past the rowset data. When the user chooses to send updates, deletes, and inserts to the data source, the code sets the binding offset appropriately and calls **SQLBulkOperations**. For simplicity, the user cannot buffer more than 10 updates, deletes, or inserts.  
   
-```  
+```cpp  
 // SQLBulkOperations_Function.cpp  
 // compile with: ODBC32.lib  
 #include <windows.h>  


### PR DESCRIPTION
syntax highlighting for code example
added markdown label for the code example language
adding the markdown label makes the code more readable