### PR TITLE
Elaborate on CHAR function behavior with an eye to UTF-8

### DIFF
--- a/docs/t-sql/functions/char-transact-sql.md
+++ b/docs/t-sql/functions/char-transact-sql.md
@@ -200,8 +200,10 @@ NULL                                NULL
   
 ### G. Using CONVERT instead of CHAR to decode multibyte characters
 This example relies on the default codepage of the current database to decode a multibyte character.
-`CONVERT` here operates on a character encoding: SHIFT\_JIS.
-`CHAR` operates on character sets and codepoints: JIS X 208 code 2-86 (row 2 cell 86).
+`CONVERT` here operates on a character encoding, SHIFT\_JIS.
+`CHAR` and `NCHAR` operate on character sets and codepoints,
+which works well with ASCII code 13 above, but not with JIS X 208 code 2-86 here.
+Encoding JIS X 208 ku-ten codes to SHIFT\_JIS is outside the scope of this example.
 
 ```sql
 CREATE DATABASE [multibyte-char-context]
@@ -248,7 +250,7 @@ UTF-8 **char** and UTF-16 **nchar** are different _encoding forms_ using 8-bit a
   FROM enc
 ```
 
-[!INCLUDE[ssResult](../../includes/ssresult-md.md)] Generated under a `\_SC` collation with supplementary character support.
+[!INCLUDE[ssResult](../../includes/ssresult-md.md)] Generated under a `_SC` collation with supplementary character support.
 
 ```
 Music note Music note (UTF-8) Code Point  UTF-16LE bytes UTF-8 bytes

--- a/docs/t-sql/functions/char-transact-sql.md
+++ b/docs/t-sql/functions/char-transact-sql.md
@@ -181,8 +181,8 @@ single_byte_representing_complete_character single_byte_representing_complete_ch
 ### F. Using CHAR to return multibyte characters
 This example uses integer and hex values in the valid range for Extended ASCII.
 However, the `CHAR` function returns `NULL` because the parameter represents only the first byte of a multibyte character.
-A **char(2)** double-byte character cannot be composed from or divided into constituent parts without conversion:
-such parts are not generally valid **char(1)** values.
+A **char(2)** double-byte character cannot be composed from or divided into parts without conversion:
+those parts are not generally valid **char(1)** values.
   
 ```sql
 SELECT CHAR(129) AS first_byte_of_double_byte_character, 
@@ -198,7 +198,7 @@ first_byte_of_double_byte_character first_byte_of_double_byte_character
 NULL                                NULL                                         
 ```
   
-### G. Using CONVERT instead of CHAR to return legacy multibyte characters
+### G. Using CONVERT instead of CHAR to decode multibyte characters
 This example relies on the default codepage of the current database to decode a multibyte character.
 `CONVERT` here operates on a character encoding: SHIFT\_JIS.
 `CHAR` operates on character sets and codepoints: JIS X 208 code 2-86 (row 2 cell 86).
@@ -222,7 +222,7 @@ eighth-note context-dependent-convert context-dependent-cast
 ♪           ♪                         ♪
 ```
 
-### H. Using NCHAR instead of CHAR to return UTF-8 characters
+### H. Using NCHAR instead of CHAR to look up UTF-8 characters
 This example highlights the distinction the Unicode standard makes between a character's _code point_ and the _code unit sequence_ under a given _encoding form_.
 The binary code assigned to a character in a classic character set is its only numeric identifier.
 In contrast, the UTF-8 byte sequence associated with a character is an algorithmic encoding of its assigned numeric identifier: the code point.
@@ -233,7 +233,7 @@ UTF-8 **char** and UTF-16 **nchar** are different _encoding forms_ using 8-bit a
     -- BMP character
     SELECT NCHAR(9835)
     UNION ALL
