### PR TITLE
new Microsoft.Data.SqlClient namespace

### DIFF
--- a/docs/connect/sql-connection-libraries.md
+++ b/docs/connect/sql-connection-libraries.md
@@ -43,7 +43,7 @@ although the FWLink is less precise than is https://github.com/Microsoft/msphpsq
 
 | Language | Download the SQL driver |
 | :------- | :---------------------- |
-| C# | [ADO.NET](https://www.microsoft.com/net/download/)<br /><br />[.NET Core, for Linux-Ubuntu](https://www.microsoft.com/net/core#Ubuntu)<br />[.NET Core, for MacOS](https://www.microsoft.com/net/core#macos)<br />[.NET Core, for Windows](https://www.microsoft.com/net/core) |
+| C# | [ADO.NET](https://www.microsoft.com/net/download/)<br />[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/)<br /><br />[.NET Core, for Linux-Ubuntu](https://www.microsoft.com/net/core#Ubuntu)<br />[.NET Core, for MacOS](https://www.microsoft.com/net/core#macos)<br />[.NET Core, for Windows](https://www.microsoft.com/net/core) |
 | C++ | [ODBC](./odbc/download-odbc-driver-for-sql-server.md)<br /><br />[OLE DB](./oledb/download-oledb-driver-for-sql-server.md) |
 | Java | [JDBC](./jdbc/download-microsoft-jdbc-driver-for-sql-server.md) |
 | Node.js | [Node.js driver, install instructions](./node-js/step-1-configure-development-environment-for-node-js-development.md) |


### PR DESCRIPTION
This namespace is new and will be future. System.Data.SqlClient won't get any new features. Original ADO.NET hyperlink is just referencing recent .NET 4.8 which itself does not contain new namespace Microsoft.Data.SqlClient. It's misleading developers they need to download new .NET and it will be there, but it's not, there is more info here: https://devblogs.microsoft.com/dotnet/introducing-the-new-microsoftdatasqlclient/. 
What changes will I see in Microsoft.Data.SqlClient versus System.Data.SqlClient?
There are two primary changes:

First, since this is an application level package, for .NET Framework any updates to the library will need to be shipped in an application update, rather than coming from Windows Update. This matches the existing behavior for .NET Core applications.

Second, there are a few new features in Microsoft.Data.SqlClient which will not be backported to System.Data.SqlClient. Those features are Data Classification Support, UTF-8 support for .Net Framework, and Always Encrypted support for .NET Core.