### PR TITLE
About locking with REORGANIZE

### DIFF
--- a/docs/t-sql/statements/alter-index-transact-sql.md
+++ b/docs/t-sql/statements/alter-index-transact-sql.md
@@ -252,7 +252,7 @@ PARTITION
  REORGANIZE a **rowstore** index  
  For rowstore indexes, REORGANIZE specifies to reorganize the index leaf level. The REORGANIZE operation is:  
   
--   Always performed online. This means long-term blocking table locks are not held and queries or updates to the underlying table can continue during the ALTER INDEX REORGANIZE transaction.  
+-	It locks the object using schema shared locks (Sch-S) and exclusive locks. If another session reads data using NOLOCK hint, it will bypass the REORGANIZE (REBUILD blocks all, including statements with NOLOCK hint). Statements that modify data are always blocked.
 -   Not allowed for a disabled index  
 -   Not allowed when ALLOW_PAGE_LOCKS is set to OFF  
 -   Not rolled back when it is performed within a transaction and the transaction is rolled back.  

--- a/docs/t-sql/statements/alter-index-transact-sql.md
+++ b/docs/t-sql/statements/alter-index-transact-sql.md
@@ -252,13 +252,13 @@ PARTITION
  REORGANIZE a **rowstore** index  
  For rowstore indexes, REORGANIZE specifies to reorganize the index leaf level. The REORGANIZE operation is:  
   
--   Always performed online. This means long-term blocking table locks are not held and queries or updates to the underlying table can continue during the ALTER INDEX REORGANIZE transaction.   
--   Not allowed for a disabled index  
--   Not allowed when ALLOW_PAGE_LOCKS is set to OFF  
--   Not rolled back when it is performed within a transaction and the transaction is rolled back.  
+-   Always performed online. This means long-term blocking table locks are not held and queries or updates to the underlying table can continue during the ALTER INDEX REORGANIZE transaction.
+-   Not allowed for a disabled index.
+-   Not allowed when ALLOW_PAGE_LOCKS is set to OFF.
+-   Not rolled back when it is performed within a transaction and the transaction is rolled back.
 
 > [!NOTE]
-> When ALTER INDEX REORGANIZE uses explicit transactions (e.g., ALTER INDEX inside a BEGIN TRAN ... COMMIT/ROLLBACK) instead of the default implicit transaction mode, the locking behavior of REORGANIZE becomes more restrictive, potentially causing blocking. For more information on implicit transactions, see [SET IMPLICIT_TRANSACTIONS &#40;Transact-SQL&#41;](../../t-sql/statements/set-implicit-transactions-transact-sql.md)
+> When ALTER INDEX REORGANIZE uses explicit transactions (for example, ALTER INDEX inside a BEGIN TRAN ... COMMIT/ROLLBACK) instead of the default implicit transaction mode, the locking behavior of REORGANIZE becomes more restrictive, potentially causing blocking. For more information about implicit transactions, see [SET IMPLICIT_TRANSACTIONS &#40;Transact-SQL&#41;](../../t-sql/statements/set-implicit-transactions-transact-sql.md).
 
 For more information, see [Reorganize and Rebuild Indexes](../../relational-databases/indexes/reorganize-and-rebuild-indexes.md). 
 

--- a/docs/t-sql/statements/alter-index-transact-sql.md
+++ b/docs/t-sql/statements/alter-index-transact-sql.md
@@ -258,7 +258,7 @@ PARTITION
 -   Not rolled back when it is performed within a transaction and the transaction is rolled back.  
 
 > [!NOTE]
-> If using explicit transactions instead of the default implicit transaction mode (e.g., ALTER INDEX within BEGIN TRAN ... COMMIT/ROLLBACK), the locking behavior of REORGANIZE becomes more restrictive. For more information on implicit transactions, see [SET IMPLICIT_TRANSACTIONS &#40;Transact-SQL&#41;](../../t-sql/statements/set-implicit-transactions-transact-sql.md)
+> When ALTER INDEX REORGANIZE uses explicit transactions (e.g., ALTER INDEX inside a BEGIN TRAN ... COMMIT/ROLLBACK) instead of the default implicit transaction mode, the locking behavior of REORGANIZE becomes more restrictive, potentially causing blocking. For more information on implicit transactions, see [SET IMPLICIT_TRANSACTIONS &#40;Transact-SQL&#41;](../../t-sql/statements/set-implicit-transactions-transact-sql.md)
 
 For more information, see [Reorganize and Rebuild Indexes](../../relational-databases/indexes/reorganize-and-rebuild-indexes.md). 
 

--- a/docs/t-sql/statements/alter-index-transact-sql.md
+++ b/docs/t-sql/statements/alter-index-transact-sql.md
@@ -252,10 +252,13 @@ PARTITION
  REORGANIZE a **rowstore** index  
  For rowstore indexes, REORGANIZE specifies to reorganize the index leaf level. The REORGANIZE operation is:  
   
--	It locks the object using schema shared locks (Sch-S) and exclusive locks. If another session reads data using NOLOCK hint, it will bypass the REORGANIZE (REBUILD blocks all, including statements with NOLOCK hint). Statements that modify data are always blocked.
+-   Always performed online. This means long-term blocking table locks are not held and queries or updates to the underlying table can continue during the ALTER INDEX REORGANIZE transaction.   
 -   Not allowed for a disabled index  
 -   Not allowed when ALLOW_PAGE_LOCKS is set to OFF  
 -   Not rolled back when it is performed within a transaction and the transaction is rolled back.  
+
+> [!NOTE]
+> If using explicit transactions instead of the default implicit transaction mode (e.g., ALTER INDEX within BEGIN TRAN ... COMMIT/ROLLBACK), the locking behavior of REORGANIZE becomes more restrictive. For more information on implicit transactions, see [SET IMPLICIT_TRANSACTIONS &#40;Transact-SQL&#41;](../../t-sql/statements/set-implicit-transactions-transact-sql.md)
 
 For more information, see [Reorganize and Rebuild Indexes](../../relational-databases/indexes/reorganize-and-rebuild-indexes.md). 
 


### PR DESCRIPTION
Original text says that REORGANIZE not block concurrent readers and writers. But is not true.

Use following code to check this:

```sql
-- create some test table
create table __reorgtest(c int);

-- create sample nonclustered index
create index x on __reorgtest(c);

-- insert some data
insert into __reorgtest values(2020);
go 1000


-- Open another session and run this (we call Session X):
begin tran;;
alter index x on __reorgtest reorganize;

-- Open another session and run this (we call session Y):
begin tran;;
select count(*) from __reorgtest

-- On this session, check tran_locks! 
select * from sys.dm_tran_locks where request_session_id in (  X,Y ) -- replace and y by sessions id opened above.

-- Current behavior on my tests: Session Y gets blocked by X.
-- THe inverse can be checked: Try start first a select (wth holdlock) or update operation on some row, and try start X(reorganize). Reorganize gets blocked!

```


Behavior checked on 
* Microsoft SQL Server 2019 (RTM-GDR) (KB4517790) - 15.0.2070.41 (X64)   Oct 28 2019 19:56:59   Copyright (C) 2019 Microsoft Corporation  Developer Edition (64-bit) on Windows 10 Home Single Language 10.0 <X64> (Build 18363: ) 
* Microsoft SQL Server 2016 (SP2-CU10) (KB4524334) - 13.0.5492.2 (X64)   Oct  4 2019 19:14:08   Copyright (c) Microsoft Corporation  Standard Edition (64-bit) on Windows Server 2012 R2 Standard 6.3 <X64> (Build 9600: )