### PR TITLE
visually separate key name from other text

### DIFF
--- a/docs/odbc/reference/install/odbc-data-sources-subkey.md
+++ b/docs/odbc/reference/install/odbc-data-sources-subkey.md
@@ -15,8 +15,8 @@ ms.assetid: 0a8ccb80-c573-4418-84e5-f04a2b0e2ac1
 author: MightyPen
 ms.author: genemi
 ---
-# ODBC Data Sources Subkey
-The values under the ODBC Data Sources subkey list the data sources. The format of these values is as shown in the following table.  
+# 'ODBC Data Sources' Subkey
+The values under the 'ODBC Data Sources' subkey list the data sources. The format of these values is as shown in the following table.  
   
 |Name|Data type|Data|  
 |----------|---------------|----------|  
@@ -24,7 +24,7 @@ The values under the ODBC Data Sources subkey list the data sources. The format 
   
  The *data-source-name* value is defined by the administration program (which usually prompts the user for it), and *driver-description* is defined by the driver developer (it is usually the name of the DBMS associated with the driver).  
   
- For example, suppose three data sources have been defined: Inventory, which uses SQL Server; Payroll, which uses dBASE; and Personnel, which uses formatted text files. The values under the ODBC Data Sources subkey might be as follows:  
+ For example, suppose three data sources have been defined: Inventory, which uses SQL Server; Payroll, which uses dBASE; and Personnel, which uses formatted text files. The values under the 'ODBC Data Sources' subkey might be as follows:  
   
 ```  
 Inventory : REG_SZ : SQL Server  


### PR DESCRIPTION
The formatting in this commit is only a proposal. The main concern is the name of the key is difficult to parse easily from the text as there's no visual delimiter of what's the key and what's part of the explaination.

If this type of formatting isn't appropriate, feel free to close.