### PR TITLE
syntax highlighting for code example

### DIFF
--- a/docs/odbc/reference/syntax/sqldescribeparam-function.md
+++ b/docs/odbc/reference/syntax/sqldescribeparam-function.md
@@ -30,7 +30,7 @@ manager: craigg
   
 ## Syntax  
   
-```  
+```cpp  
   
 SQLRETURN SQLDescribeParam(  
       SQLHSTMT        StatementHandle,  
@@ -105,7 +105,7 @@ SQLRETURN SQLDescribeParam(
 ## Code Example  
  The following example prompts the user for an SQL statement and then prepares that statement. Next, it calls **SQLNumParams** to determine whether the statement contains any parameters. If the statement contains parameters, it calls **SQLDescribeParam** to describe those parameters and **SQLBindParameter** to bind them. Finally, it prompts the user for the values of any parameters and then executes the statement.  
   
-```  
+```cpp  
 SQLCHAR       Statement[100];  
 SQLSMALLINT   NumParams, i, DataType, DecimalDigits, Nullable;  
 SQLUINTEGER   ParamSize;  


### PR DESCRIPTION
syntax highlighting for code example
added markdown label for the code example language
adding the markdown label makes the code more readable