### PR TITLE
data type syntax missing underscore in name

### DIFF
--- a/docs/t-sql/statements/create-table-transact-sql.md
+++ b/docs/t-sql/statements/create-table-transact-sql.md
@@ -115,7 +115,7 @@ column_name <data_type>
     [ <column_constraint> [, ...n ] ]
     [ <column_index> ]
   
-<data type> ::=
+<data_type> ::=
 [ type_schema_name . ] type_name
     [ ( precision [ , scale ] | max |
         [ { CONTENT | DOCUMENT } ] xml_schema_collection ) ]
@@ -285,7 +285,7 @@ column_name <data_type>
     [ <column_constraint> ]
     [ <column_index> ]
   
-<data type> ::=
+<data_type> ::=
  [type_schema_name . ] type_name [ (precision [ , scale ]) ]
 
 <column_constraint> ::=


### PR DESCRIPTION
column_name <data*_*type>, but later, data* *type!