### PR TITLE
Correct typo

### DIFF
--- a/docs/linux/sql-server-linux-configure-docker.md
+++ b/docs/linux/sql-server-linux-configure-docker.md
@@ -303,7 +303,7 @@ docker ps
 To start a bash terminal in the container run:
 
 ```bash
-docker exec -ti <Container ID> /bin/bash
+docker exec -it <Container ID> /bin/bash
 ```
 
 Now you can run commands as though you are running them at the terminal inside the container. When finished, type `exit`. This exits in the interactive command session, but your container continues to run.


### PR DESCRIPTION
The interactive parameter for use with docker container is "it", not "ti"