### PR TITLE
Typo "**@parameter_value**"→"**\@parameter_value**"

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sysmail-help-configure-sp-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sysmail-help-configure-sp-transact-sql.md
@@ -34,13 +34,13 @@ sysmail_help_configure_sp  [ [ @parameter_name = ] 'parameter_name' ]
   
 ## Arguments  
  [**@parameter_name** = ] **'***parameter_name***'**  
- The name of the configuration setting to retrieve. When specified, the value of the configuration setting is returned in the **@parameter_value** OUTPUT parameter. When no **@parameter_name** is specified, this stored procedure returns a result set containing all of the Database Mail configuration settings in the instance.  
+ The name of the configuration setting to retrieve. When specified, the value of the configuration setting is returned in the **\@parameter_value** OUTPUT parameter. When no **\@parameter_name** is specified, this stored procedure returns a result set containing all of the Database Mail configuration settings in the instance.  
   
 ## Return Code Values  
  **0** (success) or **1** (failure)  
   
 ## Result Sets  
- When no **@parameter_name** is specified, returns a result set with the following columns.  
+ When no **\@parameter_name** is specified, returns a result set with the following columns.  
   
 ||||  
 |-|-|-|  
@@ -52,7 +52,7 @@ sysmail_help_configure_sp  [ [ @parameter_name = ] 'parameter_name' ]
 ## Remarks  
  The stored procedure **sysmail_help_configure_sp** lists the current Database Mail configuration settings for the instance.  
   
- When a **@parameter_name** is specified, but no output parameter is provided for **@parameter_value**, this stored procedure produces no output.  
+ When a **\@parameter_name** is specified, but no output parameter is provided for **\@parameter_value**, this stored procedure produces no output.  
   
  The stored procedure **sysmail_help_configure_sp** is in the **msdb** database and is owned by the **dbo** schema. The procedure must be invoked with a three-part name if the current database is not **msdb**.  
   


### PR DESCRIPTION
bold with escape characters

https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sysmail-help-configure-sp-transact-sql?view=sql-server-ver15