### PR TITLE
Fix example to match the description

### DIFF
--- a/docs/t-sql/statements/create-credential-transact-sql.md
+++ b/docs/t-sql/statements/create-credential-transact-sql.md
@@ -97,7 +97,7 @@ GO
 
 ### B. Creating a Credential for EKM
 
-The following example uses a previously created account called `User1OnEKM` on an EKM module through the EKM's Management tools, with a basic account type and password. The **sysadmin** account on the server creates a credential that is used to connect to the EKM account, and assigns it to the `User1`[!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] account:
+The following example uses a previously created account called `User1OnEKM` on an EKM module through the EKM's Management tools, with a basic account type and password. The **sysadmin** account on the server creates a credential that is used to connect to the EKM account, and assigns it to the `User1` [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] account:
 
 ```sql
 CREATE CREDENTIAL CredentialForEKM
@@ -106,13 +106,8 @@ CREATE CREDENTIAL CredentialForEKM
 GO
 
 /* Modify the login to assign the cryptographic provider credential */
-ALTER LOGIN Login1
+ALTER LOGIN User1
 ADD CREDENTIAL CredentialForEKM;
-
-/* Modify the login to assign a non cryptographic provider credential */
-ALTER LOGIN Login1
-WITH CREDENTIAL = AlterEgo;
-GO
 ```
 
 ### C. Creating a Credential for EKM Using the Azure Key Vault


### PR DESCRIPTION
The credential provider is assigned to User1 and not Login1.
According to docs only the "ADD CREDENTIAL CredentialForEKM" is needed.
https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-login-transact-sql?view=sql-server-ver15#f-mapping-a-login-to-an-extensible-key-management-credential

The following assignment seems to be needed for the previous example where the AlterEgo credentials were defined.
/* Modify the login to assign a non cryptographic provider credential */
ALTER LOGIN Login1
WITH CREDENTIAL = AlterEgo;
GO