### PR TITLE
Update overview-of-always-on-availability-groups-sql-server.md

### DIFF
--- a/docs/database-engine/availability-groups/windows/overview-of-always-on-availability-groups-sql-server.md
+++ b/docs/database-engine/availability-groups/windows/overview-of-always-on-availability-groups-sql-server.md
@@ -85,7 +85,7 @@ ms.author: mathoma
   
  Three forms of failover exist-automatic, manual, and forced (with possible data loss). The form or forms of failover supported by a given secondary replica depends on its availability mode, and, for synchronous-commit mode, on the failover mode on the primary replica and target secondary replica, as follows.  
   
--   Synchronous-commit mode supports two forms of failover-*planned manual failover* and *automatic failover*, if the target secondary replica is currently synchronized with the avt1. The support for these forms of failover depends on the setting of the *failover mode property* on the failover partners. If failover mode is set to "manual" on either the primary or secondary replica, only manual failover is supported for that secondary replica. If failover mode is set to "automatic" on both the primary and secondary replicas, both automatic and manual failover are supported on that secondary replica.  
+-   Synchronous-commit mode supports two forms of failover-*planned manual failover* and *automatic failover*, if the target secondary replica is currently synchronized with the primary replica. The support for these forms of failover depends on the setting of the *failover mode property* on the failover partners. If failover mode is set to "manual" on either the primary or secondary replica, only manual failover is supported for that secondary replica. If failover mode is set to "automatic" on both the primary and secondary replicas, both automatic and manual failover are supported on that secondary replica.  
   
     -   **Planned manual failover** (without data loss)  
   


### PR DESCRIPTION
I'm assuming that "avt1" is actually "primary replica"?

This is since I haven't seen another mention of "avt1" in the documentation so far.