### PR TITLE
Update sql-server-linux-active-directory-authentication.md

### DIFF
--- a/docs/linux/sql-server-linux-active-directory-authentication.md
+++ b/docs/linux/sql-server-linux-active-directory-authentication.md
@@ -190,6 +190,7 @@ Make sure you've installed the [mssql-tools](sql-server-linux-setup-tools.md) pa
 ```bash
 sqlcmd -S mssql-host.contoso.com
 ```
+Different from SQL Windows, Kerberos authentication works for local connection in SQL Linux. You can test the Windows Authentication in the SQL Linux box.
 
 ### SSMS on a domain-joined Windows client
 

--- a/docs/linux/sql-server-linux-active-directory-authentication.md
+++ b/docs/linux/sql-server-linux-active-directory-authentication.md
@@ -190,7 +190,7 @@ Make sure you've installed the [mssql-tools](sql-server-linux-setup-tools.md) pa
 ```bash
 sqlcmd -S mssql-host.contoso.com
 ```
-Different from SQL Windows, Kerberos authentication works for local connection in SQL Linux. You can test the Windows Authentication in the SQL Linux box.
+Different from SQL Windows, Kerberos authentication works for local connection in SQL Linux. However, you still need to provide the FQDN of the SQL Linux host, and AD Authentication will not work if you attempt to connect to '.' ,'localhost','127.0.0.1',etc.
 
 ### SSMS on a domain-joined Windows client
 


### PR DESCRIPTION
Kerberos authentication only works for remote session in SQL Windows platform. SQL Linux makes it available for local connection.

I added following statement in section 'Connect to SQL Server using AD Authentication'
Different from SQL Windows, Kerberos authentication works for local connection in SQL Linux. You can test the Windows Authentication in the SQL Linux box.