### PR TITLE
Replace "Database Login" with "Database User"

### DIFF
--- a/docs/relational-databases/tutorial-signing-stored-procedures-with-a-certificate.md
+++ b/docs/relational-databases/tutorial-signing-stored-procedures-with-a-certificate.md
@@ -76,7 +76,7 @@ AS
 BEGIN  
    -- Show who is running the stored procedure  
    SELECT SYSTEM_USER 'system Login'  
-   , USER AS 'Database Login'  
+   , USER AS 'Database User'  
    , NAME AS 'Context'  
    , TYPE  
    , USAGE   
@@ -211,7 +211,7 @@ AS
 BEGIN  
    -- Shows who is running the stored procedure  
    SELECT SYSTEM_USER 'system Login'  
-   , USER AS 'Database Login'  
+   , USER AS 'Database User'  
    , NAME AS 'Context'  
    , TYPE  
    , USAGE   


### PR DESCRIPTION
Replace "Database Login" with "Database User" - this type of mistakes confuses readers to think that a LOGIN is in the database level. I see multiple questions in the MSDN forum which confuse LOGIN and USER which came from reading a blog or document.