### PR TITLE
Consistent formatting for code examples under "Perform Index Operations Online"

### DIFF
--- a/docs/relational-databases/indexes/codesnippet/tsql/perform-index-operations_1.sql
+++ b/docs/relational-databases/indexes/codesnippet/tsql/perform-index-operations_1.sql
@@ -1,4 +1,4 @@
---Create a clustered index on the PRIMARY filegroup if the index does not exist.
+-- Create a clustered index on the PRIMARY filegroup if the index does not exist.
 IF NOT EXISTS (SELECT name FROM sys.indexes WHERE name = 
             N'AK_BillOfMaterials_ProductAssemblyID_ComponentID_StartDate')
     CREATE UNIQUE CLUSTERED INDEX
@@ -7,6 +7,7 @@ IF NOT EXISTS (SELECT name FROM sys.indexes WHERE name =
         StartDate)
     ON 'PRIMARY';
 GO
+
 -- Verify filegroup location of the clustered index.
 SELECT t.name AS [Table Name], i.name AS [Index Name], i.type_desc,
     i.data_space_id, f.name AS [Filegroup Name]
@@ -15,7 +16,8 @@ FROM sys.indexes AS i
     JOIN sys.tables as t ON i.object_id = t.object_id
         AND i.object_id = OBJECT_ID(N'Production.BillOfMaterials','U')
 GO
---Create filegroup NewGroup if it does not exist.
+
+-- Create filegroup NewGroup if it does not exist.
 IF NOT EXISTS (SELECT name FROM sys.filegroups
                 WHERE name = N'NewGroup')
     BEGIN
@@ -27,9 +29,11 @@ IF NOT EXISTS (SELECT name FROM sys.filegroups
         TO FILEGROUP NewGroup;
     END
 GO
---Verify new filegroup
+
+-- Verify new filegroup
 SELECT * from sys.filegroups;
 GO
+
 -- Drop the clustered index and move the BillOfMaterials table to
 -- the Newgroup filegroup.
 -- Set ONLINE = OFF to execute this example on editions other than Enterprise Edition.
@@ -37,6 +41,7 @@ DROP INDEX AK_BillOfMaterials_ProductAssemblyID_ComponentID_StartDate
     ON Production.BillOfMaterials 
     WITH (ONLINE = ON, MOVE TO NewGroup);
 GO
+
 -- Verify filegroup location of the moved table.
 SELECT t.name AS [Table Name], i.name AS [Index Name], i.type_desc,
     i.data_space_id, f.name AS [Filegroup Name]

--- a/docs/relational-databases/indexes/perform-index-operations-online.md
+++ b/docs/relational-databases/indexes/perform-index-operations-online.md
@@ -90,12 +90,11 @@ monikerRange: "=azuresqldb-current||>=sql-server-2016||=sqlallproducts-allversio
 ### To create, rebuild, or drop an index online  
   
 The following example rebuilds an existing online index in the AdventureWorks database.
-  
- ```sql  
- ALTER INDEX AK_Employee_NationalIDNumber
-   ON HumanResources.Employee  
-   REBUILD WITH (ONLINE = ON)
-;
+
+```sql
+ALTER INDEX AK_Employee_NationalIDNumber
+    ON HumanResources.Employee
+    REBUILD WITH (ONLINE = ON);
 ```  
   
 The following example deletes a clustered index online and moves the resulting table (heap) to the filegroup `NewGroup` by using the `MOVE TO` clause. The `sys.indexes`, `sys.tables`, and `sys.filegroups` catalog views are queried to verify the index and table placement in the filegroups before and after the move.  


### PR DESCRIPTION
Page Edited - [Perform Index Operations Online](https://docs.microsoft.com/en-us/sql/relational-databases/indexes/perform-index-operations-online?view=sqlallproducts-allversions)

### Changes
 - Proper spacing in comments for readability.
 - Make indentation consistent for SQL examples - 4 spaces. 