### PR TITLE
Update Powershell script to Change ownership for all subscriptions ow…

### DIFF
--- a/docs/reporting-services/subscriptions/manage-subscription-owners-and-run-subscription-powershell.md
+++ b/docs/reporting-services/subscriptions/manage-subscription-owners-and-run-subscription-powershell.md
@@ -211,7 +211,7 @@ ForEach ($item in $items)
         $curRepSubs = $rs2010.ListSubscriptions($item.Path);  
         ForEach ($curRepSub in $curRepSubs)  
         {  
-            if ($curRepSub.Owner -eq $previousOwner)  
+            if ($curRepSub.Owner -eq $currentOwner)  
             {  
                 $subscriptions += $curRepSub;  
             }  


### PR DESCRIPTION
…ned by a specific user

Change the parameter within the IF block of the ForEach Block from $previousOwner to $currentOwner as the parameter has been declared with the name $currentOwner. The script does not work when $previousOwner is used