### PR TITLE
Typo "**@qs**"→"**\@qs**"

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-help-spatial-geography-index-xml-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-help-spatial-geography-index-xml-transact-sql.md
@@ -51,7 +51,7 @@ sp_help_spatial_geography_index_xml [ @tabname =] 'tabname'
  Properties containing NULL values are not included in the return set.  
   
 ## Example  
- The following example uses `sp_help_spatial_geography_index_xml` to investigate the spatial index **SIndx_SpatialTable_geography_col2** defined on table **geography_col** for the given query sample in **@qs**. This example returns the core properties of the specified index in an XML fragment that displays the name and value of the properties selected.  
+ The following example uses `sp_help_spatial_geography_index_xml` to investigate the spatial index **SIndx_SpatialTable_geography_col2** defined on table **geography_col** for the given query sample in **\@qs**. This example returns the core properties of the specified index in an XML fragment that displays the name and value of the properties selected.  
   
  An [XQuery](../../xquery/xquery-basics.md) is then run on the result set, returning a specific property.  
   


### PR DESCRIPTION
bold with escape characters

https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-help-spatial-geography-index-xml-transact-sql?view=sql-server-ver15