### PR TITLE
Improve accuracy for Table Value Constructor

### DIFF
--- a/docs/t-sql/queries/table-value-constructor-transact-sql.md
+++ b/docs/t-sql/queries/table-value-constructor-transact-sql.md
@@ -1,7 +1,7 @@
 ---
 title: "Table Value Constructor (Transact-SQL) | Microsoft Docs"
 ms.custom: ""
-ms.date: "05/10/2019"
+ms.date: "05/23/2019"
 ms.prod: sql
 ms.prod_service: "database-engine, sql-database"
 ms.reviewer: ""
@@ -22,7 +22,7 @@ manager: craigg
 # Table Value Constructor (Transact-SQL)
 [!INCLUDE[tsql-appliesto-ss2008-asdb-xxxx-xxx-md](../../includes/tsql-appliesto-ss2008-asdb-xxxx-xxx-md.md)]
 
-  Specifies a set of row value expressions to be constructed into a table. The [!INCLUDE[tsql](../../includes/tsql-md.md)] table value constructor allows multiple rows of data to be specified in a single DML statement. It can be specified either as the VALUES clause of an INSERT ... VALUES statement, or as a derived table in either the USING clause of the MERGE statement or the FROM clause.
+  Specifies a set of row value expressions to be constructed into a table. The [!INCLUDE[tsql](../../includes/tsql-md.md)] table value constructor allows multiple rows of data to be specified in a single DML statement. The table value constructor can be specified either as the VALUES clause of an INSERT ... VALUES statement, or as a derived table in either the USING clause of the MERGE statement or the FROM clause.
   
  ![Topic link icon](../../database-engine/configure-windows/media/topic-link.gif "Topic link icon") [Transact-SQL Syntax Conventions](../../t-sql/language-elements/transact-sql-syntax-conventions-transact-sql.md)  
   
@@ -64,7 +64,7 @@ VALUES ( <row value expression list> ) [ ,...n ]
   
  Only single scalar values are allowed as a row value expression. A subquery that involves multiple columns is not allowed as a row value expression. For example, the following code results in a syntax error because the third row value expression list contains a subquery with multiple columns.  
   
-```  
+```sql
 USE AdventureWorks2012;  
 GO  
 CREATE TABLE dbo.MyProducts (Name varchar(50), ListPrice money);  
@@ -75,25 +75,23 @@ VALUES ('Helmet', 25.50),
        ('Wheel', 30.00),  
        (SELECT Name, ListPrice FROM Production.Product WHERE ProductID = 720);  
 GO  
-  
 ```  
   
  However, the statement can be rewritten by specifying each column in the subquery separately. The following example successfully inserts three rows into the `MyProducts` table.  
   
-```  
+```sql
 INSERT INTO dbo.MyProducts (Name, ListPrice)  
 VALUES ('Helmet', 25.50),  
        ('Wheel', 30.00),  
        ((SELECT Name FROM Production.Product WHERE ProductID = 720),  
         (SELECT ListPrice FROM Production.Product WHERE ProductID = 720));  
 GO  
-  
 ```  
   
 ## Data Types  
  The values specified in a multi-row INSERT statement follow the data type conversion properties of the UNION ALL syntax. This results in the implicit conversion of unmatched types to the type of higher [precedence](../../t-sql/data-types/data-type-precedence-transact-sql.md). If the conversion is not a supported implicit conversion, an error is returned. For example, the following statement inserts an integer value and a character value into a column of type **char**.  
   
-```  
+```sql
 CREATE TABLE dbo.t (a int, b char);  
 GO  
 INSERT INTO dbo.t VALUES (1,'a'), (2, 1);  
@@ -102,7 +100,7 @@ GO
   
  When the INSERT statement is run, [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] tries to convert 'a' to an integer because the data type precedence indicates that an integer is of a higher type than a character. The conversion fails and an error is returned. You can avoid the error by explicitly converting values as appropriate. For example, the previous statement can be written as follows.  
   
-```  
+```sql
 INSERT INTO dbo.t VALUES (1,'a'), (2, CONVERT(CHAR,1));  
 ```  
   
@@ -111,20 +109,19 @@ INSERT INTO dbo.t VALUES (1,'a'), (2, CONVERT(CHAR,1));
 ### A. Inserting multiple rows of data  
  The following example creates the table `dbo.Departments` and then uses the table value constructor to insert five rows into the table. Because values for all columns are supplied and are listed in the same order as the columns in the table, the column names do not have to be specified in the column list.  
   
-```  
+```sql
 USE AdventureWorks2012;  
 GO  
 INSERT INTO Production.UnitMeasure  
 VALUES (N'FT2', N'Square Feet ', '20080923'), (N'Y', N'Yards', '20080923'),
        (N'Y3', N'Cubic Yards', '20080923');  
 GO  
-  
 ```  
   
 ### B. Inserting multiple rows with DEFAULT and NULL values  
  The following example demonstrates specifying DEFAULT and NULL when using the table value constructor to insert rows into a table.  
   
