### PR TITLE
Updated applies to - exclude MI

### DIFF
--- a/docs/ssms/agent/resize-the-job-history-log.md
+++ b/docs/ssms/agent/resize-the-job-history-log.md
@@ -21,7 +21,7 @@ manager: craigg
 monikerRange: "= azuresqldb-mi-current || >= sql-server-2016 || = sqlallproducts-allversions"
 ---
 # Resize the Job History Log
-[!INCLUDE[appliesto-ss-asdbmi-xxxx-xxx-md](../../includes/appliesto-ss-asdbmi-xxxx-xxx-md.md)]
+[!INCLUDE[appliesto-ss-xxxx-xxxx-xxx-md.md](../../includes/appliesto-ss-xxxx-xxxx-xxx-md.md)]
 
 > [!IMPORTANT]  
 > On [Azure SQL Database Managed Instance](https://docs.microsoft.com/azure/sql-database/sql-database-managed-instance), most, but not all SQL Server Agent features are currently supported. See [Azure SQL Database Managed Instance T-SQL differences from SQL Server](https://docs.microsoft.com/azure/sql-database/sql-database-managed-instance-transact-sql-information#sql-server-agent) for details.


### PR DESCRIPTION
Updated applies to from 'appliesto-ss-asdbmi-xxxx-xxx-md.md' to 'appliesto-ss-xxxx-xxxx-xxx-md.md' since Managed Instance does not support resizing SQL agent job history. 

Reference article:

https://docs.microsoft.com/en-us/azure/sql-database/sql-database-managed-instance-transact-sql-information#sql-server-agent 
•SQL Server Agent settings are read only. The procedure sp_set_agent_properties isn't supported in Managed Instance.

And there is no right click - properties - option when working with Managed Instance for SQL Server Agent.