### PR TITLE
Typo "**@failover_mode=**"→"**\@failover_mode=**"

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-helpreplfailovermode-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-helpreplfailovermode-transact-sql.md
@@ -47,7 +47,7 @@ sp_helpreplfailovermode [ @publisher= ] 'publisher'
 `[ @failover_mode_id = ] 'failover_mode_id' OUTPUT`
  Returns the integer value of the failover mode and is an **OUTPUT** parameter. *failover_mode_id* is a **tinyint** with a default of **0**. It returns **0** for immediate updating and **1** for queued updating.  
   
- [**@failover_mode=**] **'***failover_mode***'OUTPUT**  
+ [**\@failover_mode=**] **'***failover_mode***'OUTPUT**  
  Returns the mode in which data modifications are made at the Subscriber. *failover_mode* is a **nvarchar(10)** with a default of NULL. Is an **OUTPUT** parameter.  
   
 |Value|Description|  


### PR DESCRIPTION
bold with escape characters

https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-helpreplfailovermode-transact-sql?view=sql-server-ver15