### PR TITLE
Fix typo

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-posttracertoken-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-posttracertoken-transact-sql.md
@@ -38,7 +38,7 @@ sp_posttracertoken [ @publication = ] 'publication'
 `[ @publication = ] 'publication'`
  Is the name of the publication for which latency is being measured. *publication* is **sysname**, with no default.  
   
-`[ @tracer_token_id = ] _tracer_token_idOUTPUT`
+`[ @tracer_token_id = ] _tracer_token_id OUTPUT`
  Is the ID of the tracer token inserted. *tracer_token_id* is **int** with a default of NULL, and it is an OUTPUT parameter. This value can be used to execute [sp_helptracertokenhistory &#40;Transact-SQL&#41;](../../relational-databases/system-stored-procedures/sp-helptracertokenhistory-transact-sql.md) or [sp_deletetracertokenhistory &#40;Transact-SQL&#41;](../../relational-databases/system-stored-procedures/sp-deletetracertokenhistory-transact-sql.md) without first executing [sp_helptracertokens &#40;Transact-SQL&#41;](../../relational-databases/system-stored-procedures/sp-helptracertokens-transact-sql.md).  
   
 `[ @publisher = ] 'publisher'`


### PR DESCRIPTION
Add space between the parameter & OUTPUT keyword