### PR TITLE
Consistent SQL formatting for SQL examples under page "JSON data in SQL Server"

### DIFF
--- a/docs/relational-databases/json/json-data-sql-server.md
+++ b/docs/relational-databases/json/json-data-sql-server.md
@@ -42,7 +42,7 @@ Here's an example of JSON text:
 ]
 ```
 
-SQL Server built-in functions and operators enables you to do the following things with JSON data:
+By using SQL Server built-in functions and operators, you can do the following things with JSON text:
 
 - Parse JSON text and read or modify values.  
 - Transform arrays of JSON objects into table format.  

--- a/docs/relational-databases/json/json-data-sql-server.md
+++ b/docs/relational-databases/json/json-data-sql-server.md
@@ -29,16 +29,19 @@ JSON functions in SQL Server enable you to combine NoSQL and relational concepts
 Here's an example of JSON text:
 
 ```json
-[{
+[
+  {
     "name": "John",
     "skills": ["SQL", "C#", "Azure"]
-}, {
+  },
+  {
     "name": "Jane",
     "surname": "Doe"
-}]
+  }
+]
 ```
 
-SQL Server built-in functions and operators enables you to do the following things with JSON data: 
+SQL Server built-in functions and operators enables you to do the following things with JSON data:
 
 - Parse JSON text and read or modify values.  
 - Transform arrays of JSON objects into table format.  
@@ -55,28 +58,27 @@ The next sections discuss the key capabilities that SQL Server provides with its
 
 ### Extract values from JSON text and use them in queries
 If you have JSON text that's stored in database tables, you can read or modify values in the JSON text by using the following built-in functions:  
-    
+
 - [ISJSON (Transact-SQL)](../../t-sql/functions/isjson-transact-sql.md) tests whether a string contains valid JSON.
 - [JSON_VALUE (Transact-SQL)](../../t-sql/functions/json-value-transact-sql.md) extracts a scalar value from a JSON string.
 - [JSON_QUERY (Transact-SQL)](../../t-sql/functions/json-query-transact-sql.md) extracts an object or an array from a JSON string.
 - [JSON_MODIFY (Transact-SQL)](../../t-sql/functions/json-modify-transact-sql.md) changes a value in a JSON string.
 
-
 **Example**
-  
+
 In the following example, the query uses both relational and JSON data (stored in a column named `jsonCol`) from a table:  
   
 ```sql  
-SELECT Name,Surname,
- JSON_VALUE(jsonCol,'$.info.address.PostCode') AS PostCode,
- JSON_VALUE(jsonCol,'$.info.address."Address Line 1"')+' '
-  +JSON_VALUE(jsonCol,'$.info.address."Address Line 2"') AS Address,
- JSON_QUERY(jsonCol,'$.info.skills') AS Skills
+SELECT Name, Surname,
+  JSON_VALUE(jsonCol, '$.info.address.PostCode') AS PostCode,
+  JSON_VALUE(jsonCol, '$.info.address."Address Line 1"') + ' '
+  + JSON_VALUE(jsonCol, '$.info.address."Address Line 2"') AS Address,
+  JSON_QUERY(jsonCol,'$.info.skills') AS Skills
 FROM People
-WHERE ISJSON(jsonCol)>0
- AND JSON_VALUE(jsonCol,'$.info.address.Town')='Belgrade'
- AND Status='Active'
-ORDER BY JSON_VALUE(jsonCol,'$.info.address.PostCode')
+WHERE ISJSON(jsonCol) > 0
+  AND JSON_VALUE(jsonCol, '$.info.address.Town') = 'Belgrade'
+  AND Status = 'Active'
+ORDER BY JSON_VALUE(jsonCol, '$.info.address.PostCode')
 ```  
   
 Applications and tools see no difference between the values taken from scalar table columns and the values taken from JSON columns. You can use values from JSON text in any part of a Transact-SQL query (including WHERE, ORDER BY, or GROUP BY clauses, window aggregates, and so on). JSON functions use JavaScript-like syntax for referencing values inside JSON text.
@@ -118,8 +120,8 @@ FROM OPENJSON(@json)
         age int, dateOfBirth datetime2 '$.dob')  
 ```  
   
