### PR TITLE
Fix "Constant Folding" info in "Query Processing Architecture Guide"

### DIFF
--- a/docs/relational-databases/query-processing-architecture-guide.md
+++ b/docs/relational-databases/query-processing-architecture-guide.md
@@ -1,7 +1,7 @@
 ---
 title: "Query Processing Architecture Guide | Microsoft Docs"
 ms.custom: ""
-ms.date: "02/24/2019"
+ms.date: "11/26/2019"
 ms.prod: sql
 ms.prod_service: "database-engine, sql-database, sql-data-warehouse, pdw"
 ms.reviewer: ""
@@ -132,17 +132,18 @@ The basic steps that [!INCLUDE[ssNoVersion](../includes/ssnoversion-md.md)] uses
 [!INCLUDE[ssNoVersion](../includes/ssnoversion-md.md)] uses constant folding with the following types of expressions:
 - Arithmetic expressions, such as 1+1, 5/3*2, that contain only constants.
 - Logical expressions, such as 1=1 and 1>2 AND 3>4, that contain only constants.
+- Deterministic scalar-valued CLR user-defined functions and deterministic methods of CLR user-defined types (starting with [!INCLUDE[ssSQL11](../includes/sssql11-md.md)]). These are foldable only if they are marked as `IsDeterministic=true` and do not perform any data access.
 - Built-in functions that are considered foldable by [!INCLUDE[ssNoVersion](../includes/ssnoversion-md.md)], including `CAST` and `CONVERT`. Generally, an intrinsic function is foldable if it is a function of its inputs only and not other contextual information, such as SET options, language settings, database options, and encryption keys. Nondeterministic functions are not foldable. Deterministic built-in functions are foldable, with some exceptions.
 
 > [!NOTE] 
-> An exception is made for large object types. If the output type of the folding process is a large object type (text, image, nvarchar(max), varchar(max), or varbinary(max)), then [!INCLUDE[ssNoVersion](../includes/ssnoversion-md.md)] does not fold the expression.
+> An exception is made for large object types. If the output type of the folding process is a large object type (ntext, text, image, nvarchar(max), varchar(max), varbinary(max), or xml), then [!INCLUDE[ssNoVersion](../includes/ssnoversion-md.md)] does not fold the expression.
 
 #### Nonfoldable Expressions
 All other expression types are not foldable. In particular, the following types of expressions are not foldable:
 - Nonconstant expressions such as an expression whose result depends on the value of a column.
 - Expressions whose results depend on a local variable or parameter, such as @x.
 - Nondeterministic functions.
-- User-defined functions (both [!INCLUDE[tsql](../includes/tsql-md.md)] and CLR).
+- User-defined functions (both [!INCLUDE[tsql](../includes/tsql-md.md)] and CLR with exceptions noted above under "Foldable Expressions").
 - Expressions whose results depend on language settings.
 - Expressions whose results depend on SET options.
 - Expressions whose results depend on server configuration options.


### PR DESCRIPTION
This PR fixes #3696 .

