### PR TITLE
Typo "**@***number_var*"→"**\@***number_var*"

### DIFF
--- a/docs/t-sql/functions/date-and-time-data-types-and-functions-transact-sql.md
+++ b/docs/t-sql/functions/date-and-time-data-types-and-functions-transact-sql.md
@@ -118,10 +118,10 @@ The following tables list the [!INCLUDE[tsql](../../includes/tsql-md.md)] date a
 |Function|Syntax|Return value|Return data type|Determinism|  
 |---|---|---|---|---|
 |[@@DATEFIRST](../../t-sql/functions/datefirst-transact-sql.md)|@@DATEFIRST|Returns the current value, for the session, of SET DATEFIRST.|**tinyint**|Nondeterministic|  
-|[SET DATEFIRST](../../t-sql/statements/set-datefirst-transact-sql.md)|SET DATEFIRST { *number* &#124; **@***number_var* }|Sets the first day of the week to a number from 1 through 7.|Not applicable|Not applicable|  
+|[SET DATEFIRST](../../t-sql/statements/set-datefirst-transact-sql.md)|SET DATEFIRST { *number* &#124; **\@***number_var* }|Sets the first day of the week to a number from 1 through 7.|Not applicable|Not applicable|  
 |[SET DATEFORMAT](../../t-sql/statements/set-dateformat-transact-sql.md)|SET DATEFORMAT { *format* &#124; **@**_format_var_ }|Sets the order of the dateparts (month/day/year) for entering **datetime** or **smalldatetime** data.|Not applicable|Not applicable|  
 |[@@LANGUAGE](../../t-sql/functions/language-transact-sql.md)|@@LANGUAGE|Returns the name of the language in current used. @@LANGUAGE is not a date or time function. However, the language setting can affect the output of date functions.|Not applicable|Not applicable|  
-|[SET LANGUAGE](../../t-sql/statements/set-language-transact-sql.md)|SET LANGUAGE { [ N ] **'**_language_**'** &#124; **@***language_var* }|Sets the language environment for the session and system messages. SET LANGUAGE is not a date or time function. However, the language setting affects the output of date functions.|Not applicable|Not applicable|  
+|[SET LANGUAGE](../../t-sql/statements/set-language-transact-sql.md)|SET LANGUAGE { [ N ] **'**_language_**'** &#124; **\@***language_var* }|Sets the language environment for the session and system messages. SET LANGUAGE is not a date or time function. However, the language setting affects the output of date functions.|Not applicable|Not applicable|  
 |[sp_helplanguage](../../relational-databases/system-stored-procedures/sp-helplanguage-transact-sql.md)|**sp_helplanguage** [ [ **@language =** ] **'**_language_**'** ]|Returns information about date formats of all supported languages. **sp_helplanguage** is not a date or time stored procedure. However, the language setting affects the output of date functions.|Not applicable|Not applicable|  
   
 ###  <a name="ValidateDateandTimeValues"></a> Functions That Validate Date and Time Values

--- a/docs/t-sql/functions/date-and-time-data-types-and-functions-transact-sql.md
+++ b/docs/t-sql/functions/date-and-time-data-types-and-functions-transact-sql.md
@@ -118,10 +118,10 @@ The following tables list the [!INCLUDE[tsql](../../includes/tsql-md.md)] date a
 |Function|Syntax|Return value|Return data type|Determinism|  
 |---|---|---|---|---|
 |[@@DATEFIRST](../../t-sql/functions/datefirst-transact-sql.md)|@@DATEFIRST|Returns the current value, for the session, of SET DATEFIRST.|**tinyint**|Nondeterministic|  
-|[SET DATEFIRST](../../t-sql/statements/set-datefirst-transact-sql.md)|SET DATEFIRST { *number* &#124; **\@***number_var* }|Sets the first day of the week to a number from 1 through 7.|Not applicable|Not applicable|  
+|[SET DATEFIRST](../../t-sql/statements/set-datefirst-transact-sql.md)|SET DATEFIRST { *number* &#124; **\@**_number_var_ }|Sets the first day of the week to a number from 1 through 7.|Not applicable|Not applicable|  
 |[SET DATEFORMAT](../../t-sql/statements/set-dateformat-transact-sql.md)|SET DATEFORMAT { *format* &#124; **@**_format_var_ }|Sets the order of the dateparts (month/day/year) for entering **datetime** or **smalldatetime** data.|Not applicable|Not applicable|  
 |[@@LANGUAGE](../../t-sql/functions/language-transact-sql.md)|@@LANGUAGE|Returns the name of the language in current used. @@LANGUAGE is not a date or time function. However, the language setting can affect the output of date functions.|Not applicable|Not applicable|  
-|[SET LANGUAGE](../../t-sql/statements/set-language-transact-sql.md)|SET LANGUAGE { [ N ] **'**_language_**'** &#124; **\@***language_var* }|Sets the language environment for the session and system messages. SET LANGUAGE is not a date or time function. However, the language setting affects the output of date functions.|Not applicable|Not applicable|  
+|[SET LANGUAGE](../../t-sql/statements/set-language-transact-sql.md)|SET LANGUAGE { [ N ] **'**_language_**'** &#124; **\@**_language_var_ }|Sets the language environment for the session and system messages. SET LANGUAGE is not a date or time function. However, the language setting affects the output of date functions.|Not applicable|Not applicable|  
 |[sp_helplanguage](../../relational-databases/system-stored-procedures/sp-helplanguage-transact-sql.md)|**sp_helplanguage** [ [ **@language =** ] **'**_language_**'** ]|Returns information about date formats of all supported languages. **sp_helplanguage** is not a date or time stored procedure. However, the language setting affects the output of date functions.|Not applicable|Not applicable|  
   
 ###  <a name="ValidateDateandTimeValues"></a> Functions That Validate Date and Time Values


### PR DESCRIPTION
Bold with escape characters

https://docs.microsoft.com/en-us/sql/t-sql/functions/date-and-time-data-types-and-functions-transact-sql?view=sql-server-ver15