### PR TITLE
Largest Allocaiton unit is 32 MB in NTFS

### DIFF
--- a/docs/database-engine/configure-windows/hybrid-buffer-pool.md
+++ b/docs/database-engine/configure-windows/hybrid-buffer-pool.md
@@ -91,7 +91,7 @@ SELECT name, is_memory_optimized_enabled FROM sys.databases;
 
 It is not recommended to enable hybrid buffer pool on instances with less than 16-GB RAM.
 
-When formatting your PMEM device on Windows, use the largest allocation unit size available for NTFS (2 MB in Windows Server 2019) and ensure the device has been formatted for DAX (Direct Access).
+When formatting your PMEM device on Windows, use the largest allocation unit size available for NTFS (32 MB in Windows Server 2019) and ensure the device has been formatted for DAX (Direct Access) - /DAX:enable.
 
 Files sizes should be a multiple of 2 MB (modulo 2 MB should equal zero).
 


### PR DESCRIPTION
format /?
 /A:size         Overrides the default allocation unit size. Default settings
                  are strongly recommended for general use.
                  ReFS supports 4096, 64K.
                  NTFS supports 512, 1024, 2048, 4096, 8192, 16K, 32K, 64K,
                  128K, 256K, 512K, 1M, 2M.
                  FAT supports 512, 1024, 2048, 4096, 8192, 16K, 32K, 64K,
                  (128K, 256K for sector size > 512 bytes).
                  FAT32 supports 512, 1024, 2048, 4096, 8192, 16K, 32K, 64K,
                  (128K, 256K for sector size > 512 bytes).
                  exFAT supports 512, 1024, 2048, 4096, 8192, 16K, 32K, 64K,
                  128K, 256K, 512K, 1M, 2M, 4M, 8M, 16M, 32M.