### PR TITLE
Wrong link to failover

### DIFF
--- a/docs/database-engine/availability-groups/windows/distributed-availability-groups.md
+++ b/docs/database-engine/availability-groups/windows/distributed-availability-groups.md
@@ -39,7 +39,7 @@ You can configure the data movement in distributed availability groups as synchr
 
 ![Distributed availability group and its data movement](./media/distributed-availability-group/dag-02-distributed-ag-data-movement.png)
 
-The only way to make AG 2's primary replica accept inserts, updates, and deletions is to manually fail over the distributed availability group from AG 1. In the preceding figure, because AG 1 contains the writeable copy of the database, issuing a failover makes AG 2 the availability group that can handle inserts, updates, and deletions. For information about how to fail over one distributed availability group to another, see [Failover to a secondary availability group]( https://docs.microsoft.com/sql/database-engine/availability-groups/windows/distributed-availability-groups-always-on-availability-groups).
+The only way to make AG 2's primary replica accept inserts, updates, and deletions is to manually fail over the distributed availability group from AG 1. In the preceding figure, because AG 1 contains the writeable copy of the database, issuing a failover makes AG 2 the availability group that can handle inserts, updates, and deletions. For information about how to fail over one distributed availability group to another, see [Failover to a secondary availability group]( https://docs.microsoft.com/en-us/sql/database-engine/availability-groups/windows/configure-distributed-availability-groups?view=sql-server-ver15#failover).
 
 > [!NOTE]
 > Distributed availability groups in SQL Server 2016 support failover only from one availability group to another by using the option FORCE_FAILOVER_ALLOW_DATA_LOSS.

--- a/docs/database-engine/availability-groups/windows/distributed-availability-groups.md
+++ b/docs/database-engine/availability-groups/windows/distributed-availability-groups.md
@@ -39,7 +39,7 @@ You can configure the data movement in distributed availability groups as synchr
 
 ![Distributed availability group and its data movement](./media/distributed-availability-group/dag-02-distributed-ag-data-movement.png)
 
-The only way to make AG 2's primary replica accept inserts, updates, and deletions is to manually fail over the distributed availability group from AG 1. In the preceding figure, because AG 1 contains the writeable copy of the database, issuing a failover makes AG 2 the availability group that can handle inserts, updates, and deletions. For information about how to fail over one distributed availability group to another, see [Failover to a secondary availability group]( https://docs.microsoft.com/en-us/sql/database-engine/availability-groups/windows/configure-distributed-availability-groups?view=sql-server-ver15#failover).
+The only way to make AG 2's primary replica accept inserts, updates, and deletions is to manually fail over the distributed availability group from AG 1. In the preceding figure, because AG 1 contains the writeable copy of the database, issuing a failover makes AG 2 the availability group that can handle inserts, updates, and deletions. For information about how to fail over one distributed availability group to another, see [Failover to a secondary availability group](configure-distributed-availability-groups.md#failover).
 
 > [!NOTE]
 > Distributed availability groups in SQL Server 2016 support failover only from one availability group to another by using the option FORCE_FAILOVER_ALLOW_DATA_LOSS.


### PR DESCRIPTION
Wrong link for [Failover to a secondary availability group]. fixed