### PR TITLE
clean up CREATE ASYMMETRIC KEY

### DIFF
--- a/docs/t-sql/statements/create-asymmetric-key-transact-sql.md
+++ b/docs/t-sql/statements/create-asymmetric-key-transact-sql.md
@@ -1,7 +1,7 @@
 ---
 title: "CREATE ASYMMETRIC KEY (Transact-SQL) | Microsoft Docs"
 ms.custom: ""
-ms.date: "08/07/2017"
+ms.date: "05/23/2019"
 ms.prod: sql
 ms.prod_service: "database-engine, sql-database"
 ms.reviewer: ""
@@ -37,18 +37,18 @@ manager: craigg
 ## Syntax  
   
 ```  
-CREATE ASYMMETRIC KEY Asym_Key_Name   
+CREATE ASYMMETRIC KEY asym_key_name   
    [ AUTHORIZATION database_principal_name ]  
-   [ FROM <Asym_Key_Source> ]  
+   [ FROM <asym_key_source> ]  
    [ WITH <key_option> ] 
    [ ENCRYPTION BY <encrypting_mechanism> ] 
    [ ; ]
   
-<Asym_Key_Source>::=  
+<asym_key_source>::=  
      FILE = 'path_to_strong-name_file'  
    | EXECUTABLE FILE = 'path_to_executable_file'  
-   | ASSEMBLY Assembly_Name  
-   | PROVIDER Provider_Name  
+   | ASSEMBLY assembly_name  
+   | PROVIDER provider_name  
   
 <key_option> ::=  
    ALGORITHM = <algorithm>  
@@ -65,51 +65,54 @@ CREATE ASYMMETRIC KEY Asym_Key_Name
 ```  
   
 ## Arguments  
- FROM *Asym_Key_Source*  
- Specifies the source from which to load the asymmetric key pair.  
-  
+ *asym_key_name*  
+ Is the name for the asymmetric key in the database. Asymmetric key names must comply with the rules for [identifiers](../../relational-databases/databases/database-identifiers.md) and must be unique within the database.  
+
  AUTHORIZATION *database_principal_name*  
  Specifies the owner of the asymmetric key. The owner cannot be a role or a group. If this option is omitted, the owner will be the current user.  
   
- FILE ='*path_to_strong-name_file*'  
- Specifies the path of a strong-name file from which to load the key pair.  
+ FROM *asym_key_source*  
+ Specifies the source from which to load the asymmetric key pair.  
+  
+ FILE = '*path_to_strong-name_file*'  
+ Specifies the path of a strong-name file from which to load the key pair. Limited to 260 characters by MAX_PATH from the Windows API.  
   
 > [!NOTE]  
 >  This option is not available in a contained database.  
   
- EXECUTABLE FILE ='*path_to_executable_file*'  
- Specifies an assembly file from which to load the public key. Limited to 260 characters by MAX_PATH from the Windows API.  
+ EXECUTABLE FILE = '*path_to_executable_file*'  
+ Specifies the path of an assembly file from which to load the public key. Limited to 260 characters by MAX_PATH from the Windows API.  
   
 > [!NOTE]  
 >  This option is not available in a contained database.  
   
- ASSEMBLY *Assembly_Name*  
- Specifies the name of an assembly from which to load the public key.  
+ ASSEMBLY *assembly_name*  
+ Specifies the name of a signed assembly that has already been loaded into the database from which to load the public key.  
   
