### PR TITLE
The word 'display' was misspelled

### DIFF
--- a/docs/reporting-services/report-builder/rendering-to-html-report-builder-and-ssrs.md
+++ b/docs/reporting-services/report-builder/rendering-to-html-report-builder-and-ssrs.md
@@ -81,7 +81,7 @@ ms.author: maggies
  Additional search and find functionality is provided by the ReportViewer Web Forms control.  
   
 ##  <a name="FontsOnClient"></a> Fonts on the Client Computer
- When a custom font is used within the report, the computer that is used to view the report (the client computer) must have the custom font installed for the report to display correctly. If the font is not installed on the client computer, the report will diplay a system default font instead of the custom font.
+ When a custom font is used within the report, the computer that is used to view the report (the client computer) must have the custom font installed for the report to display correctly. If the font is not installed on the client computer, the report will display a system default font instead of the custom font.
   
 ##  <a name="DeviceInfo"></a> Device Information Settings  
  You can change some default settings for this renderer, including which mode to render in, by changing the device information settings. For more information, see [HTML Device Information Settings](../../reporting-services/html-device-information-settings.md).  


### PR DESCRIPTION
The word 'display' was misspelled in the "Fonts on the Client Computer" section