### PR TITLE
syntax highlighting for code example

### DIFF
--- a/docs/odbc/reference/syntax/sqlcolumns-function.md
+++ b/docs/odbc/reference/syntax/sqlcolumns-function.md
@@ -30,7 +30,7 @@ manager: craigg
   
 ## Syntax  
   
-```  
+```cpp  
   
 SQLRETURN SQLColumns(  
      SQLHSTMT       StatementHandle,  
@@ -176,7 +176,7 @@ SQLRETURN SQLColumns(
 ## Code Example  
  In the following example, an application declares buffers for the result set returned by **SQLColumns**. It calls **SQLColumns** to return a result set that describes each column in the EMPLOYEE table. It then calls **SQLBindCol** to bind the columns in the result set to the buffers. Finally, the application fetches each row of data with **SQLFetch** and processes it.  
   
-```  
+```cpp  
 // SQLColumns_Function.cpp  
 // compile with: ODBC32.lib  
 #include <windows.h>  


### PR DESCRIPTION
syntax highlighting for code example
added markdown label for the code example language
adding the markdown label makes the code more readable