### PR TITLE
Typo "**@sync_type**"→"**@sync_type**"

### DIFF
--- a/docs/relational-databases/system-tables/syssubscriptions-transact-sql.md
+++ b/docs/relational-databases/system-tables/syssubscriptions-transact-sql.md
@@ -37,7 +37,7 @@ ms.author: sstein
 |**update_mode**|**tinyint**|The update mode:<br /><br /> **0** = Read only.<br /><br /> **1** = Immediate-updating.|  
 |**loopback_detection**|**bit**|Applies to subscriptions that are part of a bidirectional transactional replication topology. Loopback detection determines whether the Distribution Agent sends transactions originated at the Subscriber back to the Subscriber:<br /><br /> **0** = Sends back.<br /><br /> **1** = Does not send back.|  
 |**queued_reinit**|**bit**|Specifies whether the article is marked for initialization or reinitialization. A value of **1** specifies that the subscribed article is marked for initialization or reinitialization.|  
-|**nosync_type**|**tinyint**|The type of subscription initialization:<br /><br /> **0** = automatic (snapshot)<br /><br /> **1** = replication support only<br /><br /> **2** = initialize with backup<br /><br /> **3** = initialize from log sequence number (LSN)<br /><br /> For more information, see the **@sync_type** parameter of [sp_addsubscription](../../relational-databases/system-stored-procedures/sp-addsubscription-transact-sql.md).|  
+|**nosync_type**|**tinyint**|The type of subscription initialization:<br /><br /> **0** = automatic (snapshot)<br /><br /> **1** = replication support only<br /><br /> **2** = initialize with backup<br /><br /> **3** = initialize from log sequence number (LSN)<br /><br /> For more information, see the **\@sync_type** parameter of [sp_addsubscription](../../relational-databases/system-stored-procedures/sp-addsubscription-transact-sql.md).|  
 |**srvname**|**sysname**|The name of the Subscriber.|  
   
 ## See Also  


### PR DESCRIPTION
bold with escape characters

https://docs.microsoft.com/en-us/sql/relational-databases/system-tables/syssubscriptions-transact-sql?view=sql-server-ver15