### PR TITLE
Typo "**@runinscaleout**"→"**\@runinscaleout**"

### DIFF
--- a/docs/integration-services/scale-out/run-packages-in-integration-services-ssis-scale-out.md
+++ b/docs/integration-services/scale-out/run-packages-in-integration-services-ssis-scale-out.md
@@ -60,7 +60,7 @@ After you deploy packages to the Integration Services server, you can run them i
 
 1.  Create executions.
 
-    Call `[catalog].[create_execution]` for each package. Set the parameter **@runinscaleout** to `True`. If not all Scale Out Worker computers are allowed to run the package, set the parameter **@useanyworker** to `False`. For more info about this stored procedure and the **@useanyworker** parameter, see [catalog.create_execution](../system-stored-procedures/catalog-create-execution-ssisdb-database.md). 
+    Call `[catalog].[create_execution]` for each package. Set the parameter **\@runinscaleout** to `True`. If not all Scale Out Worker computers are allowed to run the package, set the parameter **\@useanyworker** to `False`. For more info about this stored procedure and the **\@useanyworker** parameter, see [catalog.create_execution](../system-stored-procedures/catalog-create-execution-ssisdb-database.md). 
 
 2. Set execution parameters.
 
@@ -72,7 +72,7 @@ After you deploy packages to the Integration Services server, you can run them i
 
 4. Start the executions.
 
-    Call `[catalog].[start_execution]`. Set the parameter **@retry_count** to set the number of times a package execution will retry if it fails.
+    Call `[catalog].[start_execution]`. Set the parameter **\@retry_count** to set the number of times a package execution will retry if it fails.
     
 ### Example
 The following example runs two packages, `package1.dtsx` and `package2.dtsx`, in Scale Out with one Scale Out Worker.  
@@ -113,7 +113,7 @@ To set the default execution mode for packages to **Scale Out**, do the followin
 
 2.  In the **Catalog Properties** dialog box, set **Server-wide Default execution mode** to **Scale Out**.
 
-After you set this default execution mode, you no longer have to specify the **@runinscaleout** parameter when you call the `[catalog].[create_execution]` stored procedure. Packages are run in Scale Out automatically. 
+After you set this default execution mode, you no longer have to specify the **\@runinscaleout** parameter when you call the `[catalog].[create_execution]` stored procedure. Packages are run in Scale Out automatically. 
 
 ![Exe mode](media/exe-mode.PNG)
 


### PR DESCRIPTION
bold with escape characters

https://docs.microsoft.com/en-us/sql/integration-services/scale-out/run-packages-in-integration-services-ssis-scale-out?view=sql-server-ver15