### PR TITLE
Typo "*@schema_name*"→"*\@schema_name*"

### DIFF
--- a/docs/relational-databases/system-stored-procedures/temporal-table-sp-xtp-flush-temporal-history.md
+++ b/docs/relational-databases/system-stored-procedures/temporal-table-sp-xtp-flush-temporal-history.md
@@ -35,10 +35,10 @@ sys.sp_xtp_flush_temporal_history @schema_name, @object_name
 ```  
   
 ## Arguments  
- *@schema_name*  
+ *\@schema_name*  
  The schema name for the current or temporal table  
   
- *@object_name*  
+ *\@object_name*  
  The name of the current or temporal table  
   
 ## Return Code Values  


### PR DESCRIPTION
Italic with escape characters

https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/temporal-table-sp-xtp-flush-temporal-history?view=sql-server-2017