### PR TITLE
Clarification of log count

### DIFF
--- a/docs/database-engine/configure-windows/scm-services-configure-sql-server-error-logs.md
+++ b/docs/database-engine/configure-windows/scm-services-configure-sql-server-error-logs.md
@@ -32,7 +32,7 @@ ms.author: mikeray
   
       **Maximum number of error log files**
 
-      Specify the maximum number of error log files created before they are recycled. The default is 6, which is the number of previous backup logs [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] retains before recycling them.
+      Specify the maximum number of error log files created before they are recycled. The default is 6, one current and the 5 previous backup logs that [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] retains before recycling them.
 
     b. Log file size
 


### PR DESCRIPTION
Previous wording implied 6 previous logs and ignored the current one. Added a better explanation.