### PR TITLE
Fix Terminology

### DIFF
--- a/docs/database-engine/availability-groups/windows/read-scale-availability-groups.md
+++ b/docs/database-engine/availability-groups/windows/read-scale-availability-groups.md
@@ -28,7 +28,7 @@ In [!INCLUDE[sssql15-md](../../../includes/sssql15-md.md)] and earlier, all avai
 If your business requirement is to conserve resources for mission-critical workloads that run on the primary replica, you can use read-only routing or directly connect to readable secondary replicas. You don't need to depend on integration with any clustering technology. These new capabilities are available for SQL Server 2017 running on both Windows and Linux platforms.
 
 >[!IMPORTANT]
->This is not a high-availability setup. There is no infrastructure to monitor and coordinate failure detection and automatic failover. Without a cluster, SQL Server can't provide the low recovery time objective (RTO) that an automated high-availability solution provides. If you need high-availability capabilities, use a cluster manager (Windows Server failover clustering on Windows or Pacemaker on Linux).
+>This is not a high-availability setup. There is no infrastructure to monitor and coordinate failure detection and automatic failover. Without a cluster, SQL Server can't provide the low recovery time objective (RTO) that an automated high-availability solution provides. If you need high-availability capabilities, use a cluster manager (Windows Server Failover Cluster on Windows or Pacemaker on Linux).
 >
 >The read-scale availability group can provide disaster recovery capability. When the read-only replicas are in synchronous-commit mode, they provide a recovery point objective (RPO) of zero. To fail over a read-scale availability group, see [Fail over the primary replica on a read-scale availability group](perform-a-planned-manual-failover-of-an-availability-group-sql-server.md#ReadScaleOutOnly).
 


### PR DESCRIPTION
Windows Server failover clustering was used; in this context you are referring to the Windows Server Failover Cluster [WSFC]. This has been fixed in other places.