### PR TITLE
Update lesson-1-creating-database-objects.md to avoid deprecated data type

### DIFF
--- a/docs/t-sql/lesson-1-creating-database-objects.md
+++ b/docs/t-sql/lesson-1-creating-database-objects.md
@@ -78,14 +78,14 @@ In a Query Editor window, type and execute the following code to change your con
   ```  
   
 ### Create the table
-In a Query Editor window, type and execute the following code to create a simple table named `Products`. The columns in the table are named `ProductID`, `ProductName`, `Price`, and `ProductDescription`. The `ProductID` column is the primary key of the table. `int`, `varchar(25)`, `money`, and `text` are all data types. Only the `Price` and `ProductionDescription` columns can have no data when a row is inserted or changed. This statement contains an optional element (`dbo.`) called a schema. The schema is the database object that owns the table. If you are an administrator, `dbo` is the default schema. `dbo` stands for database owner.  
+In a Query Editor window, type and execute the following code to create a simple table named `Products`. The columns in the table are named `ProductID`, `ProductName`, `Price`, and `ProductDescription`. The `ProductID` column is the primary key of the table. `int`, `varchar(25)`, `money`, and `varchar(max)` are all data types. Only the `Price` and `ProductionDescription` columns can have no data when a row is inserted or changed. This statement contains an optional element (`dbo.`) called a schema. The schema is the database object that owns the table. If you are an administrator, `dbo` is the default schema. `dbo` stands for database owner.  
   
   ```sql  
   CREATE TABLE dbo.Products  
      (ProductID int PRIMARY KEY NOT NULL,  
      ProductName varchar(25) NOT NULL,  
      Price money NULL,  
-     ProductDescription text NULL)  
+     ProductDescription varchar(max) NULL)  
   GO  
  ```  
 


### PR DESCRIPTION
Use `varchar(max)` instead of `text`, which is deprecated, in the `CREATE TABLE` part of the tutorial. This is especially important to prevent new users from establishing a habit of using the `text` data type, only to have that removed in a future version.