### PR TITLE
Moving download link for SSMS to more formal text

### DIFF
--- a/docs/ssms/download-sql-server-management-studio-ssms.md
+++ b/docs/ssms/download-sql-server-management-studio-ssms.md
@@ -36,7 +36,9 @@ Use SSMS to query, design, and manage your databases and data warehouses, wherev
 
 SSMS is free!
 
-## [Download SSMS](https://aka.ms/ssmsfullsetup)
+## Download SSMS
+
+The latest release of SSMS can be downloaded [here](https://aka.ms/sssmsfullsetup).
 
 SSMS 18.4 is the latest general availability (GA) version of SSMS. If you have a previous GA version of SSMS 18 installed, installing SSMS 18.4 upgrades it to 18.4. If you have an older *preview* version of SSMS 18.x installed, you must uninstall it before installing SSMS 18.4.
 

--- a/docs/ssms/download-sql-server-management-studio-ssms.md
+++ b/docs/ssms/download-sql-server-management-studio-ssms.md
@@ -38,7 +38,7 @@ SSMS is free!
 
 ## Download SSMS
 
-The latest release of SSMS can be downloaded [here](https://aka.ms/sssmsfullsetup).
+[Download](https://aka.ms/sssmsfullsetup) the latest release of SSMS.
 
 SSMS 18.4 is the latest general availability (GA) version of SSMS. If you have a previous GA version of SSMS 18 installed, installing SSMS 18.4 upgrades it to 18.4. If you have an older *preview* version of SSMS 18.x installed, you must uninstall it before installing SSMS 18.4.
 


### PR DESCRIPTION
Markdown headers should not be used as reference/hyperlinks to other content. Moving the link for downloading SSMS to a more formal `here` as all users are familiar with seeing.

Fixes #3431 
Fixes #3469