### PR TITLE
Typo "*@mode*"→"*\@mode*"

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sys-sp-rda-set-query-mode-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sys-sp-rda-set-query-mode-transact-sql.md
@@ -33,7 +33,7 @@ sp_rda_set_query_mode [ @mode = ] @mode
 ```  
   
 ## Arguments  
- [ @mode = ] *@mode*  
+ [ @mode = ] *\@mode*  
  Is one of the following values.  
   
 -   **DISABLED** All queries against Stretch-enabled tables fail.  
@@ -42,7 +42,7 @@ sp_rda_set_query_mode [ @mode = ] @mode
   
 -   **LOCAL_AND_REMOTE** Queries against Stretch-enabled tables return both local and remote data. This is the default behavior.  
   
- [ @force = ]  *@force*  
+ [ @force = ]  *\@force*  
  Is an optional bit value that you can set to 1 if you want to change query mode without validation.  
   
 ## Return Code Values  


### PR DESCRIPTION
Italic with escape characters

https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sys-sp-rda-set-query-mode-transact-sql?view=sql-server-2017