### PR TITLE
Fix typo in enable-kerberos.md

### DIFF
--- a/docs/azure-data-studio/enable-kerberos.md
+++ b/docs/azure-data-studio/enable-kerberos.md
@@ -154,7 +154,7 @@ Get a Ticket Granting Ticket (TGT) from KDC.
 kinit username@DOMAIN.COMPANY.COM
 ```
 
-View the available tickets using kinit. If the kinit was successful, you should see a ticket. 
+View the available tickets using klist. If the kinit was successful, you should see a ticket. 
 
 ```bash
 klist


### PR DESCRIPTION
The documentation says "View the available tickets using kinit", should be "View the available tickets using klist", per the code snippet below.