### PR TITLE
Typo "**@failover_mode=**"→"**\@failover_mode=**"

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-setreplfailovermode-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-setreplfailovermode-transact-sql.md
@@ -42,9 +42,9 @@ sp_setreplfailovermode [ @publisher= ] 'publisher'
  Is the name of the publication database. *publisher_db* is **sysname**, with no default.  
   
 `[ @publication = ] 'publication'`
- Is the name of the publication. *publication*is **sysname**, with no default.  
+ Is the name of the publication. *publication* is **sysname**, with no default.  
   
- [**\@failover_mode=**] **'***failover_mode***'**  
+`[ @failover_mode = ] 'failover_mode'`  
  Is the failover mode for the subscription. *failover_mode* is **nvarchar(10)** and can be one of these values.  
   
 |Value|Description|  

--- a/docs/relational-databases/system-stored-procedures/sp-setreplfailovermode-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-setreplfailovermode-transact-sql.md
@@ -44,7 +44,7 @@ sp_setreplfailovermode [ @publisher= ] 'publisher'
 `[ @publication = ] 'publication'`
  Is the name of the publication. *publication* is **sysname**, with no default.  
   
-`[ @failover_mode = ] 'failover_mode'`  
+`[ @failover_mode = ] 'failover_mode'`
  Is the failover mode for the subscription. *failover_mode* is **nvarchar(10)** and can be one of these values.  
   
 |Value|Description|  

--- a/docs/relational-databases/system-stored-procedures/sp-setreplfailovermode-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-setreplfailovermode-transact-sql.md
@@ -44,7 +44,7 @@ sp_setreplfailovermode [ @publisher= ] 'publisher'
 `[ @publication = ] 'publication'`
  Is the name of the publication. *publication*is **sysname**, with no default.  
   
- [**@failover_mode=**] **'***failover_mode***'**  
+ [**\@failover_mode=**] **'***failover_mode***'**  
  Is the failover mode for the subscription. *failover_mode* is **nvarchar(10)** and can be one of these values.  
   
 |Value|Description|  


### PR DESCRIPTION
bold with escape characters

https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-setreplfailovermode-transact-sql?view=sql-server-2017