### PR TITLE
Modification to the default instance web portal URL mentioned

### DIFF
--- a/docs/reporting-services/install-windows/about-url-reservations-and-registration-ssrs-configuration-manager.md
+++ b/docs/reporting-services/install-windows/about-url-reservations-and-registration-ssrs-configuration-manager.md
@@ -79,8 +79,8 @@ ms.author: maggies
   
 |Instance Type|Application|Default URL|Actual URL reservation in HTTP.SYS|  
 |-------------------|-----------------|-----------------|----------------------------------------|  
-|Default instance|Report Server Web service|`https://\<servername>/reportserver`|`https://<servername>:80/reportserver`|  
-|Default instance|Web portal|`https://<servername>/reportserver`|`https://<servername>:80/reportserver`|  
+|Default instance|Report Server Web service|`https://<servername>/reportserver`|`https://<servername>:80/reportserver`|  
+|Default instance|Web portal|`https://<servername>/reports`|`https://<servername>:80/reports`|  
 |Named instance|Report Server Web service|`https://<servername>/reportserver_<instancename>`|`https://<servername>:80/reportserver_<instancename>`|  
 |Named instance|Web portal|`https://<servername>/reports_<instancename>`|`https://<servername>:80/reports_<instancename>`|  
 |SQL Server Express|Report Server Web service|`https://<servername>/reportserver_SQLExpress`|`https://<servername>:80/reportserver_SQLExpress`|  


### PR DESCRIPTION
The SSRS web portal by default is reserved as https://<servername>/reports and not https://<servername>/reportserver. Requesting modification of the document to include the right URL