### PR TITLE
Typo "**@job_name**"→"**\@job_name**"

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-purge-jobhistory-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-purge-jobhistory-transact-sql.md
@@ -44,7 +44,7 @@ sp_purge_jobhistory
 >  Members of the **sysadmin** fixed server role or members of the **SQLAgentOperatorRole** fixed database role can execute **sp_purge_jobhistory** without specifying a *job_name* or *job_id*. When **sysadmin** users do not specify these arguments, the job history for all local and multiserver jobs is deleted within the time specified by *oldest_date*. When **SQLAgentOperatorRole** users do not specify these arguments, the job history for all local jobs is deleted within the time specified by *oldest_date*.  
   
 `[ @job_id = ] job_id`
- The job identification number of the job for the records to be deleted. *job_id*is **uniqueidentifier**, with a default of NULL. Either *job_id* or *job_name* must be specified, but both cannot be specified. See the note in the description of **\@job_name** for information about how **sysadmin** or **SQLAgentOperatorRole** users can use this argument.  
+ The job identification number of the job for the records to be deleted. *job_id* is **uniqueidentifier**, with a default of NULL. Either *job_id* or *job_name* must be specified, but both cannot be specified. See the note in the description of **\@job_name** for information about how **sysadmin** or **SQLAgentOperatorRole** users can use this argument.  
   
 `[ @oldest_date = ] oldest_date`
  The oldest record to retain in the history. *oldest_date* is **datetime**, with a default of NULL. When *oldest_date* is specified, **sp_purge_jobhistory** only removes records that are older than the value specified.  

--- a/docs/relational-databases/system-stored-procedures/sp-purge-jobhistory-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-purge-jobhistory-transact-sql.md
@@ -44,7 +44,7 @@ sp_purge_jobhistory
 >  Members of the **sysadmin** fixed server role or members of the **SQLAgentOperatorRole** fixed database role can execute **sp_purge_jobhistory** without specifying a *job_name* or *job_id*. When **sysadmin** users do not specify these arguments, the job history for all local and multiserver jobs is deleted within the time specified by *oldest_date*. When **SQLAgentOperatorRole** users do not specify these arguments, the job history for all local jobs is deleted within the time specified by *oldest_date*.  
   
 `[ @job_id = ] job_id`
- The job identification number of the job for the records to be deleted. *job_id*is **uniqueidentifier**, with a default of NULL. Either *job_id* or *job_name* must be specified, but both cannot be specified. See the note in the description of **@job_name** for information about how **sysadmin** or **SQLAgentOperatorRole** users can use this argument.  
+ The job identification number of the job for the records to be deleted. *job_id*is **uniqueidentifier**, with a default of NULL. Either *job_id* or *job_name* must be specified, but both cannot be specified. See the note in the description of **\@job_name** for information about how **sysadmin** or **SQLAgentOperatorRole** users can use this argument.  
   
 `[ @oldest_date = ] oldest_date`
  The oldest record to retain in the history. *oldest_date* is **datetime**, with a default of NULL. When *oldest_date* is specified, **sp_purge_jobhistory** only removes records that are older than the value specified.  


### PR DESCRIPTION
bold with escape characters

https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-purge-jobhistory-transact-sql?view=sql-server-2017