### PR TITLE
Add units to Statistics Collection Interval

### DIFF
--- a/docs/relational-databases/performance/best-practice-with-the-query-store.md
+++ b/docs/relational-databases/performance/best-practice-with-the-query-store.md
@@ -77,7 +77,7 @@ ALTER DATABASE [QueryStoreDB]
 SET QUERY_STORE (DATA_FLUSH_INTERVAL_SECONDS = 900);  
 ```  
 
- **Statistics Collection Interval**: Defines the level of granularity for the collected runtime statistic. The default is 60 minutes. Consider using a lower value if you require finer granularity or less time to detect and mitigate issues. Keep in mind that the value directly affects the size of Query Store data. Use [!INCLUDE[ssManStudioFull](../../includes/ssmanstudiofull-md.md)] or [!INCLUDE[tsql](../../includes/tsql-md.md)] to set a different value for **Statistics Collection Interval**:  
+ **Statistics Collection Interval (Minutes)**: Defines the level of granularity for the collected runtime statistic. The default is 60 minutes. Consider using a lower value if you require finer granularity or less time to detect and mitigate issues. Keep in mind that the value directly affects the size of Query Store data. Use [!INCLUDE[ssManStudioFull](../../includes/ssmanstudiofull-md.md)] or [!INCLUDE[tsql](../../includes/tsql-md.md)] to set a different value for **Statistics Collection Interval**:  
   
 ```sql  
 ALTER DATABASE [QueryStoreDB] 


### PR DESCRIPTION
Data Flush Interval and Stale Query Threshold include their units in the label, but Statistics Collection Interval did not.