### PR TITLE
Remove campaign tags in VS download link

### DIFF
--- a/docs/ssdt/download-sql-server-data-tools-ssdt.md
+++ b/docs/ssdt/download-sql-server-data-tools-ssdt.md
@@ -30,7 +30,7 @@ If you already have a license to Visual Studio 2019:
 
 If you don’t already have a license to Visual Studio 2019:
 
-- Install [Visual Studio 2019 Community](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_content=sqlssdt)
+- Install [Visual Studio 2019 Community](https://visualstudio.microsoft.com/downloads/)
 - Install the Analysis Services, Integration Services, or Reporting Services extension as appropriate
 
 ## Changes in SSDT for Visual Studio 2017


### PR DESCRIPTION
We've found that it's better not to have the campaign id links, since for "normal" links, we can track the originating page by using the ReferralPath.  Adding campaign id links removes the ReferralPath data.  
