### PR TITLE
Update collation-and-unicode-support.md

### DIFF
--- a/docs/relational-databases/collations/collation-and-unicode-support.md
+++ b/docs/relational-databases/collations/collation-and-unicode-support.md
@@ -523,8 +523,6 @@ If you use supplementary characters:
 -   Supplementary characters can be used in ordering and comparison operations in collation versions 90 or greater.    
 -   All version 100 collations support linguistic sorting with supplementary characters.    
 -   Supplementary characters aren't supported for use in metadata, such as in names of database objects.    
--   Databases that use collations with supplementary characters (\_SC) can't be enabled for [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] Replication. This is because some of the system tables and stored procedures that are created for replication use the legacy **ntext** data type, which doesn't support supplementary characters.  
-
 -   The SC flag can be applied to:    
     -   Version 90 collations    
     -   Version 100 collations    


### PR DESCRIPTION
Removing the limitation of supplementary characters in Replication due to an internal table having an NTEXT column. As of SQL Server versions 2014 SP3, 2016 SP2, and 2017 CU5, the NTEXT has been replaced with NVARCHAR(max), thus making supplementary characters possible.

@pmasl - can you have a look?