### PR TITLE
Fix User vs Login for granting exec to "xp_cmdshell"

### DIFF
--- a/docs/relational-databases/system-stored-procedures/xp-cmdshell-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/xp-cmdshell-transact-sql.md
@@ -1,7 +1,7 @@
 ---
 title: "xp_cmdshell (Transact-SQL) | Microsoft Docs"
 ms.custom: ""
-ms.date: "03/16/2017"
+ms.date: "12/01/2019"
 ms.prod: sql
 ms.prod_service: "database-engine"
 ms.reviewer: ""
@@ -91,7 +91,7 @@ EXEC sp_xp_cmdshell_proxy_account 'SHIPPING\KobeR','sdfh%dkc93vcMt0';
     > [!NOTE]  
     >  You can also configure this proxy account using [!INCLUDE[ssManStudioFull](../../includes/ssmanstudiofull-md.md)] by right-clicking **Properties** on your server name in Object Explorer, and looking on the **Security** tab for the **Server proxy account** section.  
   
-3.  In [!INCLUDE[ssManStudio](../../includes/ssmanstudio-md.md)], using the master database, execute the `GRANT exec ON xp_cmdshell TO '<somelogin>'` statement to give specific non-**sysadmin** users the ability to execute **xp_cmdshell**. The specified login must be mapped to a user in the master database.  
+3.  In [!INCLUDE[ssManStudio](../../includes/ssmanstudio-md.md)], using the master database, execute the `GRANT exec ON xp_cmdshell TO N'<some_user>';` statement to give specific non-**sysadmin** users the ability to execute **xp_cmdshell**. The specified user must exist in the master database.  
   
  Now non-administrators can launch operating system processes with **xp_cmdshell** and those processes run with the permissions of the proxy account that you have configured. Users with CONTROL SERVER permission (members of the **sysadmin** fixed server role) will continue to receive the permissions of the [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] service account for child processes that are launched by **xp_cmdshell**.  
   


### PR DESCRIPTION
This PR fixes #3719 .

These two changes regard Item \# 3 under "[Permissions](https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/xp-cmdshell-transact-sql#permissions)" on the "xp_cmdshell" page. That paragraph is currently as follows:

> In Management Studio, using the master database, execute the `GRANT exec ON xp_cmdshell TO '<somelogin>'` statement to give specific non-**sysadmin** users the ability to execute **xp\_cmdshell**. The specified login must be mapped to a user in the master database.

1. `GRANT` statement includes reference to "login" when logins cannot be granted permissions on schema-bound objects.

2. The final sentence of that paragraph states that the login (being granted the permission) needs to be mapped to a user in the `master` database. Yes, a user does need to exist in `master`, but again, this has nothing to do with logins:
    1. The user does not even need to have an associated login (even if that will be the case in 99.99% of cases). { see example 2 }
    2. If the user does have an associated login, the names don't need to be the same, so the focus can't be on login because you have to use the "user" name, not the "login" name. Otherwise, the implication is that as long as the login does have a user mapped in `master`, then it would work to grant permission to the login (assuming different names between login and user such that this is a meaningful distinction).  { see example 1 }

The following example shows:
1. You can't grant permission to the login.
2. The login, having a mapped user in `master`, still can't be granted permission.
3. The _user_ can be granted the permission.

```sql
USE [master];
CREATE LOGIN [Test-Login] WITH PASSWORD = 'oooops', CHECK_POLICY = OFF;


GRANT EXEC ON xp_cmdshell TO [Test-Login];
/*
Msg 15151, Level 16, State 1, Line XXXXX
Cannot find the user 'Test-Login', because it does not exist or you do not have permission.
*/


CREATE USER [Test-User] FOR LOGIN [Test-Login];


GRANT EXEC ON xp_cmdshell TO [Test-Login];
/*
Msg 15151, Level 16, State 1, Line XXXXX
Cannot find the user 'Test-Login', because it does not exist or you do not have permission.
*/


GRANT EXEC ON xp_cmdshell TO [Test-User];
-- Success!!

DROP USER [Test-User];
DROP LOGIN [Test-Login];
```


The following test shows that a user does not even need to have an associated login in order to be granted permission to use `xp_cmdshell`:

```sql
USE [master];
CREATE USER [SansLogin] WITHOUT LOGIN;
GRANT EXEC ON xp_cmdshell TO [SansLogin];

EXECUTE AS USER = N'SansLogin';
SELECT SUSER_NAME() as [LOGIN], USER_NAME() as [USER];
-- S-1-9-3-346486997-1338563376-2712380339-864934077	SansLogin

EXEC xp_cmdshell N'echo t';
/*
Msg 15153, Level 16, State 1, Procedure xp_cmdshell, Line YYYY [Batch Start Line XXXXX]
The xp_cmdshell proxy account information cannot be retrieved or is invalid. Verify that
the '##xp_cmdshell_proxy_account##' credential exists and contains valid information.
*/

REVERT;
DROP USER [SansLogin];
```



Take care,
Solomon...
https://SqlQuantumLift.com/
https://SqlQuantumLeap.com/
https://SQLsharp.com/
