### PR TITLE
Typo "**@params**"→"**\@params**"

### DIFF
--- a/docs/relational-databases/errors-events/mssqlserver-10534-database-engine-error.md
+++ b/docs/relational-databases/errors-events/mssqlserver-10534-database-engine-error.md
@@ -24,10 +24,10 @@ ms.author: mathoma
 |Event Source|MSSQLSERVER|  
 |Component|SQLEngine|  
 |Symbolic Name|PG_INVALID_PARAMS|  
-|Message Text|Cannot create plan guide '%.\*ls' because the value specified for **@params** is invalid. Specify the value in the form *parameter_name parameter_type*, or specify NULL.|  
+|Message Text|Cannot create plan guide '%.\*ls' because the value specified for **\@params** is invalid. Specify the value in the form *parameter_name parameter_type*, or specify NULL.|  
   
 ## Explanation  
-The value specified for **@params** is invalid.  
+The value specified for **\@params** is invalid.  
   
 ## User Action  
 Specify the value in the form *parameter_name parameter_type*, or specify NULL.  


### PR DESCRIPTION
bold with escape characters

https://docs.microsoft.com/en-us/sql/relational-databases/errors-events/mssqlserver-10534-database-engine-error?view=sql-server-ver15