### PR TITLE
Adding SMO requirement on .NET Core

### DIFF
--- a/docs/relational-databases/server-management-objects-smo/installing-smo.md
+++ b/docs/relational-databases/server-management-objects-smo/installing-smo.md
@@ -40,6 +40,6 @@ See [NuGet Quick Start - Use a Package](https://docs.microsoft.com/nuget/quickst
   
 ## System Requirements
   
- SMO requires [!INCLUDE[dnprdnshort](../../includes/dnprdnshort-md.md)] 4.0 to run, so any applications using it must ensure that client machines have that version or higher installed. Some native binaries installed with the NetFx SMO libraries also require the VC 2013 runtime to be installed; that runtime is not included in the package. You can download the redist appropriate to your 
+ SMO requires [!INCLUDE[dnprdnshort](../../includes/dnprdnshort-md.md)] 4.0 or .NET Core 2.0 to run, so any applications using it must ensure that client machines have that version or higher installed. Some native binaries installed with the NetFx SMO libraries also require the VC 2013 runtime to be installed; that runtime is not included in the package. You can download the redist appropriate to your 
 target architecture from https://www.microsoft.com/download/details.aspx?id=40784
   


### PR DESCRIPTION
Based on research it appears that SMO https://www.nuget.org/packages/Microsoft.SqlServer.SqlManagementObjects needs can use .NET Core 2.0 as well. 
"> Dependencies 
.NETCoreApp 2.0
System.Data.SqlClient (>= 4.6.0)"

Can you validate and update the document. We have a big ISV asking for confirmation on this and thus updating doc.