### PR TITLE
Typo "*@dbcc_statement_var*"→"*\@dbcc_statement_var*"

### DIFF
--- a/docs/t-sql/database-console-commands/dbcc-help-transact-sql.md
+++ b/docs/t-sql/database-console-commands/dbcc-help-transact-sql.md
@@ -34,7 +34,7 @@ DBCC HELP ( 'dbcc_statement' | @dbcc_statement_var | '?' )
 ```  
   
 ## Arguments  
- *dbcc_statement* | *@dbcc_statement_var*  
+ *dbcc_statement* | *\@dbcc_statement_var*  
  Is the name of the DBCC command for which to receive syntax information. Provide only the part of the DBCC command that follows DBCC, for example, CHECKDB instead of DBCC CHECKDB.  
   
  ?  


### PR DESCRIPTION
Italic with escape characters

https://docs.microsoft.com/en-us/sql/t-sql/database-console-commands/dbcc-help-transact-sql?view=sql-server-2017