-    -- non-BMP supplementary character or, under legacy collation, NULL
+    -- non-BMP supplementary character or, under downlevel collation, NULL
     SELECT NCHAR(127925)
   ),
   enc(u16c, u8c) AS (

--- a/docs/t-sql/functions/char-transact-sql.md
+++ b/docs/t-sql/functions/char-transact-sql.md
@@ -177,7 +177,7 @@ single_byte_representing_complete_character single_byte_representing_complete_ch
 ```
 
 ### F. CHAR inability to return multibyte characters
-This example uses the an integer and hex values in the valid range for ASCII. However, the CHAR function returns NULL because the parameter matches the first byte of a number of multibyte characters in the collation, but no single complete character.
+This example uses integer and hex values in the valid range for ASCII. However, the CHAR function returns NULL because the parameter matches the first byte of a number of multibyte characters in the collation, but no single complete character.
   
 ```sql
 SELECT CHAR(129) AS first_byte_of_double_byte_character, 

--- a/docs/t-sql/functions/char-transact-sql.md
+++ b/docs/t-sql/functions/char-transact-sql.md
@@ -224,29 +224,30 @@ UTF-8 `CHAR` and UTF-16 `NCHAR` are different _encoding forms_ using 8-bit and 1
 ```sql
 ; WITH uni(c) AS (
     -- BMP character
-    SELECT NCHAR(0x266B)
+    SELECT NCHAR(9835)
     UNION ALL
-    -- supplementary character, collation-independent construction
-    SELECT CONVERT(NVARCHAR(2), 0x3CD8b5DF)
+    -- non-BMP supplementary character or, under legacy collation, NULL
+    SELECT NCHAR(127925)
   ),
   enc(u16c, u8c) AS (
     SELECT c, CONVERT(VARCHAR(4), c COLLATE Latin1_General_100_CI_AI_SC_UTF8)
     FROM uni
   )
-  SELECT u16c AS [music note]
-    , u8c AS [music note (UTF-8)]
+  SELECT u16c AS [Music note]
+    , u8c AS [Music note (UTF-8)]
+    , UNICODE(u16c) AS [Code Point]
     , CONVERT(VARBINARY(4), u16c) AS [UTF-16LE bytes]
     , CONVERT(VARBINARY(4), u8c)  AS [UTF-8 bytes]
   FROM enc
 ```
 
-[!INCLUDE[ssResult](../../includes/ssresult-md.md)]
+[!INCLUDE[ssResult](../../includes/ssresult-md.md)] Generated under a `_SC` collation with supplementary character support.
 
 ```
-music note music note (UTF-8) UTF-16LE bytes UTF-8 bytes
----------- ------------------ -------------- -----------
-♫          ♫                  0x6B26         0xE299AB
-🎵         🎵                 0x3CD8B5DF     0xF09F8EB5
+Music note Music note (UTF-8) Code Point  UTF-16LE bytes UTF-8 bytes
+---------- ------------------ ----------- -------------- -----------
+♫          ♫                  9835        0x6B26         0xE299AB
+🎵         🎵                 127925      0x3CD8B5DF     0xF09F8EB5
 ```
 
 ## See also

--- a/docs/t-sql/functions/char-transact-sql.md
+++ b/docs/t-sql/functions/char-transact-sql.md
@@ -179,7 +179,8 @@ single_byte_representing_complete_character single_byte_representing_complete_ch
 
 ### F. Using CHAR to return multibyte characters
 This example uses integer and hex values in the valid range for Extended ASCII. However, the CHAR function returns NULL because the parameter represents only the first byte of a multibyte character.
-Although `NCHAR(2)` supplementary characters can be composed this way, `CHAR(2)` double-byte characters cannot.
+`CHAR(2)` double-byte characters cannot be composed from constituent first and second `CHAR(1)` bytes in the way that
+`NCHAR(2)` supplementary characters can be composed from constituent high and low `NCHAR(1)` surrogates.
   
 ```sql
 SELECT CHAR(129) AS first_byte_of_double_byte_character, 

--- a/docs/t-sql/functions/char-transact-sql.md
+++ b/docs/t-sql/functions/char-transact-sql.md
@@ -43,7 +43,8 @@ CHAR ( integer_expression )
   
 ## Arguments  
 *integer_expression*  
-An integer from 0 through 255. `CHAR` returns a `NULL` value for integer expressions outside this input range or not associated with a complete character compatible with the return type.
+An integer from 0 through 255. `CHAR` returns a `NULL` value for integer expressions outside this input range or not representing a complete character.
+`CHAR` also returns a `NULL` value when the character exceeds the length of the return type.
 Many common character sets share ASCII as a sub-set and will return the same character for integer values in the range 0 through 127.
 
 > [!NOTE]
@@ -178,9 +179,10 @@ single_byte_representing_complete_character single_byte_representing_complete_ch
 ```
 
 ### F. Using CHAR to return multibyte characters
-This example uses integer and hex values in the valid range for Extended ASCII. However, the CHAR function returns NULL because the parameter represents only the first byte of a multibyte character.
-A `CHAR(2)` double-byte character cannot be composed from constituent first and second `CHAR(1)` bytes in the way that
-a `NCHAR(2)` supplementary character can be composed from constituent high and low `NCHAR(1)` surrogates.
+This example uses integer and hex values in the valid range for Extended ASCII.
+However, the `CHAR` function returns `NULL` because the parameter represents only the first byte of a multibyte character.
+A **char(2)** double-byte character cannot be composed from or divided into constituent parts without conversion:
+such parts are not generally valid **char(1)** values.
   
 ```sql
 SELECT CHAR(129) AS first_byte_of_double_byte_character, 
@@ -197,7 +199,9 @@ NULL                                NULL
 ```
   
 ### G. Using CONVERT instead of CHAR to return legacy multibyte characters
-This example relies on the default codepage of the current database to map a two-byte legacy codepoint to a single character.
+This example relies on the default codepage of the current database to decode a multibyte character.
+`CONVERT` here operates on a character encoding: SHIFT\_JIS.
+`CHAR` operates on character sets and codepoints: JIS X 208 code 2-86 (row 2 cell 86).
 
 ```sql
 CREATE DATABASE [multibyte-char-context]
@@ -222,7 +226,7 @@ eighth-note context-dependent-convert context-dependent-cast
 This example highlights the distinction the Unicode standard makes between a character's _code point_ and the _code unit sequence_ under a given _encoding form_.
 The binary code assigned to a character in a classic character set is its only numeric identifier.
 In contrast, the UTF-8 byte sequence associated with a character is an algorithmic encoding of its assigned numeric identifier: the code point.
-UTF-8 `CHAR` and UTF-16 `NCHAR` are different _encoding forms_ using 8-bit and 16-bit _code units_, of the same character set: the Unicode Character Database.
+UTF-8 **char** and UTF-16 **nchar** are different _encoding forms_ using 8-bit and 16-bit _code units_, of the same character set: the Unicode Character Database.
 
 ```sql
 ; WITH uni(c) AS (
@@ -244,7 +248,7 @@ UTF-8 `CHAR` and UTF-16 `NCHAR` are different _encoding forms_ using 8-bit and 1
   FROM enc
 ```
 
-[!INCLUDE[ssResult](../../includes/ssresult-md.md)] Generated under a `_SC` collation with supplementary character support.
+[!INCLUDE[ssResult](../../includes/ssresult-md.md)] Generated under a `\_SC` collation with supplementary character support.
 
 ```
 Music note Music note (UTF-8) Code Point  UTF-16LE bytes UTF-8 bytes

--- a/docs/t-sql/functions/char-transact-sql.md
+++ b/docs/t-sql/functions/char-transact-sql.md
@@ -31,7 +31,7 @@ monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-s
 # CHAR (Transact-SQL)
 [!INCLUDE[tsql-appliesto-ss2008-all-md](../../includes/tsql-appliesto-ss2008-all-md.md)]
 
-This function converts an **int** ASCII code to a character value.
+Returns the single-byte character with the specified integer code, as defined by the character set and encoding of the default collation of the current database.
   
 ![Topic link icon](../../database-engine/configure-windows/media/topic-link.gif "Topic link icon") [Transact-SQL Syntax Conventions](../../t-sql/language-elements/transact-sql-syntax-conventions-transact-sql.md)
   
@@ -43,10 +43,10 @@ CHAR ( integer_expression )
   
 ## Arguments  
 *integer_expression*  
-An integer from 0 through 255. `CHAR` returns a `NULL` value for integer expressions outside this range, or when then integer expresses only the first byte of a double-byte character.
+An integer from 0 through 255. `CHAR` returns a `NULL` value for integer expressions outside this range, or when no one character matches exactly the integer by both codepoint value and encoded value. Many common character sets share ASCII as a sub-set and will return the same character for integer values in the range 0 through 127.
 
 > [!NOTE]
-> Some non-European character sets, such as [Shift Japanese Industrial Standards](https://www.wikipedia.org/wiki/Shift_JIS), include characters than can be represented in a single-byte coding scheme, but require multibyte encoding. For more information on character sets, refer to [Single-Byte and Multibyte Character Sets](/cpp/c-runtime-library/single-byte-and-multibyte-character-sets). 
+> Some character sets, such as [Unicode](https://en.wikipedia.org/wiki/Unicode#Mapping_and_encodings) and [Shift Japanese Industrial Standards](https://www.wikipedia.org/wiki/Shift_JIS), have multibyte encodings than can represent some characters in a single-byte, but require as many as four for others. For more information on character sets, refer to [Single-Byte and Multibyte Character Sets](/cpp/c-runtime-library/single-byte-and-multibyte-character-sets). 
   
 ## Return types
 **char(1)**
@@ -176,8 +176,8 @@ single_byte_representing_complete_character single_byte_representing_complete_ch
 ｼ                                           ｼ                                         
 ```
 
-### F. Using CHAR to return multibyte characters  
-This example uses the an integer and hex values in the valid range for ASCII. However, the CHAR function returns NULL because the parameter represents only the first byte of a multibyte character.
+### F. CHAR inability to return multibyte characters
+This example uses the an integer and hex values in the valid range for ASCII. However, the CHAR function returns NULL because the parameter matches the first byte of a number of multibyte characters in the collation, but no single complete character.
   
 ```sql
 SELECT CHAR(129) AS first_byte_of_double_byte_character, 
@@ -193,6 +193,46 @@ first_byte_of_double_byte_character first_byte_of_double_byte_character
 NULL                                NULL                                         
 ```
   
+### G. Using CONVERT instead of CHAR to return legacy multibyte characters
+This example relies on the default codepage of the current database to map a two-byte legacy codepoint to a single character.
+
+```sql
+CREATE DATABASE [multibyte-char-context]
+  COLLATE Japanese_CI_AI
+GO
+USE [multibyte-char-context]
+GO
+SELECT NCHAR(0x266a) AS [eighth-note]
+  , CONVERT(CHAR(2), 0x81f4) AS [context-dependent-convert]
+  , CAST(0x81f4 AS CHAR(2)) AS [context-dependent-cast]
+```
+
+[!INCLUDE[ssResult](../../includes/ssresult-md.md)]
+
+```
+eighth-note context-dependent-convert context-dependent-cast
+----------- ------------------------- ----------------------
+♪           ♪                         ♪
+```
+
+### H. Using NCHAR instead of CHAR to return UTF-8 characters
+This example highlights the distinction between Unicode codepoints and Unicode encodings.
+Unlike classic character sets, UTF-8 bytes representing a given character are not synonymous with that character's codepoint.
+The character set associated with UTF-8 is Unicode, thus UTF-8 codepoints have the same identity as other Unicode encodings such as that used by NCHAR and NVARCHAR, differing only in encoded binary representation.
+
+```sql
+SELECT NCHAR(0x266a) AS [beamed-eighth-note]
+  , CONVERT(VARCHAR(4), NCHAR(0x266b) COLLATE Latin1_General_100_CI_AI_UTF8) AS [utf-8 beamed-eight-notes]
+```
+
+[!INCLUDE[ssResult](../../includes/ssresult-md.md)]
+
+```
+beamed-eighth-note utf-8 beamed-eight-notes
+------------------ ------------------------
+♫                  ♫
+```
+
 ## See also
  [ASCII &#40;Transact-SQL&#41;](../../t-sql/functions/ascii-transact-sql.md)  
  [NCHAR &#40;Transact-SQL&#41;](../../t-sql/functions/nchar-transact-sql.md)  

--- a/docs/t-sql/functions/char-transact-sql.md
+++ b/docs/t-sql/functions/char-transact-sql.md
@@ -181,8 +181,8 @@ single_byte_representing_complete_character single_byte_representing_complete_ch
 ### F. Using CHAR to return multibyte characters
 This example uses integer and hex values in the valid range for Extended ASCII.
 However, the `CHAR` function returns `NULL` because the parameter represents only the first byte of a multibyte character.
-A **char(2)** double-byte character cannot be composed from or divided into parts without conversion:
-those parts are not generally valid **char(1)** values.
+A **char(2)** double-byte character can neither be partially represented nor be divided without some conversion operation.
+The individual bytes of a double-byte character don't generally represent valid **char(1)** values.
   
 ```sql
 SELECT CHAR(129) AS first_byte_of_double_byte_character, 

--- a/docs/t-sql/functions/char-transact-sql.md
+++ b/docs/t-sql/functions/char-transact-sql.md
@@ -222,7 +222,7 @@ The character set associated with UTF-8 is Unicode, thus UTF-8 codepoints have t
 
 ```sql
 SELECT NCHAR(0x266a) AS [beamed-eighth-note]
-  , CONVERT(VARCHAR(4), NCHAR(0x266b) COLLATE Latin1_General_100_CI_AI_UTF8) AS [utf-8 beamed-eight-notes]
+  , CONVERT(VARCHAR(4), NCHAR(0x266b) COLLATE Latin1_General_100_CI_AI_SC_UTF8) AS [utf-8 beamed-eight-notes]
 ```
 
 [!INCLUDE[ssResult](../../includes/ssresult-md.md)]

--- a/docs/t-sql/functions/char-transact-sql.md
+++ b/docs/t-sql/functions/char-transact-sql.md
@@ -43,10 +43,11 @@ CHAR ( integer_expression )
   
 ## Arguments  
 *integer_expression*  
-An integer from 0 through 255. `CHAR` returns a `NULL` value for integer expressions outside this range, or when no one character matches exactly the integer by both codepoint value and encoded value. Many common character sets share ASCII as a sub-set and will return the same character for integer values in the range 0 through 127.
+An integer from 0 through 255. `CHAR` returns a `NULL` value for integer expressions outside this input range or not associated with a complete character compatible with the return type.
+Many common character sets share ASCII as a sub-set and will return the same character for integer values in the range 0 through 127.
 
 > [!NOTE]
-> Some character sets, such as [Unicode](https://en.wikipedia.org/wiki/Unicode#Mapping_and_encodings) and [Shift Japanese Industrial Standards](https://www.wikipedia.org/wiki/Shift_JIS), have multibyte encodings than can represent some characters in a single-byte, but require as many as four for others. For more information on character sets, refer to [Single-Byte and Multibyte Character Sets](/cpp/c-runtime-library/single-byte-and-multibyte-character-sets). 
+> Some character sets, such as [Unicode](https://en.wikipedia.org/wiki/Unicode#Mapping_and_encodings) and [Shift Japanese Industrial Standards](https://www.wikipedia.org/wiki/Shift_JIS), include characters that can be represented in a single-byte coding scheme, but require multibyte encoding. For more information on character sets, refer to [Single-Byte and Multibyte Character Sets](/cpp/c-runtime-library/single-byte-and-multibyte-character-sets). 
   
 ## Return types
 **char(1)**
@@ -176,8 +177,9 @@ single_byte_representing_complete_character single_byte_representing_complete_ch
 ｼ                                           ｼ                                         
 ```
 
-### F. CHAR inability to return multibyte characters
-This example uses integer and hex values in the valid range for ASCII. However, the CHAR function returns NULL because the parameter matches the first byte of a number of multibyte characters in the collation, but no single complete character.
+### F. Using CHAR to return multibyte characters
+This example uses integer and hex values in the valid range for Extended ASCII. However, the CHAR function returns NULL because the parameter represents only the first byte of a multibyte character.
+Although `NCHAR(2)` supplementary characters can be composed this way, `CHAR(2)` double-byte characters cannot.
   
 ```sql
 SELECT CHAR(129) AS first_byte_of_double_byte_character, 

--- a/docs/t-sql/functions/char-transact-sql.md
+++ b/docs/t-sql/functions/char-transact-sql.md
@@ -179,8 +179,8 @@ single_byte_representing_complete_character single_byte_representing_complete_ch
 
 ### F. Using CHAR to return multibyte characters
 This example uses integer and hex values in the valid range for Extended ASCII. However, the CHAR function returns NULL because the parameter represents only the first byte of a multibyte character.
-`CHAR(2)` double-byte characters cannot be composed from constituent first and second `CHAR(1)` bytes in the way that
-`NCHAR(2)` supplementary characters can be composed from constituent high and low `NCHAR(1)` surrogates.
+A `CHAR(2)` double-byte character cannot be composed from constituent first and second `CHAR(1)` bytes in the way that
+a `NCHAR(2)` supplementary character can be composed from constituent high and low `NCHAR(1)` surrogates.
   
 ```sql
 SELECT CHAR(129) AS first_byte_of_double_byte_character, 

--- a/docs/t-sql/functions/char-transact-sql.md
+++ b/docs/t-sql/functions/char-transact-sql.md
@@ -181,8 +181,8 @@ single_byte_representing_complete_character single_byte_representing_complete_ch
 ### F. Using CHAR to return multibyte characters
 This example uses integer and hex values in the valid range for Extended ASCII.
 However, the `CHAR` function returns `NULL` because the parameter represents only the first byte of a multibyte character.
-A **char(2)** double-byte character can neither be partially represented nor be divided without some conversion operation.
-The individual bytes of a double-byte character don't generally represent valid **char(1)** values.
+A CHAR(2) double-byte character cannot be partially represented nor divided without some conversion operation.
+The individual bytes of a double-byte character don't generally represent valid CHAR(1) values.
   
 ```sql
 SELECT CHAR(129) AS first_byte_of_double_byte_character, 
@@ -198,12 +198,10 @@ first_byte_of_double_byte_character first_byte_of_double_byte_character
 NULL                                NULL                                         
 ```
   
-### G. Using CONVERT instead of CHAR to decode multibyte characters
-This example relies on the default codepage of the current database to decode a multibyte character.
-`CONVERT` here operates on a character encoding, SHIFT\_JIS.
-`CHAR` and `NCHAR` operate on character sets and codepoints,
-which works well with ASCII code 13 above, but not with JIS X 208 code 2-86 here.
-Encoding JIS X 208 ku-ten codes to SHIFT\_JIS is outside the scope of this example.
+### G. Using CONVERT instead of CHAR to return multibyte characters
+This example accepts the binary value as an encoded multibyte character consistent with the default codepage of the current database,
+subject to validation.
+Character conversion is more broadly supported and may be an alternative to working with encoding at a lower level.
 
 ```sql
 CREATE DATABASE [multibyte-char-context]
@@ -219,9 +217,9 @@ SELECT NCHAR(0x266A) AS [eighth-note]
 [!INCLUDE[ssResult](../../includes/ssresult-md.md)]
 
 ```
-eighth-note context-dependent-convert context-dependent-cast
------------ ------------------------- ----------------------
-♪           ♪                         ♪
+codepoint encoded to char bytes decoded to char
+------------------------- ---------------------
+♪                         ♪
 ```
 
 ### H. Using NCHAR instead of CHAR to look up UTF-8 characters

--- a/docs/t-sql/functions/char-transact-sql.md
+++ b/docs/t-sql/functions/char-transact-sql.md
@@ -217,9 +217,9 @@ SELECT NCHAR(0x266A) AS [eighth-note]
 [!INCLUDE[ssResult](../../includes/ssresult-md.md)]
 
 ```
-codepoint encoded to char bytes decoded to char
-------------------------- ---------------------
-♪                         ♪
+eighth-note context-dependent-convert context-dependent-cast
+----------- ------------------------- ----------------------
+♪           ♪                         ♪
 ```
 
 ### H. Using NCHAR instead of CHAR to look up UTF-8 characters


### PR DESCRIPTION
Reframe some of the ASCII and double-byte language to something more
appropriate for the advent of UTF-8 to T-SQL CHAR types.
Add examples to direct users away from this function for those cases
for which it is unsuited.

Corrected pull-request origin account for CLA compliance.

fixes #2922