### PR TITLE
Typo "*@durationinhours*"→"*\@durationinhours*"

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sys-sp-rda-get-rpo-duration-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sys-sp-rda-get-rpo-duration-transact-sql.md
@@ -35,7 +35,7 @@ sp_rda_get_rpo_duration @durationinhours output
 ```    
     
 ## Output parameter    
- *@durationinhours*    
+ *\@durationinhours*    
   Is the number of hours (a non-null integer value) of migrated data that SQL Server retains for the current Stretch-enabled database.    
     
 ## Permissions    


### PR DESCRIPTION
Italic with escape characters

https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sys-sp-rda-get-rpo-duration-transact-sql?view=sql-server-2017