### PR TITLE
Update STRING_ESCAPE to consider the SQL compatibility version

### DIFF
--- a/docs/t-sql/functions/string-escape-transact-sql.md
+++ b/docs/t-sql/functions/string-escape-transact-sql.md
@@ -23,7 +23,13 @@ monikerRange: "= azuresqldb-current||>= sql-server-2016||>= sql-server-linux-201
 
 [!INCLUDE[tsql-appliesto-ss2016-asdb-xxxx-xxx-md](../../includes/tsql-appliesto-ss2016-asdb-xxxx-xxx-md.md)]
 
-  Escapes special characters in texts and returns text with escaped characters. **STRING_ESCAPE** is a deterministic function.  
+  Escapes special characters in texts and returns text with escaped characters. **STRING_ESCAPE** is a deterministic function. 
+  
+#### Compatibility level 130
+
+STRING_ESCAPE requires the compatibility level to be at least 130. When the level is less than 130, SQL Server is unable to find the STRING_ESCAPE function.
+
+To change the compatibility level of a database, refer to [View or Change the Compatibility Level of a Database](../../relational-databases/databases/view-or-change-the-compatibility-level-of-a-database.md).
   
  ![Topic link icon](../../database-engine/configure-windows/media/topic-link.gif "Topic link icon") [Transact-SQL Syntax Conventions](../../t-sql/language-elements/transact-sql-syntax-conventions-transact-sql.md)  
   

--- a/docs/t-sql/functions/string-escape-transact-sql.md
+++ b/docs/t-sql/functions/string-escape-transact-sql.md
@@ -23,12 +23,8 @@ monikerRange: "= azuresqldb-current||>= sql-server-2016||>= sql-server-linux-201
 
 [!INCLUDE[tsql-appliesto-ss2016-asdb-xxxx-xxx-md](../../includes/tsql-appliesto-ss2016-asdb-xxxx-xxx-md.md)]
 
-  Escapes special characters in texts and returns text with escaped characters. **STRING_ESCAPE** is a deterministic function. 
+Escapes special characters in texts and returns text with escaped characters. **STRING_ESCAPE** is a deterministic function, introduced in SQL Server 2016. 
   
-#### Compatibility level 130
-
-STRING_ESCAPE requires the compatibility level to be at least 130. When the level is less than 130, SQL Server is unable to find the STRING_ESCAPE function.
-
 To change the compatibility level of a database, refer to [View or Change the Compatibility Level of a Database](../../relational-databases/databases/view-or-change-the-compatibility-level-of-a-database.md).
   
  ![Topic link icon](../../database-engine/configure-windows/media/topic-link.gif "Topic link icon") [Transact-SQL Syntax Conventions](../../t-sql/language-elements/transact-sql-syntax-conventions-transact-sql.md)  

--- a/docs/t-sql/functions/string-escape-transact-sql.md
+++ b/docs/t-sql/functions/string-escape-transact-sql.md
@@ -25,8 +25,6 @@ monikerRange: "= azuresqldb-current||>= sql-server-2016||>= sql-server-linux-201
 
 Escapes special characters in texts and returns text with escaped characters. **STRING_ESCAPE** is a deterministic function, introduced in SQL Server 2016. 
   
-To change the compatibility level of a database, refer to [View or Change the Compatibility Level of a Database](../../relational-databases/databases/view-or-change-the-compatibility-level-of-a-database.md).
-  
  ![Topic link icon](../../database-engine/configure-windows/media/topic-link.gif "Topic link icon") [Transact-SQL Syntax Conventions](../../t-sql/language-elements/transact-sql-syntax-conventions-transact-sql.md)  
   
 ## Syntax  


### PR DESCRIPTION
The current docs does not state what SQL Server version is the minimum compatible version for use with the STRING_ESCAPE function.

I found this odd because [STRING_SPLIT](https://docs.microsoft.com/en-us/sql/t-sql/functions/string-split-transact-sql?view=sqlallproducts-allversions) function have a statement showing the minimum compatible version.