### PR TITLE
Update collation-and-unicode-support.md

### DIFF
--- a/docs/relational-databases/collations/collation-and-unicode-support.md
+++ b/docs/relational-databases/collations/collation-and-unicode-support.md
@@ -473,16 +473,12 @@ When you move data from a server to a client, your server collation might not be
 To use the UTF-8 collations that are available in [!INCLUDE[sql-server-2019](../../includes/sssqlv15-md.md)], and to improve searching and sorting of some Unicode characters (Windows collations only), you must select UTF-8 encoding-enabled collations(\_UTF8).
  
 -   The UTF8 flag can be applied to:    
-    -   Version 90 collations 
-        > [!NOTE]
-        > Only when supplementary characters (\_SC) or variation-selector-sensitive (\_VSS) aware collations already exist in this version.
-    -   Version 100 collations    
-    -   Version 140 collations   
+    -   Linguistic collations that already support supplementary characters (\_SC) or variation-selector-sensitive (\_VSS) awareness
     -   BIN2<sup>1</sup> binary collation
     
 -   The UTF8 flag can't be applied to:    
-    -   Version 90 collations that don't support supplementary characters (\_SC) or variation-selector-sensitive (\_VSS)    
-    -   The BIN or BIN2<sup>2</sup> binary collations    
+    -   Linguistic collations that don't support supplementary characters (\_SC) or variation-selector-sensitive (\_VSS) awareness
+    -   The BIN or BIN2<sup>2</sup> binary collations
     -   The SQL\_* collations  
     
 <sup>1</sup> Starting with [!INCLUDE[sql-server-2019](../../includes/sssqlv15-md.md)] CTP 2.3. [!INCLUDE[sql-server-2019](../../includes/sssqlv15-md.md)] CTP 3.0 replaced collation **UTF8_BIN2** with **Latin1_General_100_BIN2_UTF8**.        


### PR DESCRIPTION
Removing misleading note about UTF8 flag being applicable to Version 90 _SC and _VSS collations. The note is misleading due to the following reasons:
- There are no _VSS collations in any version except 140. 
- For collations version 100 and 140, the UTF8 flag can also be applied only to _SC (both 100 and 140) and _VSS (140) collations. The _VSS implies _SC, and _SC is what's really needed for the UTF8 flag to apply.

The "can't be applied" section" also only references version 90 for _SC and _VSS, which is wrong due to the same reason.

The best thing is to simply remove version splitting, and say that all linguistic collations must have either _SC or _VSS to have UTF8 flag applicable to them. I simplified the language and removed the unnecessary version details.

@pmasl @bluefooted - can you please review?