### PR TITLE
Update to add clarity to how TRANSLATE works

### DIFF
--- a/docs/t-sql/functions/translate-transact-sql.md
+++ b/docs/t-sql/functions/translate-transact-sql.md
@@ -48,7 +48,9 @@ Returns a character expression of the same data type as `inputString` where char
 
 `TRANSLATE` will return an error if *characters* and *translations* expressions have different lengths. `TRANSLATE` will return NULL if any of the arguments are NULL.  
 
-The behavior of the `TRANSLATE` function is similar to using multiple [REPLACE](../../t-sql/functions/replace-transact-sql.md) functions. `TRANSLATE` does not, however, replace a character more than once. This is dissimilar to multiple `REPLACE` functions, as each use would replace all relevant characters. 
+The behavior of the `TRANSLATE` function is similar to using multiple [REPLACE](../../t-sql/functions/replace-transact-sql.md) functions. `TRANSLATE` does not, however, replace any individual character in `inputString` more than once. A single value in the `characters` parameter, can replace multiple characters in `inputString`. 
+
+This is dissimilar to the behavior of multiple `REPLACE` functions, as each function call would replace all relevant characters, even if they had been replaced by a previous nested `REPLACE` function call. 
 
 `TRANSLATE` is always SC collation aware.
 


### PR DESCRIPTION
The previous description makes it sound like TRANSLATE will not make multiple replacements. Many people think it won't replace say all the square brackets when using TRANSLATE('[[00]] 2343:2342', '[]:', '()-') and that only the first instance of each character would be replaced. This isn't how the function works, so I've added text to clarify.