### PR TITLE
Fix the URL for CTP3.1 uninstall

### DIFF
--- a/docs/big-data-cluster/deployment-upgrade.md
+++ b/docs/big-data-cluster/deployment-upgrade.md
@@ -37,7 +37,7 @@ Currently, the only way to upgrade a big data cluster to a new release is to man
    For CTP 2.3 or higher, run the following command. Replace `ctp3.1` in the command with the version of **mssqlctl** that you are uninstalling. If the version is prior to CTP 3.1, add a dash before the version number (for example, `ctp-2.5`).
 
    ```powershell
-   pip3 uninstall -r https://mcr.microsoft.com/python/ctp3.1/mssqlctl/requirements.txt
+   pip3 uninstall -r https://private-repo.microsoft.com/python/ctp3.1/mssqlctl/requirements.txt
    ```
 
 1. Install the latest version of **azdata**. The following commands install **azdata** for CTP 3.2:


### PR DESCRIPTION
CTP3.1 uninstall documentation points to an incorrect URL for requirements.txt file. This change fixes that.