### PR TITLE
Update sqlbindcol-function.md

### DIFF
--- a/docs/odbc/reference/syntax/sqlbindcol-function.md
+++ b/docs/odbc/reference/syntax/sqlbindcol-function.md
@@ -289,7 +289,7 @@ SQLRETURN SQLBindCol(
 #include <sqlext.h>  
   
 #define NAME_LEN 50  
-#define PHONE_LEN 20  
+#define PHONE_LEN 60
   
 void show_error() {  
    printf("error\n");  
@@ -334,7 +334,7 @@ int main() {
                   retcode = SQLBindCol(hstmt, 3, SQL_C_CHAR, szPhone, PHONE_LEN, &cbPhone);   
   
                   // Fetch and print each row of data. On an error, display a message and exit.  
-                  for (i ; ; i++) {  
+                  for (int i=0 ; ; i++) {  
                      retcode = SQLFetch(hstmt);  
                      if (retcode == SQL_ERROR || retcode == SQL_SUCCESS_WITH_INFO)  
                         show_error();  


### PR DESCRIPTION
Please change

#define PHONE_LEN 20

to

#define PHONE_LEN 60

The reason is that in the Northwind.dbo.customers table, the Phone column is defined as nvarchar(24).

Without that change we are getting error that reads 
[stringData.rightTruncation.01.20200101.1117PM.txt](https://github.com/MicrosoftDocs/sql-docs/files/4015128/stringData.rightTruncation.01.20200101.1117PM.txt)
"String data, right truncation"