### PR TITLE
Typo " **@stmt**"→" **\@stmt**"

### DIFF
--- a/docs/relational-databases/errors-events/mssqlserver-10509-database-engine-error.md
+++ b/docs/relational-databases/errors-events/mssqlserver-10509-database-engine-error.md
@@ -24,10 +24,10 @@ ms.author: mathoma
 |Event Source|MSSQLSERVER|  
 |Component|SQLEngine|  
 |Symbolic Name|PG_INVALID_STMT|  
-|Message Text|Cannot create plan guide '%.\*ls' because the statement specified by **@stmt** or **@statement_start_offset** either contains a syntax error or is ineligible for use in a plan guide. Provide a single valid [!INCLUDE[tsql](../../includes/tsql-md.md)] statement or a valid starting position of the statement within the batch. To obtain a valid starting position, query the statement_start_offset column in the sys.dm_exec_query_stats dynamic management function.|  
+|Message Text|Cannot create plan guide '%.\*ls' because the statement specified by **\@stmt** or **\@statement_start_offset** either contains a syntax error or is ineligible for use in a plan guide. Provide a single valid [!INCLUDE[tsql](../../includes/tsql-md.md)] statement or a valid starting position of the statement within the batch. To obtain a valid starting position, query the statement_start_offset column in the sys.dm_exec_query_stats dynamic management function.|  
   
 ## Explanation  
-The statement specified by **@stmt** or **@statement_start_offset** either contains a syntax error or is ineligible for use in a plan guide.  
+The statement specified by **\@stmt** or **\@statement_start_offset** either contains a syntax error or is ineligible for use in a plan guide.  
   
 ## User Action  
 Provide a single valid [!INCLUDE[tsql](../../includes/tsql-md.md)] statement or a valid starting position of the statement within the batch. To obtain a valid starting position, query the statement_start_offset column in the sys.dm_exec_query_stats dynamic management function.  


### PR DESCRIPTION
bold with escape characters

https://docs.microsoft.com/en-us/sql/relational-databases/errors-events/mssqlserver-10509-database-engine-error?view=sql-server-ver15