### PR TITLE
Update: branding-the-web-portal.md

### DIFF
--- a/docs/reporting-services/branding-the-web-portal.md
+++ b/docs/reporting-services/branding-the-web-portal.md
@@ -22,7 +22,7 @@ You can alter the appearance of the web portal by branding it to your business. 
   
 A brand package for Reporting Services consists of three items and is packaged as a zip file.   
   
-- color.json  
+- colors.json  
 - metadata.xml  
 - logo.png (optional)  
   


### PR DESCRIPTION
To be consistent throughout the document when referencing the `colors.json` file.  The introduction was the only place where it was referred to as `color.json`.  Navigation contents and other references used `colors.json`.