### PR TITLE
Missing SQL14 as subscriber for merge repl

### DIFF
--- a/docs/includes/replication-compat-matrix.md
+++ b/docs/includes/replication-compat-matrix.md
@@ -21,7 +21,7 @@
 ### Merge Replication Support Matrix
 | **Publisher**   | **Distributor** | **Subscriber** |
 | :------------   | :-------------- | :------------- |
-| SQL Server 2019 | SQL Server 2019 | SQL Server 2019 <br/> SQL Server 2017 <br/> SQL Server 2016 <br/> SQL Server 2012 <br/> SQL Server 2008 R2 <br/> SQL Server 2008 <br/>   |
+| SQL Server 2019 | SQL Server 2019 | SQL Server 2019 <br/> SQL Server 2017 <br/> SQL Server 2016 <br/> SQL Server 2014 <br/> SQL Server 2012 <br/> SQL Server 2008 R2 <br/> SQL Server 2008 <br/>   |
 | SQL Server 2017 | SQL Server 2019 <br/>SQL Server 2017 | SQL Server 2017 <br/> SQL Server 2016 <br/> SQL Server 2014 <br/> SQL Server 2012 <br/> SQL Server 2008 R2 <br/> SQL Server 2008 <br/>  |
 | SQL Server 2016 | SQL Server 2019 <br/>SQL Server 2017 <br/> SQL Server 2016 |SQL Server 2016 <br/> SQL Server 2014 <br/> SQL Server 2012 <br/> SQL Server 2008 R2 <br/> SQL Server 2008 |
 | SQL Server 2014 | SQL Server 2019 <br/> SQL Server 2017 <br/> SQL Server 2016 <br/> SQL Server 2014 <br/>| SQL Server 2014 <br/> SQL Server 2012 <br/> SQL Server 2008 R2 <br/> SQL Server 2008 |


### PR DESCRIPTION
For SQL 2019, in merge replication (different rules for transactional) we support from SQL2008 to SQL 2019 subscribers but we omit SQL 2014 in the list