### PR TITLE
update dma configration file

### DIFF
--- a/docs/dma/dma-configurationsettings.md
+++ b/docs/dma/dma-configurationsettings.md
@@ -139,7 +139,7 @@ for source and target instances while running an assessment or migration, by set
 
 ## Ignore error codes
 
-Each rule has an error code in its title. You might not care about the specific rules and wants to ignore them. You can control the ignoreErrorCodes property. You can ignore one error or multiple errors that are separated by semi comma. For example, ignoreErrorCodes="46010;71501".The default value is 71501. 71501 means unresolved references found when the object references system objects like procedures, views, etc.
+Each rule has an error code in its title. You might not care about the specific rules and wants to ignore them. You can control the ignoreErrorCodes property. You can ignore one error or multiple errors that are separated by semicolon. For example, ignoreErrorCodes="46010;71501".The default value is 71501. 71501 means unresolved references found when the object references system objects like procedures, views, etc.
 
 ```
 <workflowSettings>

--- a/docs/dma/dma-configurationsettings.md
+++ b/docs/dma/dma-configurationsettings.md
@@ -139,7 +139,7 @@ for source and target instances while running an assessment or migration, by set
 
 ## Ignore error codes
 
-Each rule has an error code in its title. You might not care about the specific rules and wants to ignore them. You can control the ignoreErrorCodes property. You can ignore one error or multiple errors that are separated by semicolon. For example, ignoreErrorCodes="46010;71501".The default value is 71501. 71501 means unresolved references found when the object references system objects like procedures, views, etc.
+Each rule has an error code in its title. If you don't need rules and want to ignore them, use the ignoreErrorCodes property. You can specify to ignore a single error or multiple errors. To ignore multiple errors, use a semicolon, e.g., ignoreErrorCodes="46010;71501". The default value is 71501, which is associated with unresolved references identified when an object references system objects such as procedures, views, etc.
 
 ```
 <workflowSettings>

--- a/docs/dma/dma-configurationsettings.md
+++ b/docs/dma/dma-configurationsettings.md
@@ -139,7 +139,7 @@ for source and target instances while running an assessment or migration, by set
 
 ## Ignore error codes
 
-Each rule has an error code in its title. The rules might be obselete or you do not care about the specific rules and wants to ignore them. You can control the ignoreErrorCodes property. You can ignore one error or multiple errors that are separated by semi comma. For example, ignoreErrorCodes="46010;71501".The default value is 71501. 71501 means unresolved references found when the object references system objects like procedures, views, etc.
+Each rule has an error code in its title. You might not care about the specific rules and wants to ignore them. You can control the ignoreErrorCodes property. You can ignore one error or multiple errors that are separated by semi comma. For example, ignoreErrorCodes="46010;71501".The default value is 71501. 71501 means unresolved references found when the object references system objects like procedures, views, etc.
 
 ```
 <workflowSettings>

--- a/docs/dma/dma-configurationsettings.md
+++ b/docs/dma/dma-configurationsettings.md
@@ -137,6 +137,17 @@ for source and target instances while running an assessment or migration, by set
 </appSettings>
 ```
 
+## Ignore error codes
+
+Each rule has an error code in its title. The rules might be obselete or you do not care about the specific rules and wants to ignore them. You can control the ignoreErrorCodes property. You can ignore one error or multiple errors that are separated by semi comma. For example, ignoreErrorCodes="46010;71501".The default value is 71501. 71501 means unresolved references found when the object references system objects like procedures, views, etc.
+
+```
+<workflowSettings>
+
+<assessment parallelDatabases="8" ignoreErrorCodes="71501" />
+
+</workflowSettings>
+```
 
 ## See also
 


### PR DESCRIPTION
new feature to ignore error codes.

The errors might be obsolete or the users does not care about this specific error and the error doesn't affect the assessment result, and then the user can use ignoreErrorCodes to ignore those errors.