-**Results**  
-  
+**Results**
+
 |ID|firstName|lastName|age|dateOfBirth|  
 |--------|---------------|--------------|---------|-----------------|  
 |2|John|Smith|25||  

--- a/docs/relational-databases/json/json-data-sql-server.md
+++ b/docs/relational-databases/json/json-data-sql-server.md
@@ -256,7 +256,7 @@ Transform relational data from your database easily into the JSON format used by
 
 SQL Server provides a hybrid model for storing and processing both relational and JSON data by using standard Transact-SQL language. You can organize collections of your JSON documents in tables, establish relationships between them, combine strongly typed scalar columns stored in tables with flexible key/value pairs stored in JSON columns, and query both scalar and JSON values in one or more tables by using full Transact-SQL.
 
-JSON text is stored in varchar or nvarchar columns and is indexed as plain text. Any SQL Server feature or component that supports text supports JSON, so there are almost no constraints on interaction between JSON and other SQL Server features. You can store JSON in In-memory or Temporal tables, apply Row-Level Security predicates on JSON text, and so on.
+JSON text is stored in `VARCHAR` or `NVARCHAR` columns and is indexed as plain text. Any SQL Server feature or component that supports text supports JSON, so there are almost no constraints on interaction between JSON and other SQL Server features. You can store JSON in In-memory or Temporal tables, apply Row-Level Security predicates on JSON text, and so on.
 
 If you have pure JSON workloads where you want to use a query language that's customized for the processing of JSON documents, consider Microsoft Azure [Cosmos DB](https://azure.microsoft.com/services/cosmos-db/).  
   

--- a/docs/relational-databases/json/json-data-sql-server.md
+++ b/docs/relational-databases/json/json-data-sql-server.md
@@ -73,7 +73,7 @@ SELECT Name, Surname,
   JSON_VALUE(jsonCol, '$.info.address.PostCode') AS PostCode,
   JSON_VALUE(jsonCol, '$.info.address."Address Line 1"') + ' '
   + JSON_VALUE(jsonCol, '$.info.address."Address Line 2"') AS Address,
-  JSON_QUERY(jsonCol,'$.info.skills') AS Skills
+  JSON_QUERY(jsonCol, '$.info.skills') AS Skills
 FROM People
 WHERE ISJSON(jsonCol) > 0
   AND JSON_VALUE(jsonCol, '$.info.address.Town') = 'Belgrade'
@@ -216,7 +216,7 @@ The **FOR JSON** clause formats SQL results as JSON text that can be provided to
       "surname": "Smith"
     },
     "dob": "2005-11-04T12:00:00"
- }
+  }
 ]
 ```  
   
@@ -319,8 +319,8 @@ You can provide the content of the JSON variable by an external REST service, se
 ## Analyze JSON data with SQL queries  
 If you must filter or aggregate JSON data for reporting purposes, you can use **OPENJSON** to transform JSON to relational format. You can then use standard [!INCLUDE[tsql](../../includes/tsql-md.md)] and built-in functions to prepare the reports.  
   
-```sql  
-SELECT Tab.Id, SalesOrderJsonData.Customer, SalesOrderJsonData.Date  
+```sql
+SELECT Tab.Id, SalesOrderJsonData.Customer, SalesOrderJsonData.Date
 FROM SalesOrderRecord AS Tab
 CROSS APPLY OPENJSON (Tab.json, N'$.Orders.OrdersArray')
   WITH (
@@ -350,7 +350,7 @@ This OData URL represents a request for the ProductID and ProductName columns fo
 SELECT 'https://services.odata.org/V4/Northwind/Northwind.svc/$metadata#Products(ProductID,ProductName)/$entity' AS '@odata.context',
   ProductID,
   Name as ProductName
-FROM Production.Product  
+FROM Production.Product
 WHERE ProductID = 1
 FOR JSON AUTO;
 ```  

