### PR TITLE
Use object_id instead of hobt_id for matching resource_associated_entity_id

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-tran-locks-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-tran-locks-transact-sql.md
@@ -333,7 +333,7 @@ SELECT resource_type, resource_associated_entity_id,
 ```  
 SELECT object_name(object_id), *  
     FROM sys.partitions  
-    WHERE hobt_id=<resource_associated_entity_id>  
+    WHERE object_id=<resource_associated_entity_id>  
 ```  
   
  The following query will show blocking information.  


### PR DESCRIPTION
Following the example I tried to `SELECT * FROM sys.partitions` the object where corrently a lock is on.

Having an active transaction on table `ValuesT0Single`, running this code:

```sql
SELECT resource_associated_entity_id FROM sys.dm_tran_locks  
WHERE resource_database_id = 6 AND request_session_id = 52 and resource_type = 'object'

SELECT object_name(object_id) as objname, object_id, hobt_id
FROM sys.partitions  where hobt_id = 66099276

SELECT object_name(object_id) as objname, object_id, hobt_id
FROM sys.partitions  where object_id = 66099276
```

returns in my test case

```text
resource_associated_entity_id
-----------------------------
66099276

(1 row affected)

objname                 object_id   hobt_id
----------------------- ----------- --------------------

(0 rows affected)

objname                 object_id   hobt_id
----------------------- ----------- --------------------
ValuesT0UInt32          66099276    72057594045267968

(1 row affected)
```

As you can see, `where hobt_id = 66099276` did not return a result, while `where object_id = 66099276` does.
`ValuesT0UInt32` is the correct table name for my case.

So in my humble opinion, it should have been`WHERE object_id=<resource_associated_entity_id>` in the docs.