### PR TITLE
Updating release note and removing Java SDK note

### DIFF
--- a/docs/sql-server/what-s-new-in-sql-server-ver15.md
+++ b/docs/sql-server/what-s-new-in-sql-server-ver15.md
@@ -47,7 +47,7 @@ In addition, the following features are added or enhanced for [!INCLUDE[sql-serv
 
 | New feature or update | Details |
 |:---|:---|
-|SQL Server extensibility - Java extension|The Microsoft Extensibility SDK for Java for Microsoft SQL Server is now open sourced and available on [GitHub](http://aka.ms/mssql-java-lang-extension). |
+
 |Register external languages|New DDL, `CREATE EXTERNAL LANGUAGE`, registers external languages, like Java, in SQL Server. See [CREATE EXTERNAL LANGUAGE](../t-sql/statements/create-external-language-transact-sql.md). |
 |More supported data types for Java|See [Java data types](../language-extensions/how-to/java-to-sql-data-types.md).|
 |Custom capture policy for the Query Store|When enabled, additional Query Store configurations are available under a new Query Store Capture Policy setting, to fine tune data collection in a specific server. For more information, see [ALTER DATABASE SET Options](../t-sql/statements/alter-database-transact-sql-set-options.md).|


### PR DESCRIPTION
We have not yet published on GitHub so the release note was misleading. Once we have GitHub open, I will add it back with correct link. @dphansen @MikeRayMSFT