-ENCRYPTION BY *\<key_name_in_provider>*
- Specifies how the key is encrypted. Can be a certificate, password, or asymmetric key.  
-  
- KEY_NAME ='*key_name_in_provider*'  
- Specifies the key name from the external provider. For more information about external key management, see [Extensible Key Management &#40;EKM&#41;](../../relational-databases/security/encryption/extensible-key-management-ekm.md).  
-  
- CREATION_DISPOSITION = CREATE_NEW  
- Creates a new key on the Extensible Key Management device. PROV_KEY_NAME must be used to specify key name on the device. If a key already exists on the device the statement fails with error.  
-  
- CREATION_DISPOSITION = OPEN_EXISTING  
- Maps a [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] asymmetric key to an existing Extensible Key Management key. PROV_KEY_NAME must be used to specify key name on the device. If CREATION_DISPOSITION = OPEN_EXISTING is not provided, the default is CREATE_NEW.  
+ PROVIDER *provider_name*  
+ Specifies the name of an Extensible Key Management (EKM) provider. The provider must be defined first using the CREATE PROVIDER statement. For more information about external key management, see [Extensible Key Management &#40;EKM&#41;](../../relational-databases/security/encryption/extensible-key-management-ekm.md).  
   
  ALGORITHM = \<algorithm>  
  Five algorithms can be provided; RSA_4096, RSA_3072, RSA_2048, RSA_1024, and RSA_512.  
   
  RSA_1024 and RSA_512 are deprecated. To use RSA_1024 or RSA_512 (not recommended) you must set the database to database compatibility level 120 or lower.  
   
- PASSWORD = '*password*'  
+ PROVIDER_KEY_NAME = '*key_name_in_provider*'  
+ Specifies the key name from the external provider.  
+  
+ CREATION_DISPOSITION = CREATE_NEW  
+ Creates a new key on the Extensible Key Management device. PROVIDER_KEY_NAME must be used to specify key name on the device. If a key already exists on the device the statement fails with error.  
+  
+ CREATION_DISPOSITION = OPEN_EXISTING  
+ Maps a [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] asymmetric key to an existing Extensible Key Management key. PROVIDER_KEY_NAME must be used to specify key name on the device. If CREATION_DISPOSITION = OPEN_EXISTING is not provided, the default is CREATE_NEW.  
+  
+ ENCRYPTION BY PASSWORD = '*password*'  
  Specifies the password with which to encrypt the private key. If this clause is not present, the private key will be encrypted with the database master key. *password* is a maximum of 128 characters. *password* must meet the Windows password policy requirements of the computer that is running the instance of [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)].  
   
 ## Remarks  
- An *asymmetric key* is a securable entity at the database level. In its default form, this entity contains both a public key and a private key. When executed without the FROM clause, CREATE ASYMMETRIC KEY generates a new key pair. When executed with the FROM clause, CREATE ASYMMETRIC KEY imports a key pair from a file or imports a public key from an assembly.  
+ An *asymmetric key* is a securable entity at the database level. In its default form, this entity contains both a public key and a private key. When executed without the FROM clause, CREATE ASYMMETRIC KEY generates a new key pair. When executed with the FROM clause, CREATE ASYMMETRIC KEY imports a key pair from a file, or imports a public key from an assembly or DLL file.  
   
- By default, the private key is protected by the database master key. If no database master key has been created, a password is required to protect the private key. If a database master key does exist, the password is optional.  
+ By default, the private key is protected by the database master key. If no database master key has been created, a password is required to protect the private key.  
   
  The private key can be 512, 1024, or 2048 bits long.  
   
@@ -129,17 +132,17 @@ GO
 ```  
   
 ### B. Creating an asymmetric key from a file, giving authorization to a user  
- The following example creates the asymmetric key `PacificSales19` from a key pair stored in a file, and then authorizes user `Christina` to use the asymmetric key.  
+ The following example creates the asymmetric key `PacificSales19` from a key pair stored in a file, and assigns ownership of the asymmetric key to user `Christina`. The private key is protected by the database master key, which must be created prior to creating the asymmetric key.  
   
 ```  
-CREATE ASYMMETRIC KEY PacificSales19 AUTHORIZATION Christina   
-    FROM FILE = 'c:\PacSales\Managers\ChristinaCerts.tmp'    
-    ENCRYPTION BY PASSWORD = '<enterStrongPasswordHere>';  
+CREATE ASYMMETRIC KEY PacificSales19  
+    AUTHORIZATION Christina  
+    FROM FILE = 'c:\PacSales\Managers\ChristinaCerts.tmp';  
 GO  
 ```  
   
 ### C. Creating an asymmetric key from an EKM provider  
- The following example creates the asymmetric key `EKM_askey1` from a key pair stored in a file. It then encrypts it using an Extensible Key Management provider called `EKMProvider1`, and a key on that provider called `key10_user1`.  
+ The following example creates the asymmetric key `EKM_askey1` from a key pair stored in an Extensible Key Management provider called `EKM_Provider1`, and a key on that provider called `key10_user1`.  
   
 ```  
 CREATE ASYMMETRIC KEY EKM_askey1   
@@ -152,10 +155,12 @@ GO
 ```  
   
 ## See Also  
- [Choose an Encryption Algorithm](../../relational-databases/security/encryption/choose-an-encryption-algorithm.md)   
- [ALTER ASYMMETRIC KEY &#40;Transact-SQL&#41;](../../t-sql/statements/alter-asymmetric-key-transact-sql.md)   
- [DROP ASYMMETRIC KEY &#40;Transact-SQL&#41;](../../t-sql/statements/drop-asymmetric-key-transact-sql.md)   
- [Encryption Hierarchy](../../relational-databases/security/encryption/encryption-hierarchy.md)   
+ [ALTER ASYMMETRIC KEY &#40;Transact-SQL&#41;](../../t-sql/statements/alter-asymmetric-key-transact-sql.md)  
+ [DROP ASYMMETRIC KEY &#40;Transact-SQL&#41;](../../t-sql/statements/drop-asymmetric-key-transact-sql.md)  
+ [ASYMKEYPROPERTY &#40;Transact-SQL&#41;](../../t-sql/functions/asymkeyproperty-transact-sql.md)  
+ [ASYMKEY_ID &#40;Transact-SQL&#41;](../../t-sql/functions/asymkey-id-transact-sql.md)  
+ [Choose an Encryption Algorithm](../../relational-databases/security/encryption/choose-an-encryption-algorithm.md)  
+ [Encryption Hierarchy](../../relational-databases/security/encryption/encryption-hierarchy.md)  
  [Extensible Key Management Using Azure Key Vault &#40;SQL Server&#41;](../../relational-databases/security/encryption/extensible-key-management-using-azure-key-vault-sql-server.md)  
   
   


### PR DESCRIPTION
These changes pertain to Issue #2198 .

1. **Syntax** section:
    1. Lowercased user-supplied values to be consistent with other documentation pages

2. **Arguments** section:
    1. Added missing entry for _asym_key_name_
    2. Moved `AUTHORIZATION` to the top to match order in **Syntax** section
    3. Improved definition of `FILE` option
    4. Improved definition of `EXECUTABLE FILE` option
    5. Improved definition of `ASSEMBLY` option
    6. Added missing entry for `PROVIDER`
    7. Removed `ENCRYPTION BY *\<key_name_in_provider>*` as it is not a valid as stated (is part of `ENCRYPTION BY PASSWORD` -- see below)
    8. Moved `ALGORITHM` up to match order of options shown in **Syntax** section
    9. Changed `PASSWORD` to be `ENCRYPTION BY PASSWORD`
    10. Lowercased user-supplied values to be consistent with other documentation pages

3. **Remarks** section:
    1. Added "or DLL file" to end of 1st paragraph, regarding the `FROM` clause (yes, DLL from either file system or as a loaded assembly -- same thing just different location -- only stores the public key)
    2. Removed 3rd sentence of 2nd paragraph -- "If a database master key does exist, the password is optional." -- as it contradicted the 2nd sentence, and was just incorrect. With no DMK, the following statement:

        ```sql
        CREATE ASYMMETRIC KEY [AKeyNoPassword]
        WITH ALGORITHM = RSA_2048;
        ```
        gets the following error:

        > /*
        > Msg 15581, Level 16, State 6, Line XXXXX
        > Please create a master key in the database or open the master key in the session before performing this operation.
        > */

4. **Examples** section:
   1. In example "B", for correctness changed

        > and then authorizes user `Christina` to use the asymmetric key

        to be:

        > and assigns ownership of the asymmetric key to user `Christina`
    2. In example "B", for variety removed `ENCRYPTION BY PASSWORD` clause as that is shown in example "A". Without this clause, the Database Master Key will be used, hence it must already exist. I added a sentence mentioning this to the end of the example description.
    3. In example "C", for correctness changed 

        > stored in a file. It then encrypts it using an Extensible

       to be:

       > stored in an Extensible
    4. In example "C", fixed name "EKMProvider1" to be "EKM_Provider1" (to match T-SQL statement) in example description
    5. In example "C", not sure if lack of `ENCRYPTION BY PASSWORD` implies Database Master Key is used, or if that is a non-issue when using an EKM provider. I have never used an EKM provider so for now I am leaving that part as is (i.e. not mentioned in the example description).

5. **See Also** section:
    1. Moved "Choose an Encryption Algorithm" to below statements and functions for better organization
    2. Added links to functions: `ASYMKEYPROPERTY` and `ASYMKEY_ID`