### PR TITLE
Update walkthrough-set-up-integration-services-scale-out.md

### DIFF
--- a/docs/integration-services/scale-out/walkthrough-set-up-integration-services-scale-out.md
+++ b/docs/integration-services/scale-out/walkthrough-set-up-integration-services-scale-out.md
@@ -155,7 +155,7 @@ On the Scale Out Master computer, open the port specified during the Scale Out M
 
 If you didn't set the startup type of the services to **Automatic** during installation, start the following services:
 
--   SQL Server Integration Services Scale Out Master 14.0 (SSISScaleOutMaster140S
+-   SQL Server Integration Services Scale Out Master 14.0 (SSISScaleOutMaster140)
 
 -   SQL Server Integration Services Scale Out Worker 14.0 (SSISScaleOutWorker140)
 


### PR DESCRIPTION
Fixed the parentheses:

-   SQL Server Integration Services Scale Out Master 14.0 (SSISScaleOutMaster140s
to
-   SQL Server Integration Services Scale Out Master 14.0 (SSISScaleOutMaster140)