### PR TITLE
Typo "*@user_defined_event_id*"→"*\@user_defined_event_id*"

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-audit-write-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-audit-write-transact-sql.md
@@ -36,7 +36,7 @@ sp_audit_write [ @user_defined_event_id = ] user_defined_event_id
   
 ## Arguments  
  `[ @user_defined_event_id = ] user_defined_event_id`  
- A parameter defined by the user and recorded in the **user_defined_event_id** column of the audit log. *@user_defined_event_id* is type **smallint**.  
+ A parameter defined by the user and recorded in the **user_defined_event_id** column of the audit log. *\@user_defined_event_id* is type **smallint**.  
   
  `[ @succeeded = ] succeeded`  
  A parameter passed by user to indicate whether the event was successful or not. This appears in the succeeded column of the audit log. `@succeeded` is **bit**.  


### PR DESCRIPTION
Italic with escape characters

https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-audit-write-transact-sql?view=sql-server-2017