### PR TITLE
Feature name fix

### DIFF
--- a/docs/sql-server/editions-and-components-of-sql-server-2017.md
+++ b/docs/sql-server/editions-and-components-of-sql-server-2017.md
@@ -162,7 +162,7 @@ The Developer edition continues to support only 1 client for [SQL Server Distrib
 |Database recovery advisor|Yes|Yes|Yes|Yes|Yes|
 |Encrypted backup|Yes|Yes|No|No|No|
 |Hybrid backup to Windows Azure (backup to URL)|Yes|Yes|No|No|No|
-|Clusterless availability group|Yes|Yes|No|No|No|No|
+|Read-scale availability group|Yes|Yes|No|No|No|No|
 |Minimum replica commit availability group|Yes|Yes|Yes|No|No|No|
   
 


### PR DESCRIPTION
The proper name for an AG without a cluster is a read scale (availability) group.