### PR TITLE
remove self-referencing link

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-executesql-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-executesql-transact-sql.md
@@ -244,8 +244,6 @@ EXECUTE sp_executesql
           @level = 109;  
 ```  
   
- For additional examples, see [sp_executesql (Transact-SQL)](https://msdn.microsoft.com/library/ms188001.aspx).  
-  
 ## See Also  
  [EXECUTE &#40;Transact-SQL&#41;](../../t-sql/language-elements/execute-transact-sql.md)   
  [System Stored Procedures &#40;Transact-SQL&#41;](../../relational-databases/system-stored-procedures/system-stored-procedures-transact-sql.md)  


### PR DESCRIPTION
the 

> For additional examples, see sp_executesql (Transact-SQL).

link at the bottom of the page goes to: https://msdn.microsoft.com/library/ms188001.aspx

which then permanently redirects to https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-executesql-transact-sql (the page in the documentation we're currently on)

I tried looking on the internet archive wayback machine to see if there was any content to be salvaged, but it doesn't seem to have that page indexed.