### PR TITLE
Typo "**@language**"→"**\@language**"

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-execute-external-script-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-execute-external-script-transact-sql.md
@@ -68,10 +68,10 @@ sp_execute_external_script
 ::: moniker-end
 
 ## Arguments
- **@language** = N'*language*'  
+ **\@language** = N'*language*'  
  Indicates the script language. *language* is **sysname**.  Depending on your version of SQL Server, valid values are R (SQL Server 2016 and later), Python (SQL Server 2017 and later), and Java (SQL Server 2019 preview). 
   
- **@script** = N'*script*' 
+ **\@script** = N'*script*' 
  External language  script specified as a literal or variable input. *script* is **nvarchar(max)**.  
 
 `[ @input_data_1 =  N'input_data_1' ]`


### PR DESCRIPTION
bold with escape characters

https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-execute-external-script-transact-sql?view=sql-server-ver15