### PR TITLE
Typo " **@stmt**"→" **\@stmt**"

### DIFF
--- a/docs/relational-databases/errors-events/mssqlserver-10507-database-engine-error.md
+++ b/docs/relational-databases/errors-events/mssqlserver-10507-database-engine-error.md
@@ -24,7 +24,7 @@ ms.author: mathoma
 |Event Source|MSSQLSERVER|  
 |Component|SQLEngine|  
 |Symbolic Name|PG_STMT_DOES_NOT_MATCH|  
-|Message Text|Cannot create plan guide '%.\*ls' because the statement specified by **@stmt** and **@module_or_batch**, or by **@plan_handle** and **@statement_start_offset**, does not match any statement in the specified module or batch. Modify the values to match a statement in the module or batch.|  
+|Message Text|Cannot create plan guide '%.\*ls' because the statement specified by **\@stmt** and **\@module_or_batch**, or by **\@plan_handle** and **\@statement_start_offset**, does not match any statement in the specified module or batch. Modify the values to match a statement in the module or batch.|  
   
 ## Explanation  
 A statement in the specified module or batch could not be matched to the specified statement or statement offset value.  


### PR DESCRIPTION
bold with escape characters

https://docs.microsoft.com/en-us/sql/relational-databases/errors-events/mssqlserver-10507-database-engine-error?view=sql-server-ver15