### PR TITLE
Doc update for RFC 13199988

### DIFF
--- a/docs/database-engine/availability-groups/windows/active-secondaries-backup-on-secondary-replicas-always-on-availability-groups.md
+++ b/docs/database-engine/availability-groups/windows/active-secondaries-backup-on-secondary-replicas-always-on-availability-groups.md
@@ -32,7 +32,9 @@ ms.author: mathoma
   
 -   **BACKUP DATABASE** supports only copy-only full backups of databases, files, or filegroups when it is executed on secondary replicas. Note that copy-only backups do not impact the log chain or clear the differential bitmap.  
   
--   Differential backups are not supported on secondary replicas.  
+-   Differential backups are not supported on secondary replicas.
+
+-   Concurrent backups, such as executing a transaction log backup on the primary replica while a full database backup is executing on the secondary replica, is currently not supported. 
   
 -   **BACKUP LOG** supports only regular log backups (the COPY_ONLY option is not supported for log backups on secondary replicas).  
   


### PR DESCRIPTION
Via RFC 13199988, we confirmed that executing a backup on the primary at the same time a backup is occurring on the secondary, is not supported. https://sqlbuvsts01:8443/web/wi.aspx?pcguid=86a4a1ca-bfe6-4329-be8d-f5c4a2420c67&id=13199988