### PR TITLE
[typo] extra trailing "]" in jmespath.org link

### DIFF
--- a/docs/big-data-cluster/reference-azdata-bdc-spark-statement.md
+++ b/docs/big-data-cluster/reference-azdata-bdc-spark-statement.md
@@ -46,7 +46,7 @@ Show this help message and exit.
 #### `--output -o`
 Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
 #### `--query -q`
-JMESPath query string. See [http://jmespath.org/](http://jmespath.org/]) for more information and examples.
+JMESPath query string. See [http://jmespath.org/](http://jmespath.org/) for more information and examples.
 #### `--verbose`
 Increase logging verbosity. Use --debug for full debug logs.
 ## azdata bdc spark statement create


### PR DESCRIPTION
current link "http://jmespath.org/]"  leads to "403 Forbidden    Code: AccessDenied"