### PR TITLE
Correct an error in one of the create PK examples

### DIFF
--- a/docs/relational-databases/tables/create-primary-keys.md
+++ b/docs/relational-databases/tables/create-primary-keys.md
@@ -108,7 +108,7 @@ monikerRange: "=azuresqldb-current||>=sql-server-2016||=sqlallproducts-allversio
     (  
        CustomerID uniqueidentifier DEFAULT NEWSEQUENTIALID(),
        TransactionID int IDENTITY (1,1) NOT NULL,  
-       CONSTRAINT PK_TransactionHistoryArchive_TransactionID PRIMARY KEY NONCLUSTERED (uniqueidentifier)  
+       CONSTRAINT PK_TransactionHistoryArchive1_CustomerID PRIMARY KEY NONCLUSTERED (CustomerID)  
     );  
     GO  
 


### PR DESCRIPTION
Corrected the column specified in the constraint. It was "uniqueidentifier" instead of "CustomerID".

Changed the name of "PK_TransactionHistoryArchive_TransactionID" to "PK_TransactionHistoryArchive1_CustomerID" to reflect the name of the table and the name of the PK column.