### PR TITLE
Typo "*@table_name*"→"*\@table_name*"

### DIFF
--- a/docs/relational-databases/system-stored-procedures/temporal-table-sys-sp-cleanup-temporal-history.md
+++ b/docs/relational-databases/system-stored-procedures/temporal-table-sys-sp-cleanup-temporal-history.md
@@ -24,7 +24,7 @@ sp_cleanup_temporal_history [@schema_name = ] schema_name, [@table_name = ] tabl
   
 ## Arguments  
 
-*@table_name*
+*\@table_name*
 
 The name of the temporal table for which retention cleanup is invoked.
 


### PR DESCRIPTION
Italic with escape characters

https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/temporal-table-sys-sp-cleanup-temporal-history?view=azuresqldb-current