### PR TITLE
Update manage-subscription-owners-and-run-subscription-powershell.md

### DIFF
--- a/docs/2014/reporting-services/subscriptions/manage-subscription-owners-and-run-subscription-powershell.md
+++ b/docs/2014/reporting-services/subscriptions/manage-subscription-owners-and-run-subscription-powershell.md
@@ -207,7 +207,7 @@ ForEach ($item in $items)
         $curRepSubs = $rs2010.ListSubscriptions($item.Path);  
         ForEach ($curRepSub in $curRepSubs)  
         {  
-            if ($curRepSub.Owner -eq $previousOwner)  
+            if ($curRepSub.Owner -eq $currentOwner)  
             {  
                 $subscriptions += $curRepSub;  
             }  


### PR DESCRIPTION
Line 210: current subscription owner variable was listed as "$previousOwner"; not defined elsewhere. Changed to "$currentOwner" to reflect the parameter definition in lines 188 and 193.