### PR TITLE
Clarification on permission section

### DIFF
--- a/docs/relational-databases/native-client/features/filestream-support.md
+++ b/docs/relational-databases/native-client/features/filestream-support.md
@@ -19,7 +19,7 @@ ms.author: genemi
 
   FILESTREAM provides a way to store and access large binary values, either through [!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)] or by direct access to the Windows file system. A large binary value is a value larger than 2 gigabytes (GB). For more information about enhanced FILESTREAM support, see [FILESTREAM &#40;SQL Server&#41;](../../../relational-databases/blob/filestream-sql-server.md).  
   
- When a database connection is opened, **@@TEXTSIZE** will be set to -1 ("unlimited"), by default.  
+ When a database connection is opened, **\@\@TEXTSIZE** will be set to -1 ("unlimited"), by default.  
   
  It is also possible to access and update FILESTREAM columns using Windows file system APIs.  
   

--- a/docs/relational-databases/stored-procedures/return-data-from-a-stored-procedure.md
+++ b/docs/relational-databases/stored-procedures/return-data-from-a-stored-procedure.md
@@ -19,8 +19,8 @@ monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-s
 
   There are three ways of returning data from a procedure to a calling program: result sets, output parameters, and return codes. This topic provides information on the three approaches.  
   
-  ## Returning Data Using Result Sets
- If you include a SELECT statement in the body of a stored procedure (but not a SELECT ... INTO or INSERT ... SELECT), the rows specified by the SELECT statement will be sent directly to the client.  For large result sets the stored procedure execution will not continue to the next statement until the result set has been completely sent to the client.  For small result sets the results will be spooled for return to the client and execution will continue.  If multiple such SELECT statements are run during the exeuction of the stored proceudre, multiple result sets will be sent to the client.  This behavior also applies to nested TSQL batches, nested stored procedures and top-level TSQL batches.
+## Returning Data Using Result Sets
+If you include a SELECT statement in the body of a stored procedure (but not a SELECT ... INTO or INSERT ... SELECT), the rows specified by the SELECT statement will be sent directly to the client.  For large result sets, the stored procedure execution will not continue to the next statement until the result set has been completely sent to the client.  For small result sets, the results will be spooled for return to the client and execution will continue.  If multiple such SELECT statements are run during the execution of the stored procedure, multiple result sets will be sent to the client.  This behavior also applies to nested TSQL batches, nested stored procedures and top-level TSQL batches.
  
  
  ### Examples of Returning Data Using a Result Set 


### PR DESCRIPTION
I think the security section [here..](https://docs.microsoft.com/en-us/sql/t-sql/statements/backup-transact-sql?view=sql-server-ver15#security) leading confusion, ([comments here](https://dba.stackexchange.com/a/252718/185080) for the reference). Probably, adding additional sentence (as follows) would make it more clear and avoid such confusions. 

BACKUP DATABASE and BACKUP LOG permissions default to members of the sysadmin fixed server role and the db_owner and db_backupoperator fixed database roles. "However, Explicit DENY can be applied to user/role"