### PR TITLE
FORMAT - removal of reference to ssCurrent

### DIFF
--- a/docs/t-sql/functions/format-transact-sql.md
+++ b/docs/t-sql/functions/format-transact-sql.md
@@ -23,7 +23,7 @@ monikerRange: "= azuresqldb-current||>= sql-server-2016||>= sql-server-linux-201
 
 [!INCLUDE[tsql-appliesto-ss2012-asdb-xxxx-xxx-md](../../includes/tsql-appliesto-ss2012-asdb-xxxx-xxx-md.md)]
 
-Returns a value formatted with the specified format and optional culture in [!INCLUDE[ssCurrent](../../includes/sscurrent-md.md)]. Use the FORMAT function for locale-aware formatting of date/time and number values as strings. For general data type conversions, use CAST or CONVERT.  
+Returns a value formatted with the specified format and optional culture. Use the FORMAT function for locale-aware formatting of date/time and number values as strings. For general data type conversions, use CAST or CONVERT.  
   
  ![Topic link icon](../../database-engine/configure-windows/media/topic-link.gif "Topic link icon") [Transact-SQL Syntax Conventions](../../t-sql/language-elements/transact-sql-syntax-conventions-transact-sql.md)  
   


### PR DESCRIPTION
The statement that currently shows in the documentation *"Returns a value formatted with the specified format and optional culture in SQL Server 2017"* is very misleading; it makes it seem like `FORMAT` was added with SQL Server 2017, however, the first version it was made available in is 2012. Stating that the function works in a specific way in 2017, when it hasn't functionally changed since it was added in 2012 doesn't add anything to the article, and in fact, likely only provides confusion.