### PR TITLE
Typo " *@conversation_group_id*"→" *\@conversation_group_id*"

### DIFF
--- a/docs/t-sql/statements/get-conversation-group-transact-sql.md
+++ b/docs/t-sql/statements/get-conversation-group-transact-sql.md
@@ -50,7 +50,7 @@ ms.author: carlrab
  WAITFOR  
  Specifies that the GET CONVERSATION GROUP statement waits for a message to arrive on the queue if no messages are currently present.  
   
- *@conversation_group_id*  
+ *\@conversation_group_id*  
  Is a variable used to store the conversation group ID returned by the GET CONVERSATION GROUP statement. The variable must be of type **uniqueidentifier**. If there are no conversation groups available, the variable is set to NULL.  
   
  FROM  
@@ -66,7 +66,7 @@ ms.author: carlrab
  Is the name of the queue to get the conversation group from.  
   
  TIMEOUT *timeout*  
- Specifies the length of time, in milliseconds, that Service Broker waits for a message to arrive on the queue. This clause may only be used with the WAITFOR clause. If a statement that uses WAITFOR does not include this clause or the *timeout* is -1, the wait time is unlimited. If the timeout expires, GET CONVERSATION GROUP sets the *@conversation_group_id* variable to NULL.  
+ Specifies the length of time, in milliseconds, that Service Broker waits for a message to arrive on the queue. This clause may only be used with the WAITFOR clause. If a statement that uses WAITFOR does not include this clause or the *timeout* is -1, the wait time is unlimited. If the timeout expires, GET CONVERSATION GROUP sets the *\@conversation_group_id* variable to NULL.  
   
 ## Remarks  
   


### PR DESCRIPTION
Italic with escape characters

https://docs.microsoft.com/en-us/sql/t-sql/statements/get-conversation-group-transact-sql?view=sql-server-2017