--- a/docs/relational-databases/json/json-data-sql-server.md
+++ b/docs/relational-databases/json/json-data-sql-server.md
@@ -88,13 +88,14 @@ For more information, see [Validate, query, and change JSON data with built-in f
 ### Change JSON values
 If you must modify parts of JSON text, you can use the [JSON_MODIFY (Transact-SQL)](../../t-sql/functions/json-modify-transact-sql.md) function to update the value of a property in a JSON string and return the updated JSON string. The following example updates the value of a property in a variable that contains JSON:  
   
-```sql  
+```sql
 DECLARE @json NVARCHAR(MAX);
-SET @json = '{"info":{"address":[{"town":"Belgrade"},{"town":"Paris"},{"town":"Madrid"}]}}';
-SET @json = JSON_MODIFY(@json,'$.info.address[1].town','London');
+SET @json = '{"info": {"address": [{"town": "Belgrade"}, {"town": "Paris"}, {"town":"Madrid"}]}}';
+SET @json = JSON_MODIFY(@json, '$.info.address[1].town', 'London');
 SELECT modifiedJson = @json;
-```  
-**Results**  
+```
+
+**Results**
 
 |modifiedJson|  
 |--------|  
@@ -106,20 +107,23 @@ You don't need a custom query language to query JSON in SQL Server. To query JSO
 The following example calls **OPENJSON** and transforms the array of objects that is stored in the `@json` variable to a rowset that can be queried with a standard SQL **SELECT** statement:  
   
 ```sql  
-DECLARE @json NVARCHAR(MAX)
-SET @json =  
-N'[  
-       { "id" : 2,"info": { "name": "John", "surname": "Smith" }, "age": 25 },  
-       { "id" : 5,"info": { "name": "Jane", "surname": "Smith" }, "dob": "2005-11-04T12:00:00" }  
- ]'  
-   
-SELECT *  
-FROM OPENJSON(@json)  
-  WITH (id int 'strict $.id',  
-        firstName nvarchar(50) '$.info.name', lastName nvarchar(50) '$.info.surname',  
-        age int, dateOfBirth datetime2 '$.dob')  
-```  
-  
+DECLARE @json NVARCHAR(MAX);
+SET @json = N'[
+  {"id": 2, "info": {"name": "John", "surname": "Smith"}, "age": 25},
+  {"id": 5, "info": {"name": "Jane", "surname": "Smith"}, "dob": "2005-11-04T12:00:00"}
+]';
+
+SELECT *
+FROM OPENJSON(@json)
+  WITH (
+    id INT 'strict $.id',
+    firstName NVARCHAR(50) '$.info.name',
+    lastName NVARCHAR(50) '$.info.surname',
+    age INT,
+    dateOfBirth DATETIME2 '$.dob'
+  );
+```
+
 **Results**
 
 |ID|firstName|lastName|age|dateOfBirth|  

--- a/docs/relational-databases/json/json-data-sql-server.md
+++ b/docs/relational-databases/json/json-data-sql-server.md
@@ -143,16 +143,16 @@ For more information, see [Convert JSON Data to Rows and Columns with OPENJSON (
 
 JSON documents may have sub-elements and hierarchical data that cannot be directly mapped into the standard relational columns. In this case, you can flatten JSON hierarchy by joining parent entity with sub-arrays.
 
-In the following example, the second object in the array has sub-array representing person skills. Every sub-object can be parsed using additional `OPENJSON` function call: 
+In the following example, the second object in the array has sub-array representing person skills. Every sub-object can be parsed using additional `OPENJSON` function call:
 
 ```sql  
