### PR TITLE
Update catalog-get-parameter-values-ssisdb-database.md

### DIFF
--- a/docs/integration-services/system-stored-procedures/catalog-get-parameter-values-ssisdb-database.md
+++ b/docs/integration-services/system-stored-procedures/catalog-get-parameter-values-ssisdb-database.md
@@ -38,7 +38,7 @@ catalog.get_parameter_values [ @folder_name = ] folder_name
  The name of the project where the parameters resides. The *project_name* is **nvarchar(128)**.  
   
  [ @package_name = ] *package_name*  
- The name of the package. Specify the package name to retrieve all project parameters and the parameters from a specific package. Use NULL to retrieve all project parameters and the parameters from all packages. The *package_name* is **nvarchar(260)**.  
+ The name of the package. Specify the package name to retrieve all project parameters and the parameters from a specific package. The *package_name* is **nvarchar(260)**.  
   
  [ @reference_id = ] *reference_id*  
  The unique identifier of an environment reference. This parameter is optional. The *reference_id* is **bigint**.  


### PR DESCRIPTION
This statement, "Use NULL to retrieve all project parameters and the parameters from all packages." is incorrect. @package_name cannot be set to NULL when executing this procedure. The procedure starts with explicitly checking and raising an error when any of the required parameters are NULL:

    IF (@folder_name IS NULL OR @project_name IS NULL 
            OR @package_name IS NULL )
    BEGIN
        RAISERROR(27138, 16 , 1) WITH NOWAIT 
        RETURN 1 
    END