### PR TITLE
Typo "**@agent_type=**"→"**\@agent_type=**"

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-update-agent-profile-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-update-agent-profile-transact-sql.md
@@ -31,7 +31,7 @@ sp_update_agent_profile [@agent_type=] agent_type, [ @agent_id= ] agent_id, [ @p
 ```  
   
 ## Arguments  
- [**@agent_type=**] **'***agent_type***'**  
+ [**\@agent_type=**] **'***agent_type***'**  
  Is the type of agent. *agent_type* is **int**, with no default, and can be one of these values.  
   
 |Value|Description|  
@@ -42,10 +42,10 @@ sp_update_agent_profile [@agent_type=] agent_type, [ @agent_id= ] agent_id, [ @p
 |**4**|Merge Agent.|  
 |**9**|Queue Reader Agent.|  
   
- [**@agent_id=**] *agent_id*  
+ [**\@agent_id=**] *agent_id*  
  Is the ID of the agent. *agent_id* is **int**, with no default.  
   
- [**@profile_id=**] *profile_id*  
+ [**\@profile_id=**] *profile_id*  
  Is the ID of the profile that the agent should use. *profile_id* is **int**, with no default. To view a list of profiles defined for each agent, use [sp_help_agent_profile &#40;Transact-SQL&#41;](../../relational-databases/system-stored-procedures/sp-help-agent-profile-transact-sql.md). For more information about system profiles, see [Replication Agent Profiles](../../relational-databases/replication/agents/replication-agent-profiles.md).  
   
 ## Return Code Values  


### PR DESCRIPTION
bold with escape characters

https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-update-agent-profile-transact-sql?view=sql-server-2017