### PR TITLE
odd formatting on description of @params argument

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-executesql-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-executesql-transact-sql.md
@@ -52,7 +52,7 @@ sp_executesql [ @stmt = ] statement
   
  Each parameter included in \@stmt must have a corresponding entry in both the \@params parameter definition list and the parameter values list.  
   
- [ \@params= ] N'\@*parameter_name**data_type* [ ,... *n* ] '  
+ [ \@params= ] N'\@*parameter_name* *data_type* [ ,... *n* ] '  
  Is one string that contains the definitions of all parameters that have been embedded in \@stmt. The string must be either a Unicode constant or a Unicode variable. Each parameter definition consists of a parameter name and a data type. *n* is a placeholder that indicates additional parameter definitions. Every parameter specified in \@stmt must be defined in \@params. If the [!INCLUDE[tsql](../../includes/tsql-md.md)] statement or batch in \@stmt does not contain parameters, \@params is not required. The default value for this parameter is NULL.  
   
  [ \@param1= ] '*value1*'  


### PR DESCRIPTION
the two `*` without a space between them, each to make `parameter_name` and `data_type` emphasised were just displaying as two asterisks on docs.ms