### PR TITLE
Update dac-support-for-sql-server-objects-and-versions.md

### DIFF
--- a/docs/relational-databases/data-tier-applications/dac-support-for-sql-server-objects-and-versions.md
+++ b/docs/relational-databases/data-tier-applications/dac-support-for-sql-server-objects-and-versions.md
@@ -21,7 +21,7 @@ ms.author: "sstein"
 
 
 > [!IMPORTANT]
-> This article is valid for SQL Server 2012, but not for SQL Server 2014 or later.
+> This article is valid for SQL Server 2014 or later, but not for SQL Server 2012 or earlier.
 > For DAC articles about SQL 2012 and earlier, see the following links:
 > 
 > - https://docs.microsoft.com/previous-versions/sql/sql-server-2008-r2/ee240739(v=sql.105)


### PR DESCRIPTION
The description for the validity of the article seems back to front. It suggests that it was valid for 2012 but not for 2014 or later but then provides the links to the earlier versions. I have proposed a change in the wording to make it clear that this doc is for 2014 or later and 2012 and earlier is in the links.