### PR TITLE
Typo "**@ID(Integer)**"→"**\@ID(Integer)**"

### DIFF
--- a/docs/reporting-services/report-data/element-path-syntax-for-xml-report-data-ssrs.md
+++ b/docs/reporting-services/report-data/element-path-syntax-for-xml-report-data-ssrs.md
@@ -74,7 +74,7 @@ XMLLocalName :: =
 |**Encoding**|Indicates that the **Value** for this element is encoded XML and needs to be decoded and included as a subelement of this element.|  
 |**FieldList**|Defines the set of elements and attributes to use to retrieve data.<br /><br /> If not specified, all attributes and subelements are used as fields. If the empty field list is specified (**{}**), no fields from this node are used.<br /><br /> A **FieldList** may not contain both a **Value** and an **Element** or **ElementNode**.|  
 |**Field**|Specifies the data that is retrieved as a dataset field.|  
-|**Attribute**|A name-value pair within the **ElementNode**. For example, in the element node \<Customer ID="1">, **ID** is an attribute and **@ID(Integer)** returns "1" as an integer type in the corresponding data field **ID**.|  
+|**Attribute**|A name-value pair within the **ElementNode**. For example, in the element node \<Customer ID="1">, **ID** is an attribute and **\@ID(Integer)** returns "1" as an integer type in the corresponding data field **ID**.|  
 |**Value**|The value of the element. **Value** can only be used on the last **ElementNode** in the element path. For example, because \<Return> is a leaf node, if you include it at the end of an element path, the value of **Return {@}** is **Chair**.|  
 |**Element**|The value of the named subelement. For example, Customers {}/Customer {}/LastName retrieves values for only the LastName element.|  
 |**Type**|The optional data type to use for the field created from this element.|  


### PR DESCRIPTION
bold with escape characters

https://docs.microsoft.com/en-us/sql/reporting-services/report-data/element-path-syntax-for-xml-report-data-ssrs?view=sql-server-2017