### PR TITLE
Fixed grammar definition, added example

### DIFF
--- a/docs/t-sql/statements/create-type-transact-sql.md
+++ b/docs/t-sql/statements/create-type-transact-sql.md
@@ -46,13 +46,15 @@ manager: craigg
 -- User-defined Data Type Syntax    
 CREATE TYPE [ schema_name. ] type_name  
 {   
-    FROM base_type   
-    [ ( precision [ , scale ] ) ]  
-    [ NULL | NOT NULL ]   
-  | EXTERNAL NAME assembly_name [ .class_name ]   
-AS TABLE ( { <column_definition> | <computed_column_definition> [ ,... n ] }
-    | [ <table_constraint> ] [ ,... n ]    
-    | [ <table_index> ] [ ,... n ] } )
+    [
+      FROM base_type   
+      [ ( precision [ , scale ] ) ]  
+      [ NULL | NOT NULL ]
+    ]
+    | EXTERNAL NAME assembly_name [ .class_name ]   
+    | AS TABLE ( { <column_definition> | <computed_column_definition> [ ,... n ] }
+      [ <table_constraint> ] [ ,... n ]    
+      [ <table_index> ] [ ,... n ] } )
  
 } [ ; ]  
   
@@ -311,6 +313,25 @@ CREATE TYPE LocationTableType AS TABLE
     , CostRate INT );  
 GO  
 ```  
+
+### D. Creating a user-defined table type with primary key and index
+The following example creates a user-defined table type that has three columns, one of which (`Name`) is the primary key and another (`Price`) has a non-clustered index.  For more information about how to create and use table-valued parameters, see [Use Table-Valued Parameters &#40;Database Engine&#41;](../../relational-databases/tables/use-table-valued-parameters-database-engine.md).
+
+```sql
+CREATE TYPE InventoryItem AS TABLE
+(
+	[Name] NVARCHAR(50) NOT NULL,
+	SupplierId BIGINT NOT NULL,
+	Price DECIMAL (18, 4) NULL,
+	PRIMARY KEY (
+		Name
+	),
+	INDEX IX_InventoryItem_Price (
+		Price
+	)
+)
+GO
+```
   
 ## See Also  
  [CREATE ASSEMBLY &#40;Transact-SQL&#41;](../../t-sql/statements/create-assembly-transact-sql.md)   


### PR DESCRIPTION
Hi @stevestein  and @MightyPen , 

I saw this issue today while someone was trying to create an extension for FluentMigrator (project I'm co-maintainer of).  I think it is mostly just a formatting issue, probably as people were porting from the old Microsoft documentation over to GitHub markdown.  I also added an example, since I actually never knew you could add a primary key or index on a user-defined data type.