### PR TITLE
Fixed argument description for original_publisher

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-get-redirected-publisher-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-get-redirected-publisher-transact-sql.md
@@ -34,7 +34,7 @@ sp_get_redirected_publisher
   
 ## Arguments  
 `[ @original_publisher = ] 'original_publisher'`
- The name of the database being published. *publisher_db* is **sysname**, with no default.  
+ The name of the instance of SQL Server that originally published the database. *original_publisher* is **sysname**, with no default.
   
 `[ @publisher_db = ] 'publisher_db'`
  The name of the database being published. *publisher_db* is **sysname**, with no default.  


### PR DESCRIPTION
The description for @original_publisher is the same as @publisher_db but should be as follows:

[ @original_publisher = ] 'original_publisher' The name of the instance of SQL Server that originally published the database. original_publisher is sysname, with no default.