### PR TITLE
Correct release date for SQL 2019 CU1

### DIFF
--- a/docs/database-engine/install-windows/latest-updates-for-microsoft-sql-server.md
+++ b/docs/database-engine/install-windows/latest-updates-for-microsoft-sql-server.md
@@ -25,7 +25,7 @@ Each of the following links provides information for all of the applicable produ
 
 |Product Versions   | Latest Service Pack |  Latest GDR | Latest cumulative update | CU Release Date | General Guidance  |
 |--|--|--|--|--|--|
-|SQL Server 2019|N/A|[KB 4517790](https://support.microsoft.com/help/4517790)|CU 1 [(KB 4527376)](https://support.microsoft.com/help/4527376)|1/7/2019|[SQL Server 2019 Installation](https://docs.microsoft.com/sql/database-engine/install-windows/installation-for-sql-server)|
+|SQL Server 2019|N/A|[KB 4517790](https://support.microsoft.com/help/4517790)|CU 1 [(KB 4527376)](https://support.microsoft.com/help/4527376)|1/7/2020|[SQL Server 2019 Installation](https://docs.microsoft.com/sql/database-engine/install-windows/installation-for-sql-server)|
 |SQL Server 2017|N/A|[KB 4505224](https://support.microsoft.com/help/4505224)|CU 18 [(KB 4527377)](https://support.microsoft.com/help/4527377)|12/9/2019|[SQL Server 2017 Installation](https://docs.microsoft.com/sql/database-engine/install-windows/installation-for-sql-server)|
 |SQL Server 2016|SP2 [(KB 4052908)](https://support.microsoft.com/help/4052908)|[KB 4505220](https://support.microsoft.com/help/4505220)|CU 11 [(KB 4527378)](https://support.microsoft.com/kb/4527378)|12/9/2019|[SQL Server 2016 Installation](https://technet.microsoft.com/library/bb500469.aspx)|
 |SQL Server 2016|SP1 [(KB 3182545)](https://support.microsoft.com/help/3182545/sql-server-2016-service-pack-1-release-information)|[KB 4505219](https://support.microsoft.com/help/4505219)|CU 15 + GDR [(KB 4505221)](https://support.microsoft.com/help/4505221)|7/9/2019|[SQL Server 2016 Installation](https://technet.microsoft.com/library/bb500469.aspx)|


### PR DESCRIPTION
There's a typo for the release date of SQL Server 2019 Cumulative Update 1.  It currently says January 7, 2019, but it was actually released on January 7, 2020.