### PR TITLE
Update conversion notes in "decimal and numeric" and "float and real" pages

### DIFF
--- a/docs/t-sql/data-types/decimal-and-numeric-transact-sql.md
+++ b/docs/t-sql/data-types/decimal-and-numeric-transact-sql.md
@@ -1,7 +1,7 @@
 ---
 title: "decimal and numeric (Transact-SQL) | Microsoft Docs"
 ms.custom: ""
-ms.date: "07/23/2017"
+ms.date: "09/10/2019"
 ms.prod: sql
 ms.prod_service: "database-engine, sql-database, sql-data-warehouse, pdw"
 ms.reviewer: ""
@@ -61,7 +61,7 @@ Converting from **decimal** or **numeric** to **float** or **real** can cause so
   
 By default, [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] uses rounding when converting a number to a **decimal** or **numeric** value with a lower precision and scale. Conversely, if the SET ARITHABORT option is ON, [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] raises an error when overflow occurs. Loss of only precision and scale isn't sufficient to raise an error.
   
-When converting float or real values to decimal or numeric, the decimal value will never have more than 17 decimals. Any float value < 5E-18 will always convert as 0.
+Prior to [!INCLUDE[ssSQL16](../../includes/sssql16-md.md)], conversion of **float** values to **decimal** or **numeric** is restricted to values of precision 17 digits only. Any **float** value less than 5E-18 (when set using either the scientific notation of 5E-18 or the decimal notation of 0.0000000000000000050000000000000005) rounds down to 0. This is no longer a restriction as of [!INCLUDE[ssSQL16](../../includes/sssql16-md.md)].
   
 ## Examples  
 The following example creates a table using the **decimal** and **numeric** data types.  Values are inserted into each column. The results are returned by using a SELECT statement.

--- a/docs/t-sql/data-types/float-and-real-transact-sql.md
+++ b/docs/t-sql/data-types/float-and-real-transact-sql.md
@@ -57,7 +57,7 @@ Values of **float** are truncated when they are converted to any integer type.
   
 When you want to convert from **float** or **real** to character data, using the STR string function is usually more useful than CAST( ). This is because STR enables more control over formatting. For more information, see [STR &#40;Transact-SQL&#41;](../../t-sql/functions/str-transact-sql.md) and [Functions &#40;Transact-SQL&#41;](../../t-sql/functions/functions.md).
   
-Prior to [!INCLUDE[ssSQL16](../../includes/sssql16-md.md)], conversion of literal **float** values that use scientific notation to **decimal** or **numeric** is restricted to values of precision 17 digits only. Any value less than 5E-18 rounds down to 0. This is no longer a restriction as of [!INCLUDE[ssSQL16](../../includes/sssql16-md.md)].
+Prior to [!INCLUDE[ssSQL16](../../includes/sssql16-md.md)], conversion of **float** values to **decimal** or **numeric** is restricted to values of precision 17 digits only. Any **float** value less than 5E-18 (when set using either the scientific notation of 5E-18 or the decimal notation of 0.0000000000000000050000000000000005) rounds down to 0. This is no longer a restriction as of [!INCLUDE[ssSQL16](../../includes/sssql16-md.md)].
   
 ## See also
 [ALTER TABLE &#40;Transact-SQL&#41;](../../t-sql/statements/alter-table-transact-sql.md)  

--- a/docs/t-sql/data-types/float-and-real-transact-sql.md
+++ b/docs/t-sql/data-types/float-and-real-transact-sql.md
@@ -1,7 +1,7 @@
 ---
 title: "float and real (Transact-SQL) | Microsoft Docs"
 ms.custom: ""
-ms.date: "07/22/2017"
+ms.date: "09/10/2019"
 ms.prod: sql
 ms.prod_service: "database-engine, sql-database, sql-data-warehouse, pdw"
 ms.reviewer: ""
@@ -57,7 +57,7 @@ Values of **float** are truncated when they are converted to any integer type.
   
 When you want to convert from **float** or **real** to character data, using the STR string function is usually more useful than CAST( ). This is because STR enables more control over formatting. For more information, see [STR &#40;Transact-SQL&#41;](../../t-sql/functions/str-transact-sql.md) and [Functions &#40;Transact-SQL&#41;](../../t-sql/functions/functions.md).
   
-Conversion of **float** values that use scientific notation to **decimal** or **numeric** is restricted to values of precision 17 digits only. Any value < 5E-18 rounds down to 0.
+Prior to [!INCLUDE[ssSQL16](../../includes/sssql16-md.md)], conversion of literal **float** values that use scientific notation to **decimal** or **numeric** is restricted to values of precision 17 digits only. Any value less than 5E-18 rounds down to 0. This is no longer a restriction as of [!INCLUDE[ssSQL16](../../includes/sssql16-md.md)].
   
 ## See also
 [ALTER TABLE &#40;Transact-SQL&#41;](../../t-sql/statements/alter-table-transact-sql.md)  


### PR DESCRIPTION
Fixes #2827

The behavior changed starting in SQL Server 2016. Please see my comments in #2827 for the test code.

Please check the include reference. The `CREATE TABLE` page ( https://github.com/MicrosoftDocs/sql-docs/blob/live/docs/t-sql/statements/create-table-transact-sql.md ) uses  `[!INCLUDE[ssSQL15](../../includes/sssql15-md.md)]` but that is a bad name for the include file since there is no 2015 version. There is an identical include file with the correct name, **sssql16**, so I am using that instead. But, I have no way to test include files to hopefully there is no problem with the "16" file.

Take care,
Solomon...
https://SqlQuantumLeap.com/