### PR TITLE
Corrected syntax to OPTIMIZE_FOR_SEQUENTIAL_KEY

### DIFF
--- a/docs/t-sql/statements/alter-table-index-option-transact-sql.md
+++ b/docs/t-sql/statements/alter-table-index-option-transact-sql.md
@@ -1,5 +1,5 @@
 ---
-title: "index_option (Transact-SQL) | Microsoft Docs"
+title: " | Microsoft Docs"
 ms.custom: ""
 ms.date: 06/26/2019
 ms.prod: sql
@@ -33,7 +33,7 @@ manager: craigg
   | STATISTICS_NORECOMPUTE = { ON | OFF }  
   | ALLOW_ROW_LOCKS = { ON | OFF }  
   | ALLOW_PAGE_LOCKS = { ON | OFF } 
-  | OPTIMIZE_FOR_SEQUENTIAL_INSERTS = { ON | OFF } 
+  | OPTIMIZE_FOR_SEQUENTIAL_KEY = { ON | OFF } 
   | SORT_IN_TEMPDB = { ON | OFF }   
   | ONLINE = { ON | OFF }  
   | MAXDOP = max_degree_of_parallelism  


### PR DESCRIPTION
Changed syntax to specify OPTIMIZE_FOR_SEQUENTIAL_KEY instead of OPTIMIZE_FOR_SEQUENTIAL_INSERTS to reflect rest of doc page and current SQL 2019 CTP3.1 implementation.