### PR TITLE
Typo "**@login_name**"→"**\@login_name**"

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-grant-login-to-proxy-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-grant-login-to-proxy-transact-sql.md
@@ -39,19 +39,19 @@ sp_grant_login_to_proxy
   
 ## Arguments  
 `[ @login_name = ] 'login_name'`
- The login name to grant access to. The *login_name* is **nvarchar(256)**, with a default of NULL. One of **@login_name**, **@fixed_server_role**, or **@msdb_role** must be specified, or the stored procedure fails.  
+ The login name to grant access to. The *login_name* is **nvarchar(256)**, with a default of NULL. One of **\@login_name**, **\@fixed_server_role**, or **\@msdb_role** must be specified, or the stored procedure fails.  
   
 `[ @fixed_server_role = ] 'fixed_server_role'`
- The fixed server role to grant access to. The *fixed_server_role* is **nvarchar(256)**, with a default of NULL. One of **@login_name**, **@fixed_server_role**, or **@msdb_role** must be specified, or the stored procedure fails.  
+ The fixed server role to grant access to. The *fixed_server_role* is **nvarchar(256)**, with a default of NULL. One of **\@login_name**, **\@fixed_server_role**, or **\@msdb_role** must be specified, or the stored procedure fails.  
   
 `[ @msdb_role = ] 'msdb_role'`
- The database role in the **msdb** database to grant access to. The *msdb_role* is **nvarchar(256)**, with a default of NULL. One of **@login_name**, **@fixed_server_role**, or **@msdb_role** must be specified, or the stored procedure fails.  
+ The database role in the **msdb** database to grant access to. The *msdb_role* is **nvarchar(256)**, with a default of NULL. One of **\@login_name**, **\@fixed_server_role**, or **\@msdb_role** must be specified, or the stored procedure fails.  
   
 `[ @proxy_id = ] id`
- The identifier for the proxy to grant access for. The *id* is **int**, with a default of NULL. One of **@proxy_id** or **@proxy_name** must be specified, or the stored procedure fails.  
+ The identifier for the proxy to grant access for. The *id* is **int**, with a default of NULL. One of **\@proxy_id** or **\@proxy_name** must be specified, or the stored procedure fails.  
   
 `[ @proxy_name = ] 'proxy_name'`
- The name of the proxy to grant access for. The *proxy_name* is **nvarchar(256)**, with a default of NULL. One of **@proxy_id** or **@proxy_name** must be specified, or the stored procedure fails.  
+ The name of the proxy to grant access for. The *proxy_name* is **nvarchar(256)**, with a default of NULL. One of **\@proxy_id** or **\@proxy_name** must be specified, or the stored procedure fails.  
   
 ## Return Code Values  
  **0** (success) or **1** (failure)  


### PR DESCRIPTION
bold with escape characters

https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-grant-login-to-proxy-transact-sql?view=sql-server-2017