### PR TITLE
Typo "**@subscriptionstreams**"→"**\@subscriptionstreams**"

### DIFF
--- a/docs/2014/relational-databases/replication/administration/enhance-transactional-replication-performance.md
+++ b/docs/2014/relational-databases/replication/administration/enhance-transactional-replication-performance.md
@@ -74,7 +74,7 @@ manager: craigg
   
      The **-SubscriptionStreams** parameter can greatly improve aggregate replication throughput. It allows multiple connections to a Subscriber to apply batches of changes in parallel, while maintaining many of the transactional characteristics present when using a single thread. If one of the connections fails to execute or commit, all connections will abort the current batch, and the agent will use a single stream to retry the failed batches. Before this retry phase completes, there can be temporary transactional inconsistencies at the Subscriber. After the failed batches are successfully committed, the Subscriber is brought back to a state of transactional consistency.  
   
-     A value for this agent parameter can be specified using the **@subscriptionstreams** of [sp_addsubscription &#40;Transact-SQL&#41;](/sql/relational-databases/system-stored-procedures/sp-addsubscription-transact-sql).  
+     A value for this agent parameter can be specified using the **\@subscriptionstreams** of [sp_addsubscription &#40;Transact-SQL&#41;](/sql/relational-databases/system-stored-procedures/sp-addsubscription-transact-sql).  
   
 -   Increase the value of the **-ReadBatchSize** parameter for the Log Reader Agent.  
   


### PR DESCRIPTION
Bold with escape characters

https://docs.microsoft.com/sr-latn-RS/sql/relational-databases/replication/administration/enhance-transactional-replication-performance?view=sql-server-2014