### PR TITLE
Remove SQL DB moniker from XEvent sample

### DIFF
--- a/docs/relational-databases/extended-events/find-the-objects-that-have-the-most-locks-taken-on-them.md
+++ b/docs/relational-databases/extended-events/find-the-objects-that-have-the-most-locks-taken-on-them.md
@@ -19,7 +19,7 @@ monikerRange: "=azuresqldb-current||>=sql-server-2016||=sqlallproducts-allversio
 ---
 # Find the Objects That Have the Most Locks Taken on Them
 
-[!INCLUDE[appliesto-ss-asdb-xxxx-xxx-md](../../includes/appliesto-ss-asdb-xxxx-xxx-md.md)]
+[!INCLUDE[appliesto-ss-xxxx-xxxx-xxx-md](../../includes/appliesto-ss-xxxx-xxxx-xxx-md.md)]
 
   Database administrators often need to identify the source of locks that are hindering database performance.  
   


### PR DESCRIPTION
This sample does not work in Azure SQL Database because Azure SQL Database does not support these ones used in this sample:
- sys.server_event_sessions
- CREATE EVENT SESSION ON SERVER
- ALTER EVENT SESSION ON SERVER
- sqlserver.lock_acquired and sqlserver.lock_released event
- sys.dm_xe_session_targets