### PR TITLE
Typo "**@destination_folde**_r_"→"**\@destination_folder**"

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-copymergesnapshot-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-copymergesnapshot-transact-sql.md
@@ -19,7 +19,7 @@ ms.author: sstein
 # sp_copymergesnapshot (Transact-SQL)
 [!INCLUDE[appliesto-ss-asdbmi-xxxx-xxx-md](../../includes/appliesto-ss-asdbmi-xxxx-xxx-md.md)]
 
-  Copies the snapshot folder of the specified publication to the folder listed in the **@destination_folde**_r_. This stored procedure is executed at the Publisher on the publication database.  
+  Copies the snapshot folder of the specified publication to the folder listed in the **\@destination_folder**. This stored procedure is executed at the Publisher on the publication database.  
   
  ![Topic link icon](../../database-engine/configure-windows/media/topic-link.gif "Topic link icon") [Transact-SQL Syntax Conventions](../../t-sql/language-elements/transact-sql-syntax-conventions-transact-sql.md)  
   


### PR DESCRIPTION
bold with escape characters

https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-copymergesnapshot-transact-sql?view=sql-server-ver15