There are three mistakes in the [Constant Folding](https://docs.microsoft.com/en-us/sql/relational-databases/query-processing-architecture-guide#ConstantFolding) section:

1. There is a "note" that states:

    > If the output type of the folding process is a large object type (text, image, nvarchar(max), varchar(max), or varbinary(max)), then SQL Server does not fold the expression.

    That list of datatypes is missing both `NTEXT` and `XML`.

2. Under "**Nonfoldable Expressions**", it lists:

    > * User-defined functions (both Transact-SQL and CLR)

    That _was_ true until SQL Server 2012. Starting in that version (and still true as of SQL Server 2017), the following two items are foldable _if_ they do not do any data access:

    * Deterministic scalar-valued CLR user-defined functions
    * Deterministic methods of CLR user-defined types

    Please see [Behavior Changes in SQL Server 2012: Constant Folding for CLR User-Defined Functions and Methods](https://docs.microsoft.com/en-us/sql/database-engine/behavior-changes-to-database-engine-features-in-sql-server-2014#constant-folding-for-clr-user-defined-functions-and-methods)

3. The list of items under "**Foldable Expressions**" is missing the two SQLCLR items noted directly above.

---

**Before executing any of the following tests, be sure to enable "Include Actual Execution Plan" (Control-M). After executing each test, just "View the XML Execution Plan".**

The first two queries confirm expected behavior and indicate what it looks like when an expression is _not_ folded.

```sql
SELECT TOP 1 CONVERT(NVARCHAR(50), 'bob') AS [Folded] FROM master.dbo.spt_values;
GO
/*
                <DefinedValues>
                  <DefinedValue>
                    <ColumnReference Column="Expr1004" />
                    <ScalarOperator ScalarString="N'bob'">
                      <Const ConstValue="N'bob'" />
                    </ScalarOperator>
                  </DefinedValue>
                </DefinedValues>
*/


SELECT TOP 1 CONVERT(NVARCHAR(MAX), 'bob') AS [NOT Folded-NVCmax] FROM master.dbo.spt_values;
GO
/*
 <DefinedValues>
   <DefinedValue>
     <ColumnReference Column="Expr1004" />
     <ScalarOperator ScalarString="CONVERT(nvarchar(max),'bob',0)">
       <Identifier>
         <ColumnReference Column="ConstExpr1005">
           <ScalarOperator>
             <Convert DataType="nvarchar(max)" Length="2147483647" Style="0" Implicit="false">
               <ScalarOperator>
                 <Const ConstValue="'bob'" />
               </ScalarOperator>
             </Convert>
           </ScalarOperator>
         </ColumnReference>
       </Identifier>
     </ScalarOperator>
   </DefinedValue>
 </DefinedValues>
*/
```

The next two queries test the other LOB types: `NTEXT` and `XML`.

```sql
-- Current DB's default collation cannot be Supplementary Character-Aware (collation
-- name has either "_SC", or "_140_" but not "_BIN*") else this will receive an error.
GO
SELECT TOP 1 CONVERT(NTEXT, 'bob') AS [NOT Folded-NTEXT] FROM master.dbo.spt_values;
GO
/*
                <DefinedValues>
                  <DefinedValue>
                    <ColumnReference Column="Expr1004" />
                    <ScalarOperator ScalarString="CONVERT(ntext,'bob',0)">
                      <Identifier>
                        <ColumnReference Column="ConstExpr1005">
                          <ScalarOperator>
                            <Convert DataType="ntext" Style="0" Implicit="false">
                              <ScalarOperator>
                                <Const ConstValue="'bob'" />
                              </ScalarOperator>
                            </Convert>
                          </ScalarOperator>
                        </ColumnReference>
                      </Identifier>
                    </ScalarOperator>
                  </DefinedValue>
                </DefinedValues>
*/


SELECT TOP 1 CONVERT(XML, 'bob') AS [NOT Folded-XML] FROM master.dbo.spt_values;
GO
/*
                <DefinedValues>
                  <DefinedValue>
                    <ColumnReference Column="Expr1004" />
                    <ScalarOperator ScalarString="CONVERT(xml,'bob',0)">
                      <Identifier>
                        <ColumnReference Column="ConstExpr1005">
                          <ScalarOperator>
                            <Convert DataType="xml" Style="0" Implicit="false">
                              <ScalarOperator>
                                <Const ConstValue="'bob'" />
                              </ScalarOperator>
                            </Convert>
                          </ScalarOperator>
                        </ColumnReference>
                      </Identifier>
                    </ScalarOperator>
                  </DefinedValue>
                </DefinedValues>
*/
```

For the following SQLCLR tests I use the [SQL\#](https://SQLsharp.com/) library (that I wrote) because not only do I have it installed, but it is easy for anyone to download and install in order to duplicate these tests without needing to code or compile anything. Three of the four functions are available in the Free version, and the 4th function is a test function that isn't available in any public version (it's a rare instance of both being deterministic _and_ doing data access).

The next query shows that SQLCLR UDFs can be folded.

```sql
SELECT SQL#.String_ToTitleCase4k(N'ŧ', N'') AS [Deterministic_NoDataAccess_NoLobTypes];
/*
            <RelOp ...>
              ...
              <ConstantScan>
                <Values>
                  <Row>
                    <ScalarOperator ScalarString="N'Ŧ'">
                      <Const ConstValue="N'Ŧ'" />
                    </ScalarOperator>
                  </Row>
                </Values>
              </ConstantScan>
            </RelOp>
*/
```

The next query shows that by changing the string datatypes to `NVARCHAR(MAX`), the same function (same .NET method, but different T-SQL wrapper object in order to change the datatypes) is no longer foldable.

```sql
SELECT SQL#.String_ToTitleCase(N'ŧ', N'') AS [Deterministic_NoDataAccess_LobType];
/*
  <RelOp ...>
    ...
    <ConstantScan>
      <Values>
        <Row>
          <ScalarOperator ScalarString="[SQL#_Full].[SQL#].[String_ToTitleCase](CONVERT_IMPLICIT(nvarchar(max),N'ŧ',0),N'')">
            <UserDefinedFunction FunctionName="[SQL#_Full].[SQL#].[String_ToTitleCase]" IsClrFunction="true">
              <ScalarOperator>
                <Convert DataType="nvarchar(max)" Length="2147483647" Style="0" Implicit="true">
                  <ScalarOperator>
                    <Const ConstValue="N'ŧ'" />
                  </ScalarOperator>
                </Convert>
              </ScalarOperator>
              <ScalarOperator>
                <Const ConstValue="N''" />
              </ScalarOperator>
              <CLRFunction Assembly="SQL#" Class="STRING" Method="ToTitleCase" />
            </UserDefinedFunction>
          </ScalarOperator>
        </Row>
      </Values>
    </ConstantScan>
  </RelOp>
*/
```

The next query shows that by not being marked as `IsDeterministic=true`, the UDF is not foldable.

```sql
SELECT SQL#.Math_RandomRange(NULL, 11, 200) AS [NonDeterministic_NoDataAccess_NoLobTypes];
/*
  <DefinedValues>
    <DefinedValue>
      <ColumnReference Column="Expr1000" />
      <ScalarOperator ScalarString="[SQL#_Full].[SQL#].[Math_RandomRange](NULL,(11),(200))">
        <UserDefinedFunction FunctionName="[SQL#_Full].[SQL#].[Math_RandomRange]" IsClrFunction="true">
          <ScalarOperator>
            <Const ConstValue="NULL" />
          </ScalarOperator>
          <ScalarOperator>
            <Const ConstValue="(11)" />
          </ScalarOperator>
          <ScalarOperator>
            <Const ConstValue="(200)" />
          </ScalarOperator>
          <CLRFunction Assembly="SQL#" Class="MATH" Method="RandomRange" />
        </UserDefinedFunction>
      </ScalarOperator>
    </DefinedValue>
  </DefinedValues>
*/
```

The next query shows that even with `IsDeterministic=true` and no LOB types, doing data access makes the UDF non-foldable.
<sub>Please note that **TEST\_GetCurrentServerName** is _not_ available in the Free version, or any version, of [SQL\#](https://SQLsharp.com/).</sub>

```sql
SELECT SQL#.TEST_GetCurrentServerName() AS [Deterministic_UserDataAccess_NoLobTypes];
/*
 <DefinedValues>
   <DefinedValue>
     <ColumnReference Column="Expr1000" />
     <ScalarOperator ScalarString="[SQL#_Full].[SQL#].[TEST_GetCurrentServerName]()">
       <UserDefinedFunction FunctionName="[SQL#_Full].[SQL#].[TEST_GetCurrentServerName]" IsClrFunction="true">
         <CLRFunction Assembly="SQL#_2" Class="TEST" Method="GetCurrentServerName" />
       </UserDefinedFunction>
     </ScalarOperator>
   </DefinedValue>
 </DefinedValues>
*/
```


Take care,
Solomon...
https://SqlQuantumLift.com/
https://SqlQuantumLeap.com/
https://SQLsharp.com/

