### PR TITLE
Typo "**@identityrangemanagementoption**"→"**\@identityrangemanagemen…

### DIFF
--- a/docs/2014/relational-databases/replication/publish/manage-identity-columns.md
+++ b/docs/2014/relational-databases/replication/publish/manage-identity-columns.md
@@ -78,27 +78,27 @@ manager: craigg
   
 #### To enable automatic identity range management when defining articles for a transactional publication  
   
-1.  At the Publisher on the publication database, execute [sp_addarticle](/sql/relational-databases/system-stored-procedures/sp-addarticle-transact-sql). If the source table being published has an identity column, specify a value of **auto** for **@identityrangemanagementoption**, the range of identity values assigned to the Publisher for **@pub_identity_range**, the range of identity values assigned to each Subscribers for **@identity_range**, and the percent of total identity values used before a new identity range is assigned for **@threshold**. For more information about defining articles, see [Define an Article](define-an-article.md).  
+1.  At the Publisher on the publication database, execute [sp_addarticle](/sql/relational-databases/system-stored-procedures/sp-addarticle-transact-sql). If the source table being published has an identity column, specify a value of **auto** for **\@identityrangemanagementoption**, the range of identity values assigned to the Publisher for **\@pub_identity_range**, the range of identity values assigned to each Subscribers for **\@identity_range**, and the percent of total identity values used before a new identity range is assigned for **\@threshold**. For more information about defining articles, see [Define an Article](define-an-article.md).  
   
     > [!NOTE]  
     >  Ensure that the data type of the identity column is large enough to support the total range of identities being assigned to all Subscribers.  
   
 #### To disable automatic identity range management when defining articles for a transactional publication  
   
-1.  At the Publisher on the publication database, execute [sp_addarticle](/sql/relational-databases/system-stored-procedures/sp-addarticle-transact-sql). Specify a value of **manual** for **@identityrangemanagementoption**. For more information about defining articles, see [Define an Article](define-an-article.md).  
+1.  At the Publisher on the publication database, execute [sp_addarticle](/sql/relational-databases/system-stored-procedures/sp-addarticle-transact-sql). Specify a value of **manual** for **\@identityrangemanagementoption**. For more information about defining articles, see [Define an Article](define-an-article.md).  
   
 2.  Assign ranges to identity article columns at the Subscriber to avoid generating conflicts for updating Subscribers. For more information, see the section on assigning ranges for manual identity range management in the topic [Replicate Identity Columns](replicate-identity-columns.md).  
   
 #### To enable automatic identity range management when defining articles for a merge publication  
   
-1.  At the Publisher on the publication database, execute [sp_addmergearticle](/sql/relational-databases/system-stored-procedures/sp-addmergearticle-transact-sql). If the source table being published has an identity column, specify a value of **auto** for **@identityrangemanagementoption**, the range of identity values assigned to a server subscription for **@pub_identity_range**, the range of identity values assigned to the Publisher and each client subscription for **@identity_range**, and the percent of total identity values used before a new identity range is assigned for **@threshold**. For more information on when new identity ranges are assigned, see Assigning Identity Ranges in the topic [Replicate Identity Columns](replicate-identity-columns.md). For more information about defining articles, see [Define an Article](define-an-article.md).  
+1.  At the Publisher on the publication database, execute [sp_addmergearticle](/sql/relational-databases/system-stored-procedures/sp-addmergearticle-transact-sql). If the source table being published has an identity column, specify a value of **auto** for **\@identityrangemanagementoption**, the range of identity values assigned to a server subscription for **\@pub_identity_range**, the range of identity values assigned to the Publisher and each client subscription for **\@identity_range**, and the percent of total identity values used before a new identity range is assigned for **\@threshold**. For more information on when new identity ranges are assigned, see Assigning Identity Ranges in the topic [Replicate Identity Columns](replicate-identity-columns.md). For more information about defining articles, see [Define an Article](define-an-article.md).  
   
     > [!NOTE]  
     >  Ensure that the data type of the identity column is large enough to support the total range of identities being assigned to all Subscribers, particularly for Subscribers with server subscriptions.  
   
 #### To disable automatic identity range management when defining articles for a merge publication  
   
