### PR TITLE
Include metadata query for SQL2019

### DIFF
--- a/docs/relational-databases/security/sql-data-discovery-and-classification.md
+++ b/docs/relational-databases/security/sql-data-discovery-and-classification.md
@@ -135,6 +135,21 @@ FROM
     ON  EP.major_id = C.object_id AND EP.minor_id = C.column_id
 ```
 
+Or on SQL Server 2019 :
+```sql
+SELECT 
+    schema_name(O.schema_id) AS schema_name,
+    O.NAME AS table_name,
+    C.NAME AS column_name,
+    information_type,
+	label
+FROM sys.sensitivity_classifications sc
+    JOIN sys.objects O
+    ON  sc.major_id = O.object_id
+	JOIN sys.columns C 
+    ON  sc.major_id = C.object_id  AND sc.minor_id = C.column_id
+```
+
 ## <a id="subheading-4"></a>Next steps
 
 For Azure SQL Database, see [Azure SQL Database Data Discovery & Classification](https://go.microsoft.com/fwlink/?linkid=866265).


### PR DESCRIPTION
SQL 2019 CTP3 seems to store classification data differently, adding the TSQL query that allows to retrieve this (extracted the source table info from running the SSMS report under profiler). Might be the reason for #2209 . And is linked to my #2552 .
I suspect this should be better implemented in a version-dynamic fashion that would only display the query relevant to product version but I'm not sure how to do that =)