### PR TITLE
Remove comma in select statement

### DIFF
--- a/docs/relational-databases/extended-events/targets-for-extended-events-in-sql-server.md
+++ b/docs/relational-databases/extended-events/targets-for-extended-events-in-sql-server.md
@@ -669,7 +669,7 @@ To see the preceding XML, you can issue the following SELECT while the event ses
 
 ```sql
 SELECT
-		CAST(LocksAcquired.TargetXml AS XML)  AS RBufXml,
+		CAST(LocksAcquired.TargetXml AS XML)  AS RBufXml
 	INTO
 		#XmlAsTable
 	FROM


### PR DESCRIPTION
The comma after "CAST(LocksAcquired.TargetXml AS XML)  AS RBufXml" prevents the code from running.