### PR TITLE
(simple wording update) Use better naming for VDI (actually SQL VDI)

### DIFF
--- a/docs/linux/sql-server-linux-backup-vdi-specification.md
+++ b/docs/linux/sql-server-linux-backup-vdi-specification.md
@@ -23,7 +23,7 @@ This document covers the interfaces provided by the SQL Server on Linux virtual 
 - SQL Server on Linux does not support named instances so references to instance name have been removed. 
 - The shared library is implemented in libsqlvdi.so installed at /opt/mssql/lib/libsqlvdi.so
 
-This document is an addendum to **vbackup.chm** that details the Windows VDI Specification. Download the [Windows VDI Specification](https://www.microsoft.com/download/details.aspx?id=17282).
+This document is an addendum to **vbackup.chm** that details the MS SQL Server VDI Specifications on Windows. Download the [SQL VDI Specification on Windows](https://www.microsoft.com/download/details.aspx?id=17282).
 
 Also review the sample VDI backup solution on the [SQL Server Samples GitHub repository](https://github.com/Microsoft/sql-server-samples/tree/master/samples/features/sqlvdi-linux).
 


### PR DESCRIPTION
"our" (SQL Server's) VDI full name is actually MS SQL Server VDI, or SQL VDI in shorter form. "Windows VDI" as used in current text implies a completely different thing (Virtual Desktop Infrastructure https://azure.microsoft.com/en-us/services/virtual-desktop/)