### PR TITLE
Added limitation of allowed input value

### DIFF
--- a/docs/t-sql/functions/try-cast-transact-sql.md
+++ b/docs/t-sql/functions/try-cast-transact-sql.md
@@ -34,7 +34,7 @@ TRY_CAST ( expression AS data_type [ ( length ) ] )
   
 ## Arguments  
  *expression*  
- The value to be cast. Any valid expression.  
+ The value to be cast. Allowed input value is limited to 8000 bytes. 
   
  *data_type*  
  The data type into which to cast *expression*.  


### PR DESCRIPTION
The value which is converted to the target type is limited to 8000 bytes. If it exceed this limit a String or binary data would be truncated. is thrown. I believe this need to be known because one can add LEFT() for example to solve such case. Here are some example demonstrating this limitation with varchar and nvarchar inputs.

-- does not work

DECLARE @TEST VARCHAR(MAX);

SELECT @TEST =  CAST(REPLICATE('a', 8000) AS VARCHAR(MAX)) + '1';

SELECT DATALENGTH(@TEST)

SELECT TRY_CAST(@TEST AS INT)

GO

-- does work 

DECLARE @TEST VARCHAR(MAX);

SELECT @TEST =  CAST(REPLICATE('a', 8000) AS VARCHAR(MAX));

SELECT DATALENGTH(@TEST)

SELECT TRY_CAST(@TEST AS INT)

GO

-- does not work

DECLARE @TEST NVARCHAR(MAX);

SELECT @TEST =  CAST(REPLICATE('a', 4000) AS NVARCHAR(MAX)) + '1';

SELECT DATALENGTH(@TEST)

SELECT TRY_CAST(@TEST AS INT)

GO

-- does work 

DECLARE @TEST NVARCHAR(MAX);

SELECT @TEST =  CAST(REPLICATE('a', 4000) AS NVARCHAR(MAX));

SELECT DATALENGTH(@TEST)

SELECT TRY_CAST(@TEST AS INT)

GO