### PR TITLE
fn_hadr_is_primary_replica internally uses dm_hadr_database_replica_states

### DIFF
--- a/docs/relational-databases/system-functions/sys-fn-hadr-is-primary-replica-transact-sql.md
+++ b/docs/relational-databases/system-functions/sys-fn-hadr-is-primary-replica-transact-sql.md
@@ -63,13 +63,19 @@ END
 ```  
 SELECT sys.fn_hadr_is_primary_replica ('TestDB');  
 GO  
-```  
+```    
+  
+## Security  
+  
+### Permissions  
+ Requires VIEW SERVER STATE permission on the server.  
   
 ## See Also  
  [AlwaysOn Availability Groups Functions &#40;Transact-SQL&#41;](../../relational-databases/system-functions/always-on-availability-groups-functions-transact-sql.md)   
+ [sys.dm_hadr_database_replica_states &#40;Transact-SQL&#41;](../..//relational-databases/system-dynamic-management-views/sys-dm-hadr-database-replica-states-transact-sql.md)
  [AlwaysOn Availability Groups &#40;SQL Server&#41;](../../database-engine/availability-groups/windows/always-on-availability-groups-sql-server.md)   
  [CREATE AVAILABILITY GROUP &#40;Transact-SQL&#41;](../../t-sql/statements/create-availability-group-transact-sql.md)   
  [ALTER AVAILABILITY GROUP &#40;Transact-SQL&#41;](../../t-sql/statements/alter-availability-group-transact-sql.md)   
- [AlwaysOn Availability Groups Catalog Views &#40;Transact-SQL&#41;](../../relational-databases/system-catalog-views/always-on-availability-groups-catalog-views-transact-sql.md)  
+ [AlwaysOn Availability Groups Catalog Views &#40;Transact-SQL&#41;](../../relational-databases/system-catalog-views/always-on-availability-groups-catalog-views-transact-sql.md)     
   
   


### PR DESCRIPTION
At least in SQL Server 2016 SP2-CU7 sys.fn_hadr_is_primary_replica internally uses sys.dm_hadr_database_replica_states and seems to exhibit the same permission checks.

While I really would have hoped the documentation was right, that no special permissions are needed, it seems, that this is not the case.