### PR TITLE
Correct note about deployment models

### DIFF
--- a/docs/integration-services/packages/deploy-integration-services-ssis-projects-and-packages.md
+++ b/docs/integration-services/packages/deploy-integration-services-ssis-projects-and-packages.md
@@ -30,7 +30,7 @@ manager: craigg
 For more information about the legacy package deployment model, see [Legacy Package Deployment &#40;SSIS&#41;](../../integration-services/packages/legacy-package-deployment-ssis.md).  
   
 > [!NOTE]  
->  The project deployment model was introduced in [!INCLUDE[ssISversion11](../../includes/ssisversion11-md.md)]. With this deployment model, you were not able to deploy one or more packages without deploying the whole project. [!INCLUDE[ssISversion13](../../includes/ssisversion13-md.md)] introduced the package deployment model, which lets you deploy one or more packages without deploying the whole project.  
+>  The project deployment model was introduced in [!INCLUDE[ssISversion11](../../includes/ssisversion11-md.md)]. With this deployment model, you were not able to deploy one or more packages without deploying the whole project. [!INCLUDE[ssISversion13](../../includes/ssisversion13-md.md)] introduced the Incremental Package Deployment feature, which lets you deploy one or more packages without deploying the whole project.  
 
 > [!NOTE]
 > This article describes how to deploy SSIS packages in general, and how to deploy packages on premises. You can also deploy SSIS packages to the following platforms:


### PR DESCRIPTION
The edited note was confusing, as it reused the phrase "package deployment model" which already refers to the "Legacy Package Deployment Model". The old wording suggested (implicitly) that the Legacy Package Deployment Model was re-introduced in SQL Server 2016. 

I'm just learning about this but I believe that to be false. Based on text further down (line 57), the truth seems to be that the new Project Deployment Model was extended in 2016, to reintroduce a feature to deploy per-package, but that this wasn't really the same as the Legacy Package Deployment Model, which was and is "gone for good". 

Assuming my interpretation is correct, I've edited the note to match the content of line 57.