### PR TITLE
Update sql-server-backup-to-url-best-practices-and-troubleshooting.md

### DIFF
--- a/docs/relational-databases/backup-restore/sql-server-backup-to-url-best-practices-and-troubleshooting.md
+++ b/docs/relational-databases/backup-restore/sql-server-backup-to-url-best-practices-and-troubleshooting.md
@@ -70,7 +70,7 @@ ms.author: mikeray
   
 -   Parallel backups to the same blob cause one of the backups to fail with an **Initialization failed** error.  
   
--   Use the following error logs to help with troubleshooting backup errors:  
+-   If using Page Blobs (BACKUP... TO URL... WITH CREDENTIAL), use the following error logs to help with troubleshooting backup errors:  
   
     -   Set trace flag 3051 to turn on logging to a specific error log with the following format in:  
   

--- a/docs/relational-databases/backup-restore/sql-server-backup-to-url-best-practices-and-troubleshooting.md
+++ b/docs/relational-databases/backup-restore/sql-server-backup-to-url-best-practices-and-troubleshooting.md
@@ -70,7 +70,7 @@ ms.author: mikeray
   
 -   Parallel backups to the same blob cause one of the backups to fail with an **Initialization failed** error.  
   
--   If using Page Blobs (BACKUP... TO URL... WITH CREDENTIAL), use the following error logs to help with troubleshooting backup errors:  
+-   If using Page Blobs, for example `BACKUP... TO URL... WITH CREDENTIAL`, use the following error logs to help with troubleshooting backup errors:  
   
     -   Set trace flag 3051 to turn on logging to a specific error log with the following format in:  
   

--- a/docs/relational-databases/backup-restore/sql-server-backup-to-url-best-practices-and-troubleshooting.md
+++ b/docs/relational-databases/backup-restore/sql-server-backup-to-url-best-practices-and-troubleshooting.md
@@ -70,7 +70,7 @@ ms.author: mikeray
   
 -   Parallel backups to the same blob cause one of the backups to fail with an **Initialization failed** error.  
   
--   If using Page Blobs, for example `BACKUP... TO URL... WITH CREDENTIAL`, use the following error logs to help with troubleshooting backup errors:  
+-   If you're using page blobs, for example, `BACKUP... TO URL... WITH CREDENTIAL`, use the following error logs to help with troubleshooting backup errors:  
   
     -   Set trace flag 3051 to turn on logging to a specific error log with the following format in:  
   


### PR DESCRIPTION
The BackupToURL exe will only output the log file (using trace flag 3051) and the Windows Event Log if you are using Page Blobs (i.e. the backup T-SQL has WITH CREDENTIAL). If you are using block blobs then the TF is ignored and no output is written to log file or the Windows Event Log.

I'm propsing this update as the doc currently gives you the impression that using the TF will result in the verbose output in all use cases, which is not true. 

If there is a better way to convey this situation please update the doc to reflect that.