### PR TITLE
missed parenthesis

### DIFF
--- a/docs/t-sql/functions/openjson-transact-sql.md
+++ b/docs/t-sql/functions/openjson-transact-sql.md
@@ -365,7 +365,7 @@ DECLARE @json NVARCHAR(max)  = N'{
   INSERT INTO Person  
   SELECT *   
   FROM OPENJSON(@json)  
-  WITH id int,  
+  WITH (id int,  
         firstName nvarchar(50), lastName nvarchar(50),   
         isAlive bit, age int,  
         dateOfBirth datetime2, spouse nvarchar(50))


### PR DESCRIPTION
On "Example 5 - Import JSON data into SQL Server" in WITH clause, missing the first parenthesis.