### PR TITLE
Need to remove the SSAS and SSRS reference in SQL 2017 upgrade content

### DIFF
--- a/docs/database-engine/install-windows/supported-version-and-edition-upgrades-2017.md
+++ b/docs/database-engine/install-windows/supported-version-and-edition-upgrades-2017.md
@@ -36,7 +36,7 @@ monikerRange: ">=sql-server-2016||=sqlallproducts-allversions"
   
 ## Unsupported Scenarios  
   
--   Cross-version instances of [!INCLUDE[sssqlv14-md](../../includes/sssqlv14-md.md)] are not supported. Version numbers of the [!INCLUDE[ssDE](../../includes/ssde-md.md)], [!INCLUDE[ssASnoversion](../../includes/ssasnoversion-md.md)], and [!INCLUDE[ssRSnoversion](../../includes/ssrsnoversion-md.md)] components must be the same in an instance of [!INCLUDE[sssqlv14-md](../../includes/sssqlv14-md.md)].  
+-   Cross-version instances of [!INCLUDE[sssqlv14-md](../../includes/sssqlv14-md.md)] are not supported. Version numbers of the [!INCLUDE[ssDE](../../includes/ssde-md.md)] components must be the same in an instance of [!INCLUDE[sssqlv14-md](../../includes/sssqlv14-md.md)].  
   
 -   [!INCLUDE[sssqlv14-md](../../includes/sssqlv14-md.md)] is only available for 64-bit platforms. Cross-platform upgrade is not supported. You cannot upgrade a 32-bit instance of [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] to native 64-bit using [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] Setup. However, you can back up or detach databases from a 32-bit instance of [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)], and then restore or attach them to a new instance of [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] (64-bit) if the databases are not published in replication. You must re-create any logins and other user objects in master, msdb, and model system databases.  
   


### PR DESCRIPTION
The section I edited doesn’t make sense anymore with the original verbiage. Since RS 2017 and AS 2017 are separate installs than SQL Server 2017 now, you can’t really upgrade them at the same time through SQL Server setup like you could before. And RS and AS version numbers are completely different than SQL Server. So having them the exact same 14.x version is impossible.

I feel like the content here was copied text from the 2016 doc here - https://docs.microsoft.com/en-us/sql/database-engine/install-windows/supported-version-and-edition-upgrades

... and the SQL 2016 content does make sense to me because in 2016 you couldn’t upgrade or patch an AS or RS instance only if there was also a SQL Server instance on the same server. For example, if both SQL (database engine) and SSRS were both installed on a server and you ran the SP update on it, you HAD to upgrade both SQL and RS to the SP version. You couldn’t do only one of them.

Starting with SQL 2017, the Analysis Services and Reporting Services part of this content should be removed as we've had a few customers and CSS engineers confused by it.