### PR TITLE
bdc subcommand is missing if few places (bdc spark session)

### DIFF
--- a/docs/big-data-cluster/reference-azdata-bdc-spark-session.md
+++ b/docs/big-data-cluster/reference-azdata-bdc-spark-session.md
@@ -47,7 +47,7 @@ azdata bdc spark session create [--session-kind -k]
 ### Examples
 Create a session.
 ```bash
-azdata spark session create --session-kind pyspark
+azdata bdc spark session create --session-kind pyspark
 ```
 ### Optional Parameters
 #### `--session-kind -k`
@@ -97,7 +97,7 @@ azdata bdc spark session list
 ### Examples
 List all the active sessions.
 ```bash
-azdata spark session list
+azdata bdc spark session list
 ```
 ### Global Arguments
 #### `--debug`
@@ -119,7 +119,7 @@ azdata bdc spark session info --session-id -i
 ### Examples
 Get session info for session with ID of 0.
 ```bash
-azdata spark session info --session-id 0
+azdata bdc spark session info --session-id 0
 ```
 ### Required Parameters
 #### `--session-id -i`
@@ -144,7 +144,7 @@ azdata bdc spark session log --session-id -i
 ### Examples
 Get session log for session with ID of 0.
 ```bash
-azdata spark session log --session-id 0
+azdata bdc spark session log --session-id 0
 ```
 ### Required Parameters
 #### `--session-id -i`
@@ -169,7 +169,7 @@ azdata bdc spark session state --session-id -i
 ### Examples
 Get session state for session with ID of 0.
 ```bash
-azdata spark session state --session-id 0
+azdata bdc spark session state --session-id 0
 ```
 ### Required Parameters
 #### `--session-id -i`
@@ -194,7 +194,7 @@ azdata bdc spark session delete --session-id -i
 ### Examples
 Delete a session.
 ```bash
-azdata spark session delete --session-id 0
+azdata bdc spark session delete --session-id 0
 ```
 ### Required Parameters
 #### `--session-id -i`
@@ -207,7 +207,7 @@ Show this help message and exit.
 #### `--output -o`
 Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
 #### `--query -q`
-JMESPath query string. See [http://jmespath.org/](http://jmespath.org/]) for more information and examples.
+JMESPath query string. See [http://jmespath.org/](http://jmespath.org/) for more information and examples.
 #### `--verbose`
 Increase logging verbosity. Use --debug for full debug logs.
 


### PR DESCRIPTION
bdc subcommand is missing if few places (bdc spark statement) also remove an extra character ']' from http://jmespath.org/  URL 