-```  
+```sql
 USE AdventureWorks2012;  
 GO  
 CREATE TABLE Sales.MySalesReason(  
@@ -136,13 +133,12 @@ INSERT INTO Sales.MySalesReason
 VALUES ('Recommendation','Other'), ('Advertisement', DEFAULT), (NULL, 'Promotion');  
   
 SELECT * FROM Sales.MySalesReason;  
-  
 ```  
   
 ### C. Specifying multiple values as a derived table in a FROM clause  
  The following examples use the table value constructor to specify multiple values in the FROM clause of a SELECT statement.  
   
-```  
+```sql
 SELECT a, b FROM (VALUES (1, 2), (3, 4), (5, 6), (7, 8), (9, 10) ) AS MyTable(a, b);  
 GO  
 -- Used in an inner join to specify values to return.  
@@ -150,13 +146,12 @@ SELECT ProductID, a.Name, Color
 FROM Production.Product AS a  
 INNER JOIN (VALUES ('Blade'), ('Crown Race'), ('AWC Logo Cap')) AS b(Name)   
 ON a.Name = b.Name;  
-  
 ```  
   
 ### D. Specifying multiple values as a derived source table in a MERGE statement  
  The following example uses MERGE to modify the `SalesReason` table by either updating or inserting rows. When the value of `NewName` in the source table matches a value in the `Name` column of the target table, (`SalesReason`), the `ReasonType` column is updated in the target table. When the value of `NewName` does not match, the source row is inserted into the target table. The source table is a derived table that uses the [!INCLUDE[tsql](../../includes/tsql-md.md)] table value constructor to specify multiple rows for the source table.  
   
-```  
+```sql
 USE AdventureWorks2012;  
 GO  
 -- Create a temporary table variable to hold the output actions.  
@@ -176,19 +171,17 @@ OUTPUT $action INTO @SummaryOfChanges;
 SELECT Change, COUNT(*) AS CountPerChange  
 FROM @SummaryOfChanges  
 GROUP BY Change;  
-  
 ```  
   
 ### E. Inserting more than 1000 rows
   The following example demonstrates using the table value constructor as a derived table. This allows for inserting more than 1000 rows from a single table value constructor.
   
-```  
+```sql
 CREATE TABLE dbo.Test ([Value] int);  
   
 INSERT INTO dbo.Test ([Value])  
   SELECT drvd.[NewVal]
   FROM   (VALUES (0), (1), (2), (3), ..., (5000)) drvd([NewVal]);
-
 ```  
 
 

--- a/docs/t-sql/queries/table-value-constructor-transact-sql.md
+++ b/docs/t-sql/queries/table-value-constructor-transact-sql.md
@@ -1,7 +1,7 @@
 ---
 title: "Table Value Constructor (Transact-SQL) | Microsoft Docs"
 ms.custom: ""
-ms.date: "08/15/2017"
+ms.date: "05/10/2019"
 ms.prod: sql
 ms.prod_service: "database-engine, sql-database"
 ms.reviewer: ""
@@ -22,7 +22,7 @@ manager: craigg
 # Table Value Constructor (Transact-SQL)
 [!INCLUDE[tsql-appliesto-ss2008-asdb-xxxx-xxx-md](../../includes/tsql-appliesto-ss2008-asdb-xxxx-xxx-md.md)]
 
-  Specifies a set of row value expressions to be constructed into a table. The [!INCLUDE[tsql](../../includes/tsql-md.md)] table value constructor allows multiple rows of data to be specified in a single DML statement. The table value constructor can be specified in the VALUES clause of the INSERT statement, in the USING \<source table> clause of the MERGE statement, and in the definition of a derived table in the FROM clause.  
+  Specifies a set of row value expressions to be constructed into a table. The [!INCLUDE[tsql](../../includes/tsql-md.md)] table value constructor allows multiple rows of data to be specified in a single DML statement. It can be specified either as the VALUES clause of an INSERT ... VALUES statement, or as a derived table in either the USING clause of the MERGE statement or the FROM clause.
   
  ![Topic link icon](../../database-engine/configure-windows/media/topic-link.gif "Topic link icon") [Transact-SQL Syntax Conventions](../../t-sql/language-elements/transact-sql-syntax-conventions-transact-sql.md)  
   
@@ -52,13 +52,15 @@ VALUES ( <row value expression list> ) [ ,...n ]
  Is a constant, a variable, or an expression. The expression cannot contain an EXECUTE statement.  
   
 ## Limitations and Restrictions  
- Table value constructors can be used in one of two ways: directly in the VALUES list of an INSERT ... VALUES statement, or as a derived table anywhere that derived tables are allowed. Error 10738 is returned if the number of rows exceeds the maximum. To insert more rows than the limit allows, use one of the following methods:  
+ When used as a derived table, there is no limit to the number of rows.  
+ 
+ When used as the VALUES clause of an INSERT ... VALUES statement, there is a limit of 1000 rows. Error 10738 is returned if the number of rows exceeds the maximum. To insert more than 1000 rows, use one of the following methods:  
   
--   Create multiple INSERT statements  
+- Create multiple INSERT statements  
   
--   Use a derived table  
+- Use a derived table  
   
--   Bulk import the data by using the **bcp** utility or the BULK INSERT statement  
+- Bulk import the data by using the [**bcp** utility](../../tools/bcp-utility.md), the .NET [SqlBulkCopy class](../../../dotnet/api/system.data.sqlclient.sqlbulkcopy.md), [OPENROWSET (BULK ...)](../../t-sql/functions/openrowset-transact-sql.md), or the [BULK INSERT](../../t-sql/statements/bulk-insert-transact-sql.md) statement  
   
  Only single scalar values are allowed as a row value expression. A subquery that involves multiple columns is not allowed as a row value expression. For example, the following code results in a syntax error because the third row value expression list contains a subquery with multiple columns.  
   
@@ -113,7 +115,8 @@ INSERT INTO dbo.t VALUES (1,'a'), (2, CONVERT(CHAR,1));
 USE AdventureWorks2012;  
 GO  
 INSERT INTO Production.UnitMeasure  
-VALUES (N'FT2', N'Square Feet ', '20080923'), (N'Y', N'Yards', '20080923'), (N'Y3', N'Cubic Yards', '20080923');  
+VALUES (N'FT2', N'Square Feet ', '20080923'), (N'Y', N'Yards', '20080923'),
+       (N'Y3', N'Cubic Yards', '20080923');  
 GO  
   
 ```  
@@ -176,6 +179,19 @@ GROUP BY Change;
   
 ```  
   
+### E. Inserting more than 1000 rows
+  The following example demonstrates using the table value constructor as a derived table. This allows for inserting more than 1000 rows from a single table value constructor.
+  
+```  
+CREATE TABLE dbo.Test ([Value] int);  
+  
+INSERT INTO dbo.Test ([Value])  
+  SELECT drvd.[NewVal]
+  FROM   (VALUES (0), (1), (2), (3), ..., (5000)) drvd([NewVal]);
+
+```  
+
+
 ## See Also  
  [INSERT &#40;Transact-SQL&#41;](../../t-sql/statements/insert-transact-sql.md)   
  [MERGE &#40;Transact-SQL&#41;](../../t-sql/statements/merge-transact-sql.md)   


### PR DESCRIPTION
This PR resolves issue #2090 .

1. Reword main description such that it does not imply that the `USING` clause of the `MERGE` statement is a third and separate case from `INSERT ... VALUES` and derived tables. It is a derived table as the `USING` clause is really just a `FROM` clause (even the `MERGE` documentation states as much by directing the reader to view the documentation for the `FROM` clause: https://docs.microsoft.com/en-us/sql/t-sql/statements/merge-transact-sql#arguments ).
2. Changed the wording of "directly _in_ the VALUES list of an INSERT ... VALUES statement" to be "_as_ the VALUES clause of an INSERT ... VALUES statement":
     a. removed "directly" since it is technically a "direct" usage whether here or as a derived table
     b. use "as ... clause" instead of "in ... list" since "in" implies that the "VALUES" keyword is already there, which would end up being "VALUES (VALUES (), (), ... )" which is incorrect. Since the "VALUES" keyword is an inherent part of the Table Value Constructor (TVC), it cannot be that a TVC is used "in" a VALUES list, which assumes that `VALUES` is already present. Yes, nit-picky, but this phrasing is more accurate.
3. Removed the redundant restatement of the two places where the TVC can be used. That was stated clearly in the main description at the top of the page.
4. State the actual limit. We know it's 1000 rows, so why not state it?
5. State clearly that the row limit does _not_ apply when using the TVC as a derived table.
6. Add 2 methods for bulk inserting: .NET SqlBulkCopy class, and OPENROWSET(BULK ...)
7. For all 4 bulk insert methods, link to the actual documentation (why make the reader do an extra search for them?). Not 100% sure about the relative path for the .NET documentation. That might need to be an absolute path. Not sure how to test that prior to submitting.
8. Added newline to TVC in Example A to prevent forcing the reader to need to scroll sideways.
9. Added Example E to illustrate what is meant by "use a derived table to insert more than 1000 rows".

I have tested on SQL Server 2012, 2017, and 2019 CTP 2.5.

For more details, please see: https://sqlquantumleap.com/2019/05/09/maximum-number-of-rows-for-the-table-value-constructor/