### PR TITLE
Example is missing XML elements

### DIFF
--- a/docs/t-sql/xml/nodes-method-xml-data-type.md
+++ b/docs/t-sql/xml/nodes-method-xml-data-type.md
@@ -72,15 +72,15 @@ A `nodes()` method invocation with the query expression `/root/Location` would r
 Product  
 ModelID      Instructions  
 ----------------------------------  
-1       <root>  
+1      <root><Location LocationID="10" ... />  
              <Location LocationID="20" ... />  
              <Location LocationID="30" .../></root>  
 1      <root><Location LocationID="10" ... />  
-  
+             <Location LocationID="20" ... />  
              <Location LocationID="30" .../></root>  
 1      <root><Location LocationID="10" ... />  
              <Location LocationID="20" ... />  
-             </root>  
+             <Location LocationID="30" .../></root>  
 ```  
   
 You can then query this rowset by using **xml** data type methods. The following query extracts the subtree of the context item for each generated row:  


### PR DESCRIPTION
Each of the rows in the example is missing one element, namely the one that is the "context item" mentioned in the description immediately above the example