### PR TITLE
Discuss custom deployments that schedule pods to k8s master

### DIFF
--- a/docs/big-data-cluster/deployment-custom-configuration.md
+++ b/docs/big-data-cluster/deployment-custom-configuration.md
@@ -462,6 +462,8 @@ azdata bdc config add -c custom-bdc/bdc.json -j "$.spec.resources.zookeeper.spec
 azdata bdc config add -c custom-bdc/bdc.json -j "$.spec.resources.gateway.spec.nodeLabel=bdc-shared"
 azdata bdc config add -c custom-bdc/bdc.json -j "$.spec.resources.appproxy.spec.nodeLabel=bdc-shared"
 ```
+>[!NOTE]
+> If you plan on assigning these roles to the Kubernetes master node, you'll need to [remove its ``master:NoSchedule`` taint.](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) Be aware that this could overload the master node and inhibit its ability to perform its Kubernetes management duties on larger clusters. It's normal to see some pods scheduled to the master on any deployment: they already tolerate the ``master:NoSchedule`` taint, and they're mostly used to help manage the cluster. 
 
 ## <a id="jsonpatch"></a> Other customizations using JSON patch files
 

--- a/docs/big-data-cluster/deployment-custom-configuration.md
+++ b/docs/big-data-cluster/deployment-custom-configuration.md
@@ -463,7 +463,7 @@ azdata bdc config add -c custom-bdc/bdc.json -j "$.spec.resources.gateway.spec.n
 azdata bdc config add -c custom-bdc/bdc.json -j "$.spec.resources.appproxy.spec.nodeLabel=bdc-shared"
 ```
 >[!NOTE]
-> If you plan on assigning these roles to the Kubernetes master node, you'll need to [remove its ``master:NoSchedule`` taint.](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) Be aware that this could overload the master node and inhibit its ability to perform its Kubernetes management duties on larger clusters. It's normal to see some pods scheduled to the master on any deployment: they already tolerate the ``master:NoSchedule`` taint, and they're mostly used to help manage the cluster. 
+> Best practice avoids giving the Kubernetes master any of the above BDC roles. If you plan on assigning these roles to the Kubernetes master node anyway, you'll need to [remove its ``master:NoSchedule`` taint.](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) Be aware that this could overload the master node and inhibit its ability to perform its Kubernetes management duties on larger clusters. It's normal to see some pods scheduled to the master on any deployment: they already tolerate the ``master:NoSchedule`` taint, and they're mostly used to help manage the cluster. 
 
 ## <a id="jsonpatch"></a> Other customizations using JSON patch files
 


### PR DESCRIPTION
More commentary from the same user mentioned in some of my prior pulls. While I don't think we should _encourage_ deployments that use the master to do BDC work per-se, it's not a wholly unreasonable usecase for single-node or other small deployments, especially for lighter-on-compute pools like `shared`.