-1.  At the Publisher on the publication database, execute [sp_addmergearticle](/sql/relational-databases/system-stored-procedures/sp-addmergearticle-transact-sql). Specify one of the following values for **@identityrangemanagementoption**:  
+1.  At the Publisher on the publication database, execute [sp_addmergearticle](/sql/relational-databases/system-stored-procedures/sp-addmergearticle-transact-sql). Specify one of the following values for **\@identityrangemanagementoption**:  
   
     -   **manual** - Identity ranges must be assigned manually for updating Subscribers.  
   
@@ -114,9 +114,9 @@ manager: craigg
   
 2.  If the value of **identityrangemanagementoption** in the result set is **1**, change the settings as follows:  
   
-    -   To change the assigned identity ranges, execute [sp_changearticle](/sql/relational-databases/system-stored-procedures/sp-changearticle-transact-sql) at the Publisher on the publication database. Specify a value of **identity_range** or **pub_identity_range** for **@property** and the new range value for **@value**.  
+    -   To change the assigned identity ranges, execute [sp_changearticle](/sql/relational-databases/system-stored-procedures/sp-changearticle-transact-sql) at the Publisher on the publication database. Specify a value of **identity_range** or **pub_identity_range** for **\@property** and the new range value for **\@value**.  
   
-    -   To change the threshold at which new ranges are assigned, execute [sp_changearticle](/sql/relational-databases/system-stored-procedures/sp-changearticle-transact-sql) at the Publisher on the publication database. Specify a value of **threshold** for **@property** and the new threshold value for **@value**.  
+    -   To change the threshold at which new ranges are assigned, execute [sp_changearticle](/sql/relational-databases/system-stored-procedures/sp-changearticle-transact-sql) at the Publisher on the publication database. Specify a value of **threshold** for **\@property** and the new threshold value for **\@value**.  
   
 #### To change automatic identity range management settings for an existing article in a merge publication  
   
@@ -124,11 +124,11 @@ manager: craigg
   
 2.  If the value of **identity_support** in the result set is **1**, change the settings as follows:  
   
-    -   To change the assigned identity ranges, execute [sp_changemergearticle](/sql/relational-databases/system-stored-procedures/sp-changemergearticle-transact-sql) at the Publisher on the publication database. Specify a value of **identity_range** or **pub_identity_range** for **@property** and the new range value for **@value**.  
+    -   To change the assigned identity ranges, execute [sp_changemergearticle](/sql/relational-databases/system-stored-procedures/sp-changemergearticle-transact-sql) at the Publisher on the publication database. Specify a value of **identity_range** or **pub_identity_range** for **\@property** and the new range value for **\@value**.  
   
-    -   To change the threshold at which new ranges are assigned, execute [sp_changemergearticle](/sql/relational-databases/system-stored-procedures/sp-changemergearticle-transact-sql) at the Publisher on the publication database. Specify a value of **threshold** for **@property** and the new threshold value for **@value**. For more information on when new identity ranges are assigned, see Assigning Identity Ranges in the topic [Replicate Identity Columns](replicate-identity-columns.md).  
+    -   To change the threshold at which new ranges are assigned, execute [sp_changemergearticle](/sql/relational-databases/system-stored-procedures/sp-changemergearticle-transact-sql) at the Publisher on the publication database. Specify a value of **threshold** for **\@property** and the new threshold value for **\@value**. For more information on when new identity ranges are assigned, see Assigning Identity Ranges in the topic [Replicate Identity Columns](replicate-identity-columns.md).  
   
-    -   To disable automatic identity range management, execute [sp_changemergearticle](/sql/relational-databases/system-stored-procedures/sp-changemergearticle-transact-sql) at the Publisher on the publication database. Specify a value of **identityrangemanagementoption** for **@property** and either **manual** or **none** for **@value**.  
+    -   To disable automatic identity range management, execute [sp_changemergearticle](/sql/relational-databases/system-stored-procedures/sp-changemergearticle-transact-sql) at the Publisher on the publication database. Specify a value of **identityrangemanagementoption** for **\@property** and either **manual** or **none** for **\@value**.  
   
 ## See Also  
  [Peer-to-Peer Transactional Replication](../transactional/peer-to-peer-transactional-replication.md)   


### PR DESCRIPTION
…toption**"

Bold with escape characters

https://docs.microsoft.com/sr-latn-RS/sql/relational-databases/replication/publish/manage-identity-columns?view=sql-server-2014