### PR TITLE
Update unicode-transact-sql.md

### DIFF
--- a/docs/t-sql/functions/unicode-transact-sql.md
+++ b/docs/t-sql/functions/unicode-transact-sql.md
@@ -82,7 +82,7 @@ SET @nstring = N'Åkergatan 24';
 -- the actual Unicode character you are processing, and the UNICODE   
 -- value for this particular character.  
 PRINT 'Character #' + ' ' + 'Unicode Character' + ' ' + 'UNICODE Value';  
-WHILE @position <= DATALENGTH(@nstring)  
+WHILE @position <= LEN(@nstring)  
 -- While these are still characters in the character string,  
    BEGIN;  
    SELECT @position,   


### PR DESCRIPTION
the original author meant length, not datalength. As written, the code will return several NULL rows.