-DECLARE @json NVARCHAR(MAX)
+DECLARE @json NVARCHAR(MAX);
 SET @json =  
 N'[  
        { "id" : 2,"info": { "name": "John", "surname": "Smith" }, "age": 25 },  
        { "id" : 5,"info": { "name": "Jane", "surname": "Smith", "skills": ["SQL", "C#", "Azure"] }, "dob": "2005-11-04T12:00:00" }  
- ]'  
-   
+ ]';
+
 SELECT *  
 FROM OPENJSON(@json)  
   WITH (id int 'strict $.id',  
@@ -160,7 +160,7 @@ FROM OPENJSON(@json)
         age int, dateOfBirth datetime2 '$.dob',
 	skills nvarchar(max) '$.info.skills' as json) 
 	outer apply openjson( skills ) 
-                     with ( skill nvarchar(8) '$' )
+                     with ( skill nvarchar(8) '$' );
 ```  
 **skills** array is returned in the first `OPENJSON` as original JSON text fragment and passed to another `OPENJSON` function using `APPLY` operator. The second `OPENJSON` function will parse JSON array and return string values as single column rowset that will be joined with the result of the first `OPENJSON`. 
 The result of this query is shown in the following table:
@@ -188,7 +188,7 @@ The following example uses PATH mode with the **FOR JSON** clause:
 ```sql  
 SELECT id, firstName AS "info.name", lastName AS "info.surname", age, dateOfBirth as dob  
 FROM People  
-FOR JSON PATH  
+FOR JSON PATH;
 ```  
   
 The **FOR JSON** clause formats SQL results as JSON text that can be provided to any app that understands JSON. The PATH option uses dot-separated aliases in the SELECT clause to nest objects in the query results.  
@@ -269,7 +269,7 @@ You can format information that's stored in files as standard JSON or line-delim
 If you must load JSON data from an external service into SQL Server, you can use **OPENJSON** to import the data into SQL Server instead of parsing the data in the application layer.  
   
 ```sql  
-DECLARE @jsonVariable NVARCHAR(MAX)
+DECLARE @jsonVariable NVARCHAR(MAX);
 
 SET @jsonVariable = N'[  
         {  
@@ -294,7 +294,7 @@ SET @jsonVariable = N'[
             "Quantity":3  
           }  
        }  
-  ]'
+  ]';
 
 --INSERT INTO <sampleTable>  
 SELECT SalesOrderJsonData.*  
@@ -326,7 +326,7 @@ FROM   SalesOrderRecord AS Tab
            )  
   AS SalesOrderJsonData  
 WHERE JSON_VALUE(Tab.json, '$.Status') = N'Closed'  
-ORDER BY JSON_VALUE(Tab.json, '$.Group'), Tab.DateModified  
+ORDER BY JSON_VALUE(Tab.json, '$.Group'), Tab.DateModified;
 ```  
   
 You can use both standard table columns and values from JSON text in the same query. You can add indexes on the `JSON_VALUE(Tab.json, '$.Status')` expression to improve the performance of the query. For more information, see [Index JSON data](../../relational-databases/json/index-json-data.md).
@@ -348,7 +348,7 @@ SELECT 'https://services.odata.org/V4/Northwind/Northwind.svc/$metadata#Products
  ProductID, Name as ProductName   
 FROM Production.Product  
 WHERE ProductID = 1  
-FOR JSON AUTO  
+FOR JSON AUTO;
 ```  
   
 The output of this query is JSON text that's fully compliant with the OData spec. Formatting and escaping are handled by SQL Server. SQL Server can also format query results in any format, such as OData JSON or GeoJSON.  

