### PR TITLE
Add underscore to DATA_SOURCE in syntax section.

### DIFF
--- a/docs/t-sql/statements/bulk-insert-transact-sql.md
+++ b/docs/t-sql/statements/bulk-insert-transact-sql.md
@@ -48,7 +48,7 @@ BULK INSERT
    [ [ , ] CODEPAGE = { 'ACP' | 'OEM' | 'RAW' | 'code_page' } ]
    [ [ , ] DATAFILETYPE =
       { 'char' | 'native'| 'widechar' | 'widenative' } ]
-   [ [ , ] DATASOURCE = 'data_source_name' ]
+   [ [ , ] DATA_SOURCE = 'data_source_name' ]
    [ [ , ] ERRORFILE = 'file_name' ]
    [ [ , ] ERRORFILE_DATA_SOURCE = 'data_source_name' ]
    [ [ , ] FIRSTROW = first_row ]


### PR DESCRIPTION
Was 'DATASOURCE'. It's correct in the code examples, but not in the syntax section.