### PR TITLE
Update hints-transact-sql-query.md add SCALEOUTEXECUTION  hint

### DIFF
--- a/docs/t-sql/queries/hints-transact-sql-query.md
+++ b/docs/t-sql/queries/hints-transact-sql-query.md
@@ -86,7 +86,8 @@ Query hints specify that the indicated hints should be used throughout the query
   | EXPAND VIEWS   
   | FAST number_rows   
   | FORCE ORDER   
-  | { FORCE | DISABLE } EXTERNALPUSHDOWN  
+  | { FORCE | DISABLE } EXTERNALPUSHDOWN
+  | { FORCE | DISABLE } SCALEOUTEXECUTION
   | IGNORE_NONCLUSTERED_COLUMNSTORE_INDEX  
   | KEEP PLAN   
   | KEEPFIXED PLAN  
@@ -162,7 +163,10 @@ Specifies that the join order indicated by the query syntax is preserved during 
   
 { FORCE | DISABLE } EXTERNALPUSHDOWN  
 Force or disable the pushdown of the computation of qualifying expressions in Hadoop. Only applies to queries using PolyBase. Won't push down to Azure storage.  
-  
+
+{ FORCE | DISABLE } SCALEOUTEXECUTION
+Force or disable scale out execution of PolyBase queries that are using External tables in a SQL Server 2019 Big Data Cluster. This hint will only be honored by a query using the master instance of a SQL Big Data Cluster. The scale out will occur across the Compute Pool of the Big Data cluster. 
+
 KEEP PLAN  
 Forces the Query Optimizer to relax the estimated recompile threshold for a query. The estimated recompile threshold starts an automatic recompile for the query when the estimated number of indexed column changes have been made to a table by running one of the following statements:
 

--- a/docs/t-sql/queries/hints-transact-sql-query.md
+++ b/docs/t-sql/queries/hints-transact-sql-query.md
@@ -165,7 +165,7 @@ Specifies that the join order indicated by the query syntax is preserved during 
 Force or disable the pushdown of the computation of qualifying expressions in Hadoop. Only applies to queries using PolyBase. Won't push down to Azure storage.  
 
 { FORCE | DISABLE } SCALEOUTEXECUTION
-Force or disable scale out execution of PolyBase queries that are using External tables in a SQL Server 2019 Big Data Cluster. This hint will only be honored by a query using the master instance of a SQL Big Data Cluster. The scale out will occur across the Compute Pool of the Big Data cluster. 
+Force or disable scale out execution of PolyBase queries that are using external tables in a SQL Server 2019 big data cluster. This hint will only be honored by a query using the master instance of a SQL big data cluster. The scale out will occur across the compute pool of the big data cluster. 
 
 KEEP PLAN  
 Forces the Query Optimizer to relax the estimated recompile threshold for a query. The estimated recompile threshold starts an automatic recompile for the query when the estimated number of indexed column changes have been made to a table by running one of the following statements:


### PR DESCRIPTION
{ FORCE | DISABLE } SCALEOUTEXECUTION Query hint was added for SQL 2019 Big Data Clusters around the CTP 2.3 timeframe, but was never documented. Added this hint to the document