### PR TITLE
Typo "**@plan_handle**"→"**\@plan_handle**"

### DIFF
--- a/docs/relational-databases/errors-events/mssqlserver-10532-database-engine-error.md
+++ b/docs/relational-databases/errors-events/mssqlserver-10532-database-engine-error.md
@@ -24,13 +24,13 @@ ms.author: mathoma
 |Event Source|MSSQLSERVER|  
 |Component|SQLEngine|  
 |Symbolic Name|PG_NO_ELIGIBLE_STMT|  
-|Message Text|Cannot create plan guide '%.\*ls' because the batch or module specified by **@plan_handle** does not contain a statement that is eligible for a plan guide. Specify a different value for **@plan_handle**.|  
+|Message Text|Cannot create plan guide '%.\*ls' because the batch or module specified by **\@plan_handle** does not contain a statement that is eligible for a plan guide. Specify a different value for **\@plan_handle**.|  
   
 ## Explanation  
-The batch or module specified by **@plan_handle** does not contain a statement that is eligible for a plan guide.  
+The batch or module specified by **\@plan_handle** does not contain a statement that is eligible for a plan guide.  
   
 ## User Action  
-Specify a different value for **@plan_handle**.  
+Specify a different value for **\@plan_handle**.  
   
 ## See Also  
 [Plan Guides](~/relational-databases/performance/plan-guides.md)  


### PR DESCRIPTION
bold with escape characters

https://docs.microsoft.com/en-us/sql/relational-databases/errors-events/mssqlserver-10532-database-engine-error?view=sql-server-2017