--- a/docs/relational-databases/json/json-data-sql-server.md
+++ b/docs/relational-databases/json/json-data-sql-server.md
@@ -37,9 +37,9 @@ Here's an example of JSON text:
     "surname": "Doe"
 }]
 ```
- 
-By using SQL Server built-in functions and operators, you can do the following things with JSON text: 
- 
+
+SQL Server built-in functions and operators enables you to do the following things with JSON data: 
+
 - Parse JSON text and read or modify values.  
 - Transform arrays of JSON objects into table format.  
 - Run any Transact-SQL query on the converted JSON objects.  

--- a/docs/relational-databases/json/json-data-sql-server.md
+++ b/docs/relational-databases/json/json-data-sql-server.md
@@ -17,6 +17,7 @@ monikerRange: "=azuresqldb-current||= azure-sqldw-latest||>=sql-server-2016||=sq
 ---
 
 # JSON data in SQL Server
+
 [!INCLUDE[appliesto-ss2016-asdb-asdw-xxx-md.md](../../includes/tsql-appliesto-ss2016-asdb-asdw-xxx-md.md)]
 
 JSON is a popular textual data format that's used for exchanging data in modern web and mobile applications. JSON is also used for storing unstructured data in log files or NoSQL databases such as Microsoft Azure Cosmos DB. Many REST web services return results that are formatted as JSON text or accept data that's formatted as JSON. For example, most Azure services, such as Azure Search, Azure Storage, and Azure Cosmos DB, have REST endpoints that return or consume JSON. JSON is also the main format for exchanging data between webpages and web servers by using AJAX calls. 
@@ -51,12 +52,14 @@ SQL Server built-in functions and operators enables you to do the following thin
 ![Overview of built-in JSON support](../../relational-databases/json/media/jsonslides1overview.png "Overview of built-in JSON support")  
   
 ## Key JSON capabilities of SQL Server and SQL Database
+
 The next sections discuss the key capabilities that SQL Server provides with its built-in JSON support. You can see how to use JSON functions and operators in the following video:
 
 *SQL Server 2016 and JSON Support*
 > [!VIDEO https://channel9.msdn.com/Shows/Data-Exposed/SQL-Server-2016-and-JSON-Support/player]
 
 ### Extract values from JSON text and use them in queries
+
 If you have JSON text that's stored in database tables, you can read or modify values in the JSON text by using the following built-in functions:  
 
 - [ISJSON (Transact-SQL)](../../t-sql/functions/isjson-transact-sql.md) tests whether a string contains valid JSON.
@@ -86,6 +89,7 @@ Applications and tools see no difference between the values taken from scalar ta
 For more information, see [Validate, query, and change JSON data with built-in functions (SQL Server)](../../relational-databases/json/validate-query-and-change-json-data-with-built-in-functions-sql-server.md), [JSON_VALUE (Transact-SQL)](../../t-sql/functions/json-value-transact-sql.md), and [JSON_QUERY (Transact-SQL)](../../t-sql/functions/json-query-transact-sql.md).  
   
 ### Change JSON values
+
 If you must modify parts of JSON text, you can use the [JSON_MODIFY (Transact-SQL)](../../t-sql/functions/json-modify-transact-sql.md) function to update the value of a property in a JSON string and return the updated JSON string. The following example updates the value of a property in a variable that contains JSON:  
   
 ```sql
