### PR TITLE
ForEach file loop order specification

### DIFF
--- a/docs/integration-services/control-flow/foreach-loop-container.md
+++ b/docs/integration-services/control-flow/foreach-loop-container.md
@@ -46,7 +46,7 @@ ms.author: janinez
   
 -   Foreach ADO.NET Schema Rowset enumerator to enumerate the schema information about a data source. For example, you can enumerate and get a list of the tables in the [!INCLUDE[ssSampleDBnormal](../../includes/sssampledbnormal-md.md)] [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] database.  
   
--   Foreach File enumerator to enumerate files in a folder. The enumerator can traverse subfolders. For example, you can read all the files that have the *.log file name extension in the Windows folder and its subfolders.  
+-   Foreach File enumerator to enumerate files in a folder. The enumerator can traverse subfolders. For example, you can read all the files that have the *.log file name extension in the Windows folder and its subfolders. Note that the order in which the files are retrieved cannot be specified.  
   
 -   Foreach From Variable enumerator to enumerate the enumerable object that a specified variable contains. The enumerable object can be an array, an ADO.NET **DataTable**, an [!INCLUDE[ssISnoversion](../../includes/ssisnoversion-md.md)] enumerator, and so on. For example, you can enumerate the values of an array that contains the name of servers.  
   


### PR DESCRIPTION
The order of files is important when you are processing changefiles with cummulative updates. Even if an explicit order is not supported this is still valuable information to know for developers, so that they can take steps to mitigate this, that's why I added this text here.