### PR TITLE
Modify batch file to not delete *.bak

### DIFF
--- a/docs/big-data-cluster/tutorial-load-sample-data.md
+++ b/docs/big-data-cluster/tutorial-load-sample-data.md
@@ -28,7 +28,7 @@ This tutorial explains how to use a script to load sample data into a SQL Server
    - **kubectl**
    - **sqlcmd**
    - **curl**
-
+ 
 ## <a id="sampledata"></a> Load sample data
 
 The following steps use a bootstrap script to download a SQL Server database backup and load the data into your big data cluster. For ease of use, these steps have been broken out into [Windows](#windows) and [Linux](#linux) sections.


### PR DESCRIPTION
Not sure how to provide feedback on the referenced bootstrap-sample-db.cmd in 
https://raw.githubusercontent.com/Microsoft/sql-server-samples/master/samples/features/sql-big-data-cluster/
There is a line in that file that does this, which removes ALL .bak files in the data folder. This could delete other bak files. So this script should be modified to only delete the one backup file tpcxbb_1gb.bak

echo Removing database backup files...
%DEBUG% kubectl exec %MASTER_POD_NAME% -n %CLUSTER_NAMESPACE% -c mssql-server -i -t -- bash -c "rm -rvf /var/opt/mssql/data/*.bak"