### PR TITLE
Fix datatype in "Serialization Encoding" section of "Serialization of XML Data"

### DIFF
--- a/docs/relational-databases/xml/define-the-serialization-of-xml-data.md
+++ b/docs/relational-databases/xml/define-the-serialization-of-xml-data.md
@@ -52,7 +52,7 @@ select CAST(CAST(N'<Δ/>' as XML) as NVARCHAR(MAX))
 <Δ/>  
 ```  
   
- If the SQL target type is VARCHAR or NCHAR, the result is serialized in the encoding that corresponds to the database's collation code page without a byte order mark or XML declaration. If the target type is too small or the value cannot be mapped to the target collation code page, an error is raised.  
+ If the SQL target type is VARCHAR or CHAR, the result is serialized in the encoding that corresponds to the database's collation code page without a byte order mark or XML declaration. If the target type is too small or the value cannot be mapped to the target collation code page, an error is raised.  
   
  For example:  
   


### PR DESCRIPTION
Datatype was `NCHAR` when it clearly should have been `CHAR` as the subsection is dealing with code pages and also even mentioned `VARCHAR`.

```sql
SELECT CONVERT(XML, N'<a>&#x1234;</a>');
-- <a>ሴ</a>


SELECT CONVERT(NCHAR(50), CONVERT(XML, N'<a>&#x1234;</a>'));
-- <a>ሴ</a>                                          


SELECT CONVERT(CHAR(50), CONVERT(XML, N'<a>&#x1234;</a>'));
/*
Msg 6355, Level 16, State 1, Line XXXXX
Conversion of one or more characters from XML to target collation impossible
*/
```