### PR TITLE
Typo "**@range_size**"→"**\@range_size**"

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-sequence-get-range-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-sequence-get-range-transact-sql.md
@@ -49,25 +49,25 @@ sp_sequence_get_range [ @sequence_name = ] N'<sequence>'
  The name of the sequence object. The schema is optional. *sequence_name* is **nvarchar(776)**.  
   
 `[ @range_size = ] range_size`
- The number of values to fetch from the sequence. **@range_size** is **bigint**.  
+ The number of values to fetch from the sequence. **\@range_size** is **bigint**.  
   
 `[ @range_first_value = ] range_first_value`
- Output parameter returns the first (minimum or maximum) value of the sequence object used to calculate the requested range. **@range_first_value** is **sql_variant** with the same base type as that of the sequence object used in the request.  
+ Output parameter returns the first (minimum or maximum) value of the sequence object used to calculate the requested range. **\@range_first_value** is **sql_variant** with the same base type as that of the sequence object used in the request.  
   
 `[ @range_last_value = ] range_last_value`
- Optional output parameter returns the last value of the requested range. **@range_last_value** is **sql_variant** with the same base type as that of the sequence object used in the request.  
+ Optional output parameter returns the last value of the requested range. **\@range_last_value** is **sql_variant** with the same base type as that of the sequence object used in the request.  
   
 `[ @range_cycle_count = ] range_cycle_count`
- Optional output parameter returns the number of times that the sequence object cycled in order to return the requested range. **@range_cycle_count** is **int**.  
+ Optional output parameter returns the number of times that the sequence object cycled in order to return the requested range. **\@range_cycle_count** is **int**.  
   
 `[ @sequence_increment = ] sequence_increment`
- Optional output parameter returns the increment of the sequence object used to calculate the requested range. **@sequence_increment** is **sql_variant** with the same base type as that of the sequence object used in the request.  
+ Optional output parameter returns the increment of the sequence object used to calculate the requested range. **\@sequence_increment** is **sql_variant** with the same base type as that of the sequence object used in the request.  
   
 `[ @sequence_min_value = ] sequence_min_value`
- Optional output parameter returns the minimum value of the sequence object. **@sequence_min_value** is **sql_variant** with the same base type as that of the sequence object used in the request.  
+ Optional output parameter returns the minimum value of the sequence object. **\@sequence_min_value** is **sql_variant** with the same base type as that of the sequence object used in the request.  
   
 `[ @sequence_max_value = ] sequence_max_value`
- Optional output parameter returns the maximum value of the sequence object. **@sequence_max_value** is **sql_variant** with the same base type as that of the sequence object used in the request.  
+ Optional output parameter returns the maximum value of the sequence object. **\@sequence_max_value** is **sql_variant** with the same base type as that of the sequence object used in the request.  
   
 ## Return Code Values  
  0 (success) or 1 (failure)  


### PR DESCRIPTION
bold with escape characters

https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-sequence-get-range-transact-sql?view=sql-server-ver15