### PR TITLE
Remove reference to Azure SQL DB

### DIFF
--- a/docs/relational-databases/extended-events/view-the-extended-events-equivalents-to-sql-trace-event-classes.md
+++ b/docs/relational-databases/extended-events/view-the-extended-events-equivalents-to-sql-trace-event-classes.md
@@ -18,7 +18,7 @@ monikerRange: "=azuresqldb-current||>=sql-server-2016||=sqlallproducts-allversio
 ---
 # View the Extended Events Equivalents to SQL Trace Event Classes
 
-[!INCLUDE[appliesto-ss-asdb-xxxx-xxx-md](../../includes/appliesto-ss-asdb-xxxx-xxx-md.md)]
+[!INCLUDE[appliesto-ss-xxxx-xxxx-xxx-md](../../includes/appliesto-ss-asdb-xxxx-xxx-md.md)]
 
   If you want to use Extended Events to collect event data that is equivalent to SQL Trace event classes and columns, it is useful to understand how the SQL Trace events map to Extended Events events and actions.  
   


### PR DESCRIPTION
Doesn't appear to work as scripted (with or without reference to Master) in Azure SQL DB.