@@ -102,6 +106,7 @@ SELECT modifiedJson = @json;
 |{"info":{"address":[{"town":"Belgrade"},{"town":"London"},{"town":"Madrid"}]}|  
   
 ### Convert JSON collections to a rowset
+
 You don't need a custom query language to query JSON in SQL Server. To query JSON data, you can use standard T-SQL. If you must create a query or report on JSON data, you can easily convert JSON data to rows and columns by calling the **OPENJSON** rowset function. For more information, see [Convert JSON Data to Rows and Columns with OPENJSON (SQL Server)](../../relational-databases/json/convert-json-data-to-rows-and-columns-with-openjson-sql-server.md).  
   
 The following example calls **OPENJSON** and transforms the array of objects that is stored in the `@json` variable to a rowset that can be queried with a standard SQL **SELECT** statement:  
@@ -132,6 +137,7 @@ FROM OPENJSON(@json)
 |5|Jane|Smith||2005-11-04T12:00:00|  
   
 **OPENJSON** transforms the array of JSON objects into a table in which each object is represented as one row, and key/value pairs are returned as cells. The output observes the following rules:
+
 - **OPENJSON** converts JSON values to the types that are specified in the **WITH** clause.
 - **OPENJSON** can handle both flat key/value pairs and nested, hierarchically organized objects.
 - You don't have to return all the fields that are contained in the JSON text.
@@ -198,7 +204,7 @@ FOR JSON PATH;
 The **FOR JSON** clause formats SQL results as JSON text that can be provided to any app that understands JSON. The PATH option uses dot-separated aliases in the SELECT clause to nest objects in the query results.  
   
 **Results**
-  
+
 ```json  
 [
   {
@@ -247,8 +253,9 @@ When you need real-time analysis of IoT data, load the incoming data directly in
 Transform relational data from your database easily into the JSON format used by the REST APIs that support your web site.
 
 ## Combine relational and JSON data
+
 SQL Server provides a hybrid model for storing and processing both relational and JSON data by using standard Transact-SQL language. You can organize collections of your JSON documents in tables, establish relationships between them, combine strongly typed scalar columns stored in tables with flexible key/value pairs stored in JSON columns, and query both scalar and JSON values in one or more tables by using full Transact-SQL.
- 
+
 JSON text is stored in varchar or nvarchar columns and is indexed as plain text. Any SQL Server feature or component that supports text supports JSON, so there are almost no constraints on interaction between JSON and other SQL Server features. You can store JSON in In-memory or Temporal tables, apply Row-Level Security predicates on JSON text, and so on.
 
 If you have pure JSON workloads where you want to use a query language that's customized for the processing of JSON documents, consider Microsoft Azure [Cosmos DB](https://azure.microsoft.com/services/cosmos-db/).  
@@ -260,9 +267,10 @@ Here are some use cases that show how you can use the built-in JSON support in [
 JSON is a textual format so the JSON documents can be stored in `NVARCHAR` columns in a SQL Database. Since `NVARCHAR` type is supported in all SQL Server sub-systems you can put JSON documents in tables with **CLUSTERED COLUMNSTORE** indexes, **memory optimized** tables, or external files that can be read using OPENROWSET or PolyBase.
 
 To learn more about your options for storing, indexing, and optimizing JSON data in SQL Server, see the following articles:
--   [Store JSON documents in SQL Server or SQL Database](store-json-documents-in-sql-tables.md)
--   [Index JSON data](index-json-data.md)
--   [Optimize JSON processing with in-memory OLTP](optimize-json-processing-with-in-memory-oltp.md)
+
+- [Store JSON documents in SQL Server or SQL Database](store-json-documents-in-sql-tables.md)
+- [Index JSON data](index-json-data.md)
+- [Optimize JSON processing with in-memory OLTP](optimize-json-processing-with-in-memory-oltp.md)
 
 ### Load JSON files into SQL Server  
 
@@ -272,7 +280,8 @@ You can format information that's stored in files as standard JSON or line-delim
   
 -   If your line-delimited JSON files are stored in Azure Blob storage or the Hadoop file system, you can use PolyBase to load JSON text, parse it in Transact-SQL code, and load it into tables.  
 
-### Import JSON data into SQL Server tables  
+### Import JSON data into SQL Server tables
+
 If you must load JSON data from an external service into SQL Server, you can use **OPENJSON** to import the data into SQL Server instead of parsing the data in the application layer.  
   
 ```sql  
@@ -316,7 +325,8 @@ FROM OPENJSON (@jsonVariable, N'$')
 
 You can provide the content of the JSON variable by an external REST service, send it as a parameter from a client-side JavaScript framework, or load it from external files. You can easily insert, update, or merge results from JSON text into a SQL Server table.
 
-## Analyze JSON data with SQL queries  
+## Analyze JSON data with SQL queries
+
 If you must filter or aggregate JSON data for reporting purposes, you can use **OPENJSON** to transform JSON to relational format. You can then use standard [!INCLUDE[tsql](../../includes/tsql-md.md)] and built-in functions to prepare the reports.  
   
 ```sql
@@ -334,15 +344,16 @@ ORDER BY JSON_VALUE(Tab.json, '$.Group'), Tab.DateModified;
 ```  
   
 You can use both standard table columns and values from JSON text in the same query. You can add indexes on the `JSON_VALUE(Tab.json, '$.Status')` expression to improve the performance of the query. For more information, see [Index JSON data](../../relational-databases/json/index-json-data.md).
- 
-## Return data from a SQL Server table formatted as JSON  
+
+## Return data from a SQL Server table formatted as JSON
+
 If you have a web service that takes data from the database layer and returns it in JSON format, or if you have JavaScript frameworks or libraries that accept data formatted as JSON, you can format JSON output directly in a SQL query. Instead of writing code or including a library to convert tabular query results and then serialize objects to JSON format, you can use **FOR JSON** to delegate the JSON formatting to SQL Server.  
   
 For example, you might want to generate JSON output that's compliant with the OData specification. The web service expects a request and response in the following format: 
   
 - Request: `/Northwind/Northwind.svc/Products(1)?$select=ProductID,ProductName`  
-  
-- Response: `{"@odata.context":"https://services.odata.org/V4/Northwind/Northwind.svc/$metadata#Products(ProductID,ProductName)/$entity","ProductID":1,"ProductName":"Chai"}`  
+
+- Response: `{"@odata.context": "https://services.odata.org/V4/Northwind/Northwind.svc/$metadata#Products(ProductID,ProductName)/$entity", "ProductID": 1, "ProductName": "Chai"}`  
   
 This OData URL represents a request for the ProductID and ProductName columns for the product with `ID` 1. You can use **FOR JSON** to format the output as expected in SQL Server.  
   
@@ -358,27 +369,28 @@ FOR JSON AUTO;
 The output of this query is JSON text that's fully compliant with the OData spec. Formatting and escaping are handled by SQL Server. SQL Server can also format query results in any format, such as OData JSON or GeoJSON.  
   
 ## Test drive built-in JSON support with the AdventureWorks sample database
-To get the AdventureWorks sample database, download at least the database file and the samples and scripts file from [Microsoft Download Center](https://www.microsoft.com/download/details.aspx?id=49502). 
- 
+
+To get the AdventureWorks sample database, download at least the database file and the samples and scripts file from [Microsoft Download Center](https://www.microsoft.com/download/details.aspx?id=49502).
+
 After you restore the sample database to an instance of SQL Server 2016, extract the samples file, and then open the *JSON Sample Queries procedures views and indexes.sql* file from the JSON folder. Run the scripts in this file to reformat some existing data as JSON data, test sample queries and reports over the JSON data, index the JSON data, and import and export JSON.  
   
 Here's what you can do with the scripts that are included in the file:  
   
-* Denormalize the existing schema to create columns of JSON data.
+- Denormalize the existing schema to create columns of JSON data.
+
+  - Store information from SalesReasons, SalesOrderDetails, SalesPerson, Customer, and other tables that contain information related to sales order into JSON columns in the SalesOrder_json table.  
   
-    * Store information from SalesReasons, SalesOrderDetails, SalesPerson, Customer, and other tables that contain information related to sales order into JSON columns in the SalesOrder_json table.  
+  - Store information from EmailAddresses/PersonPhone tables in the Person_json table as arrays of JSON objects.  
   
-    * Store information from EmailAddresses/PersonPhone tables in the Person_json table as arrays of JSON objects.  
+- Create procedures and views that query JSON data.  
   
-* Create procedures and views that query JSON data.  
+- Index JSON data. Create indexes on JSON properties and full-text indexes.  
   
-* Index JSON data. Create indexes on JSON properties and full-text indexes.  
+- Import and export JSON. Create and run procedures that export the content of the Person and the SalesOrder tables as JSON results, and import and update the Person and the SalesOrder tables by using JSON input.  
   
-* Import and export JSON. Create and run procedures that export the content of the Person and the SalesOrder tables as JSON results, and import and update the Person and the SalesOrder tables by using JSON input.  
+- Run query examples. Run some queries that call the stored procedures and views that you created in steps 2 and 4.  
   
-* Run query examples. Run some queries that call the stored procedures and views that you created in steps 2 and 4.  
-  
-* Clean up scripts. Don't run this part if you want to keep the stored procedures and views that you created in steps 2 and 4.  
+- Clean up scripts. Don't run this part if you want to keep the stored procedures and views that you created in steps 2 and 4.  
   
 ## Learn more about JSON in SQL Server and Azure SQL Database  
   
@@ -392,12 +404,12 @@ For a visual introduction to the built-in JSON support in SQL Server and Azure S
 *Building REST API with SQL Server using JSON functions*
 > [!VIDEO https://www.youtube.com/embed/0m6GXF3-5WI]
 
-### Reference articles  
-  
--   [FOR Clause (Transact-SQL)](../../t-sql/queries/select-for-clause-transact-sql.md) (FOR JSON)  
--   [OPENJSON (Transact-SQL)](../../t-sql/functions/openjson-transact-sql.md)  
--   [JSON Functions (Transact-SQL)](../../t-sql/functions/json-functions-transact-sql.md)  
-    -   [ISJSON (Transact-SQL)](../../t-sql/functions/isjson-transact-sql.md)  
-    -   [JSON_VALUE (Transact-SQL)](../../t-sql/functions/json-value-transact-sql.md)  
-    -   [JSON_QUERY (Transact-SQL)](../../t-sql/functions/json-query-transact-sql.md)  
-    -   [JSON_MODIFY (Transact-SQL)](../../t-sql/functions/json-modify-transact-sql.md)  
+### Reference articles
+
+- [FOR Clause (Transact-SQL)](../../t-sql/queries/select-for-clause-transact-sql.md) (FOR JSON)  
+- [OPENJSON (Transact-SQL)](../../t-sql/functions/openjson-transact-sql.md)  
+- [JSON Functions (Transact-SQL)](../../t-sql/functions/json-functions-transact-sql.md)  
+  - [ISJSON (Transact-SQL)](../../t-sql/functions/isjson-transact-sql.md)  
+  - [JSON_VALUE (Transact-SQL)](../../t-sql/functions/json-value-transact-sql.md)  
+  - [JSON_QUERY (Transact-SQL)](../../t-sql/functions/json-query-transact-sql.md)  
+  - [JSON_MODIFY (Transact-SQL)](../../t-sql/functions/json-modify-transact-sql.md)  

--- a/docs/relational-databases/json/json-data-sql-server.md
+++ b/docs/relational-databases/json/json-data-sql-server.md
@@ -30,11 +30,11 @@ Here's an example of JSON text:
 
 ```json
 [{
-	"name": "John",
-	"skills": ["SQL", "C#", "Azure"]
+    "name": "John",
+    "skills": ["SQL", "C#", "Azure"]
 }, {
-	"name": "Jane",
-	"surname": "Doe"
+    "name": "Jane",
+    "surname": "Doe"
 }]
 ```
  


### PR DESCRIPTION
Page Edited - [JSON data in SQL Server](https://docs.microsoft.com/en-us/sql/relational-databases/json/json-data-sql-server?view=sql-server-2017)

### Changes
 - Capitalize SQL types and keywords
 - Add semi-colons to the statements that are missing them
 - Make indentation and spacing consistent across the page for SQL & JSON examples (2 spaces for indentation)
 - Proper spacing in comments and in-between operators for readability.  
 - Markdown lint fixes: trim trailing whitespaces, add new lines and change bullets. 
