### PR TITLE
Typo "**@@TEXTSIZE**"→"**\@\@TEXTSIZE**"

### DIFF
--- a/docs/relational-databases/native-client/features/filestream-support.md
+++ b/docs/relational-databases/native-client/features/filestream-support.md
@@ -19,7 +19,7 @@ ms.author: genemi
 
   FILESTREAM provides a way to store and access large binary values, either through [!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)] or by direct access to the Windows file system. A large binary value is a value larger than 2 gigabytes (GB). For more information about enhanced FILESTREAM support, see [FILESTREAM &#40;SQL Server&#41;](../../../relational-databases/blob/filestream-sql-server.md).  
   
- When a database connection is opened, **@@TEXTSIZE** will be set to -1 ("unlimited"), by default.  
+ When a database connection is opened, **\@\@TEXTSIZE** will be set to -1 ("unlimited"), by default.  
   
  It is also possible to access and update FILESTREAM columns using Windows file system APIs.  
   


### PR DESCRIPTION
bold with escape characters

https://docs.microsoft.com/en-us/sql/relational-databases/native-client/features/filestream-support?view=sql-server-ver15