### PR TITLE
ACCEPT_EULA requires "yes" value even as env variable

### DIFF
--- a/docs/big-data-cluster/deployment-guidance.md
+++ b/docs/big-data-cluster/deployment-guidance.md
@@ -143,7 +143,7 @@ The following environment variables are used for security settings that are not 
 | **CONTROLLER_PASSWORD** | Required |The password for the cluster administrator. |
 | **MSSQL_SA_PASSWORD** | Required |The password of SA user for SQL master instance. |
 | **KNOX_PASSWORD** | Required |The password for Knox **root** user. Note than in a basic authentication setup only user supported for Knox is **root**.|
-| **ACCEPT_EULA**| Required for first use of `azdata`| Requires no value. When set as an environment variable, it applies EULA to both SQL Server and `azdata`. If not set as environment variable, you can include `--accept-eula` in the first use of `azdata` command.|
+| **ACCEPT_EULA**| Required for first use of `azdata`| Set to "yes". When set as an environment variable, it applies EULA to both SQL Server and `azdata`. If not set as environment variable, you can include `--accept-eula=yes` in the first use of `azdata` command.|
 | **DOCKER_USERNAME** | Optional | The username to access the container images in case they are stored in a private repository. See the [Offline deployments](deploy-offline.md) topic for more details on how to use a private Docker repository for big data cluster deployment.|
 | **DOCKER_PASSWORD** | Optional |The password to access the above private repository. |
 
@@ -156,6 +156,7 @@ export CONTROLLER_USERNAME=admin
 export CONTROLLER_PASSWORD=<password>
 export MSSQL_SA_PASSWORD=<password>
 export KNOX_PASSWORD=<password>
+export ACCEPT_EULA=yes
 ```
 
 ```PowerShell


### PR DESCRIPTION
Source : simple testing.
=================
:~$ export ACCEPT_EULA=
:~$ azdata bdc create
The privacy statement can be viewed at:
https://go.microsoft.com/fwlink/?LinkId=853010

The license terms for SQL Server Big Data Cluster can be viewed at:
https://go.microsoft.com/fwlink/?LinkId=2002534

Do you accept the license terms? (y/n):


======================

:~$ export ACCEPT_EULA=yes
:~$ azdata bdc create
The privacy statement can be viewed at:
https://go.microsoft.com/fwlink/?LinkId=853010

The license terms for SQL Server Big Data Cluster can be viewed at:
https://go.microsoft.com/fwlink/?LinkId=2002534


Cluster deployment documentation can be viewed at:
https://aka.ms/bdc-deploy

Please choose a deployment configuration:
To see more info please exit create and use command [bdc config list -c <config_profile>]

  1. aks-dev-test
  2. kubeadm-dev-test (default choice)
  3. kubeadm-prod
  4. minikube-dev-test

 Enter your choice as a number or unique substring (Control-C aborts):