### PR TITLE
Update merge-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/merge-transact-sql.md
+++ b/docs/t-sql/statements/merge-transact-sql.md
@@ -217,8 +217,8 @@ Specifies that all rows of *target_table, which match the rows returned by \<tab
 The MERGE statement can have, at most, two WHEN MATCHED clauses. If two clauses are specified, the first clause must be accompanied by an AND \<search_condition> clause. For any given row, the second WHEN MATCHED clause is only applied if the first isn't. If there are two WHEN MATCHED clauses, one must specify an UPDATE action and one must specify a DELETE action. When UPDATE is specified in the \<merge_matched> clause, and more than one row of \<table_source> matches a row in *target_table* based on \<merge_search_condition>, [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] returns an error. The MERGE statement can't update the same row more than once, or update and delete the same row.  
   
 WHEN NOT MATCHED [ BY TARGET ] THEN \<merge_not_matched>  
-Specifies that a row is inserted into *target_table* for every row returned by \<table_source> ON \<merge_search_condition> that doesn't match a row in *target_table*, but satisfies an additional search condition, if present. The values to insert are specified by the \<merge_not_matched> clause. The MERGE statement can have only one WHEN NOT MATCHED clause.  
-  
+Specifies that a row is inserted into *target_table* for every row returned by \<table_source> ON \<merge_search_condition> that doesn't match a row in *target_table*, but satisfies an additional search condition, if present. The values to insert are specified by the \<merge_not_matched> clause. The MERGE statement can have only one WHEN NOT MATCHED [ BY TARGET ] clause.
+
 WHEN NOT MATCHED BY SOURCE THEN \<merge_matched>  
 Specifies that all rows of *target_table, which don't match the rows returned by \<table_source> ON \<merge_search_condition>, and that satisfy any additional search condition, are updated or deleted according to the \<merge_matched> clause.  
   


### PR DESCRIPTION
There are two ways to read the statement "The MERGE statement can have only one WHEN NOT MATCHED clause."
1) If you have A) "WHEN NOT MATCHED", you cannot have any other "WHEN NOT MATCHED ..." clause, including a qualified one, such as B) "WHEN NOT MATCHED BY TARGET" or C) "WHEN NOT MATCHED BY SOURCE". This is not the case since you can include both A) "WHEN NOT MATCHED" and C) "WHEN NOT MATCHED BY SOURCE" in the same MERGE statement.
or, the other way to read that statement
2) If you have A) "WHEN NOT MATCHED", you cannot have another "WHEN NOT MATCHED", but you _can_ have a qualified "WHEN NOT MATCHED" clause, such as B) "WHEN NOT MATCHED BY TARGET" or C) "WHEN NOT MATCHED BY SOURCE", or possibly both. This is not correct, since trying to include A) "WHEN NOT MATCHED" and B) "WHEN NOT MATCHED BY TARGET" in the same MERGE statement results in an error.
The correct statement would be:
3) The merge statement can have only one "WHEN NOT MATCHED" or "WHEN NOT MATCHED BY TARGET" clause, or more simply "WHEN NOT MATCHED [ BY TARGET ]" (as used elsewhere) to indicate both variations.