### PR TITLE
Update configure-distribution-availability-group.md

### DIFF
--- a/docs/relational-databases/replication/configure-distribution-availability-group.md
+++ b/docs/relational-databases/replication/configure-distribution-availability-group.md
@@ -48,12 +48,13 @@ After a distribution database in the AG is configured based on the steps describ
 
 ## Limitations or exclusions
 
-- Local distributor is not supported. For example, publisher and distributor must be different SQL Server instances. A publisher using itself as distributor (a.k.a. local distributor) cannot support distribution databases in an AG.
+- Local distributor is not supported. For example, publisher and distributor must be different SQL Server instances. These instances can be hosted on the same sets of nodes.  A publisher using itself as distributor (a.k.a. local distributor) cannot support distribution databases in an AG.
 - Oracle publisher is not supported.
 - Merge replication is not supported.
 - Transactional replication with immediate or queued updating subscriber is not supported.
 - Peer to peer replication is not supported.
-- All SQL Server instances hosting distribution database replicas must be SQL Server 2017 CU 6 or later. 
+- All SQL Server 2017 instances hosting distribution database replicas must be SQL Server 2017 CU 6 or later. 
+- All SQL Server 2016 instances hosting distribution database replicas must be SQL Server 2016 SP2-CU3 or later.
 - All SQL Server instances hosting distribution database replicas must be the same version, except during the narrow timeframe when upgrade takes place.
 - The distribution database must be in full recovery mode.
 - For recovery and to allow transaction log truncation, configure full and transaction log backups.


### PR DESCRIPTION
Since both SQL 2016 and 2017 support this feature, I added following under limitations. 

- All SQL Server 2016 instances hosting distribution database replicas must be SQL Server 2016 SP2-CU3 or later.