### PR TITLE
Typo "**@filename**"→"**\@filename**"

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-copysubscription-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-copysubscription-transact-sql.md
@@ -44,7 +44,7 @@ sp_copysubscription [ @filename = ] 'file_name'
  Is the name of the directory that contains the temp files. *temp_dir* is **nvarchar(260)**, with a default of NULL. If NULL, the [!INCLUDE[msCoName](../../includes/msconame-md.md)] [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] default data directory will be used. The directory should have enough space to hold a file the size of all the subscriber database files combined.  
   
 `[ @overwrite_existing_file = ] 'overwrite_existing_file'`
- Is an optional Boolean flag that specifies whether or not to overwrite an existing file of the same name specified in **@filename**. *overwrite_existing_file*is **bit**, with a default of **0**. If **1**, it overwrites the file specified by **@filename**, if it exists. If **0**, the stored procedure fails if the file exists, and the file is not overwritten.  
+ Is an optional Boolean flag that specifies whether or not to overwrite an existing file of the same name specified in **\@filename**. *overwrite_existing_file*is **bit**, with a default of **0**. If **1**, it overwrites the file specified by **\@filename**, if it exists. If **0**, the stored procedure fails if the file exists, and the file is not overwritten.  
   
 ## Return Code Values  
  **0** (success) or **1** (failure)  


### PR DESCRIPTION
bold with escape characters

https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-copysubscription-transact-sql?view=sql-server-ver15