### PR TITLE
Typo "**@publication=**"→"**\@publication=**"

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-validatemergepublication-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-validatemergepublication-transact-sql.md
@@ -32,7 +32,7 @@ sp_validatemergepublication [@publication=] 'publication'
 ```  
   
 ## Arguments  
- [**@publication=**] **'***publication***'**  
+ [**\@publication=**] **'***publication***'**  
  Is the name of the publication. *publication* is **sysname**, with no default.  
   
 `[ @level = ] level`


### PR DESCRIPTION
bold with escape characters

https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-validatemergepublication-transact-sql?view=sql-server-2017