### PR TITLE
Update full-text-search.md

### DIFF
--- a/docs/relational-databases/search/full-text-search.md
+++ b/docs/relational-databases/search/full-text-search.md
@@ -67,7 +67,7 @@ A full-text index includes one or more character-based columns in a table. These
     ```  
     SELECT candidate_name,SSN   
     FROM candidates   
-    WHERE CONTAINS(candidate_resume,"SQL Server") AND candidate_division =DBA;  
+    WHERE CONTAINS(candidate_resume,"SQL Server") AND candidate_division = 'DBA';  
     ```  
   
  For more information, see [Query with Full-Text Search](../../relational-databases/search/query-with-full-text-search.md).  
@@ -105,7 +105,7 @@ A full-text index includes one or more character-based columns in a table. These
 
     >[!NOTE]  
     >  In [!INCLUDE[ssKatmai](../../includes/sskatmai-md.md)] and later versions, the Full-Text Engine resides in the [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] process, rather than in a separate service. Integrating the Full-Text Engine into the Database Engine improved full-text manageability, optimization of mixed query, and overall performance.  
- 
+
 -   **Index writer (indexer).** The index writer builds the structure that is used to store the indexed tokens.  
   
 -   **Filter daemon manager.** The filter daemon manager is responsible for monitoring the status of the Full-Text Engine filter daemon host.  


### PR DESCRIPTION
Syntax error in "Recruitment scenario-searching for job candidates that have experience working with SQL Server" example.