### PR TITLE
Emphasize storage setup in BDC docs

### DIFF
--- a/docs/big-data-cluster/concept-data-persistence.md
+++ b/docs/big-data-cluster/concept-data-persistence.md
@@ -83,9 +83,9 @@ AKS comes with [two built-in storage classes](/azure/aks/azure-disks-dynamic-pv/
 Kubernetes clusters deployed using `kubeadm` do not have a built-in storage class. You must create your own storage classes and persistent volumes using local storage or your preferred provisioner, such as [Rook](https://github.com/rook/rook). In that case, you would set the `className` to the storage class you configured. 
 
 > [!IMPORTANT]
->  In the built in deployment configuration files for kubeadm (`kubeadm-dev-test` or `kubeadm-prod`) there is no storage class name specified for the data and log storage. Before deployment, you must customize the configuration file and set the value for className otherwise the pre-deployment validations will fail. Deployment also has a validation step that checks for the existence of the storage class, but not for the necessary persistent volumes. You must ensure you create enough volumes depending on the scale of your cluster. For the default minimum cluster size (default scale, no high availability) you must create at least 24 persistent volumes.
-
-[Here is an example](https://github.com/Microsoft/sql-server-samples/tree/master/samples/features/sql-big-data-cluster/deployment/kubeadm/ubuntu) of how you can create persistent volumes using the local provisioner. **If you don't understand Kubernetes storage deeply yet, this example is a good place to start.**
+>  In the built in deployment configuration files for kubeadm (`kubeadm-dev-test` or `kubeadm-prod`) there is no storage class name specified for the data and log storage. Before deployment, you must customize the configuration file and set the value for `className` otherwise the pre-deployment validations will fail. Deployment also has a validation step that checks for the existence of the storage class, but not for the necessary persistent volumes. You must ensure you create enough volumes depending on the scale of your cluster. For the default minimum cluster size (default scale, no high availability) you must create at least 24 persistent volumes.
+>
+>[Create a Kubernetes cluster](https://github.com/Microsoft/sql-server-samples/tree/master/samples/features/sql-big-data-cluster/deployment/kubeadm/ubuntu) presents an example of how you can create persistent volumes using the local provisioner. This example introduces Kubernetes storage.
 
 
 ## Customize storage configurations for each pool

--- a/docs/big-data-cluster/concept-data-persistence.md
+++ b/docs/big-data-cluster/concept-data-persistence.md
@@ -82,8 +82,10 @@ AKS comes with [two built-in storage classes](/azure/aks/azure-disks-dynamic-pv/
 
 Kubernetes clusters deployed using `kubeadm` do not have a built-in storage class. You must create your own storage classes and persistent volumes using local storage or your preferred provisioner, such as [Rook](https://github.com/rook/rook). In that case, you would set the `className` to the storage class you configured. 
 
-> [!NOTE]
->  In the built in deployment configuration files for kubeadm (`kubeadm-dev-test` or `kubeadm-prod`) there is no storage class name specified for the data and log storage. Before deployment, you must customize the configuration file and set the value for className otherwise the pre-deployment validations will fail. Deployment also has a validation step that checks for the existence of the storage class, but not for the necessary persistent volumes. You must ensure you create enough volumes depending on the scale of your cluster. For the default minimum cluster size (default scale, no high availability) you must create at least 24 persistent volumes. [Here](https://github.com/Microsoft/sql-server-samples/tree/master/samples/features/sql-big-data-cluster/deployment/kubeadm/ubuntu) is an example on how to create persistent volumes using local provisioner.
+> [!IMPORTANT]
+>  In the built in deployment configuration files for kubeadm (`kubeadm-dev-test` or `kubeadm-prod`) there is no storage class name specified for the data and log storage. Before deployment, you must customize the configuration file and set the value for className otherwise the pre-deployment validations will fail. Deployment also has a validation step that checks for the existence of the storage class, but not for the necessary persistent volumes. You must ensure you create enough volumes depending on the scale of your cluster. For the default minimum cluster size (default scale, no high availability) you must create at least 24 persistent volumes.
+
+[Here is an example](https://github.com/Microsoft/sql-server-samples/tree/master/samples/features/sql-big-data-cluster/deployment/kubeadm/ubuntu) of how you can create persistent volumes using the local provisioner. **If you don't understand Kubernetes storage deeply yet, this example is a good place to start.**
 
 
 ## Customize storage configurations for each pool

--- a/docs/big-data-cluster/deployment-guidance.md
+++ b/docs/big-data-cluster/deployment-guidance.md
@@ -67,7 +67,7 @@ After you have configured your Kubernetes cluster, you can proceed with the depl
 ## Ensure you have storage configured
 It's important for most big data cluster deployments to have persistent storage. At this time, you need to make sure you have a plan for how you're going to provide persistent storage on the Kubernetes cluster *before* you deploy the BDC tools. 
 
-If you're using AKS and you plan to use dynamically provisioned storage, you should set up a persistent volume claim on your preferred storage class now. If you aren't planning to use AKS's dynamically provisioned storage (e.g. because you're deploying on your own kubeadm cluster), you'll need to ensure you have sufficient storage for a cluster of your desired scale available and configured for use. If you wish to customize how your storage is used, you should do this now. [You can find detailed information about storage setup here.](concept-data-persistence.md)
+If you're using AKS and you plan to use dynamically provisioned storage, you should set up a persistent volume claim on your preferred storage class now. If you aren't planning to use AKS's dynamically provisioned storage (e.g. because you're deploying on your own kubeadm cluster), you'll need to ensure you have sufficient storage for a cluster of your desired scale available and configured for use. If you wish to customize how your storage is used, you should do this before proceeding. See [Data persistence with SQL Server big data cluster on Kubernetes](concept-data-persistence.md).
 
 ## <a id="deploy"></a> Deployment overview
 

--- a/docs/big-data-cluster/deployment-guidance.md
+++ b/docs/big-data-cluster/deployment-guidance.md
@@ -64,6 +64,11 @@ kubectl config view
 
 After you have configured your Kubernetes cluster, you can proceed with the deployment of a new SQL Server big data cluster. If you are upgrading from a previous release, please see [How to upgrade [!INCLUDE[big-data-clusters-2019](../includes/ssbigdataclusters-ss-nover.md)]](deployment-upgrade.md).
 
+## Ensure you have storage configured
+It's important for most big data cluster deployments to have persistent storage. At this time, you need to make sure you have a plan for how you're going to provide persistent storage on the Kubernetes cluster *before* you deploy the BDC tools. 
+
+If you're using AKS and you plan to use dynamically provisioned storage, you should set up a persistent volume claim on your preferred storage class now. If you aren't planning to use AKS's dynamically provisioned storage (e.g. because you're deploying on your own kubeadm cluster), you'll need to ensure you have sufficient storage available and configured for a cluster of your desired scale. If you wish to customize how your storage is used, you should do this now. [You can find detailed information about storage setup here.](concept-data-persistence.md)
+
 ## <a id="deploy"></a> Deployment overview
 
 Most big data cluster settings are defined in a JSON deployment configuration file. You can use a default deployment profile for AKS and Kubernetes clusters created with `kubeadm` or you can customize your own deployment configuration file to use during setup. For security reasons, authentication settings are passed via environment variables.

--- a/docs/big-data-cluster/deployment-guidance.md
+++ b/docs/big-data-cluster/deployment-guidance.md
@@ -67,7 +67,7 @@ After you have configured your Kubernetes cluster, you can proceed with the depl
 ## Ensure you have storage configured
 It's important for most big data cluster deployments to have persistent storage. At this time, you need to make sure you have a plan for how you're going to provide persistent storage on the Kubernetes cluster *before* you deploy the BDC tools. 
 
-If you're using AKS and you plan to use dynamically provisioned storage, you should set up a persistent volume claim on your preferred storage class now. If you aren't planning to use AKS's dynamically provisioned storage (e.g. because you're deploying on your own kubeadm cluster), you'll need to ensure you have sufficient storage available and configured for a cluster of your desired scale. If you wish to customize how your storage is used, you should do this now. [You can find detailed information about storage setup here.](concept-data-persistence.md)
+If you're using AKS and you plan to use dynamically provisioned storage, you should set up a persistent volume claim on your preferred storage class now. If you aren't planning to use AKS's dynamically provisioned storage (e.g. because you're deploying on your own kubeadm cluster), you'll need to ensure you have sufficient storage for a cluster of your desired scale available and configured for use. If you wish to customize how your storage is used, you should do this now. [You can find detailed information about storage setup here.](concept-data-persistence.md)
 
 ## <a id="deploy"></a> Deployment overview
 


### PR DESCRIPTION
While working directly with a user trying to deploy a BDC on-prem, I got a bunch of helpful feedback about potentially confusing parts of the documentation. While working through the docs, this user was confused as to where in the setup process we were supposed to configure persistent storage. His use-case (i.e. a test deployment used to aquaint himself with the BDC toolchain) would've been met perfectly by the example scripts linked in the storage setup page, which he didn't consciously notice to be appropriate to his situation.

Reading over the documentation, I can understand how a user (especially with middling Linux experience) could be confused about the flow of the document. I added a small section on storage to the deployment guidance section, and I tried to call more attention to the example code for kubeadm deployments (at least for users who don't have extensive k8s experience).