### PR TITLE
Configure firewall for SQL Server named instance.

### DIFF
--- a/docs/relational-databases/polybase/configure-scale-out-groups-windows.md
+++ b/docs/relational-databases/polybase/configure-scale-out-groups-windows.md
@@ -55,7 +55,7 @@ This walks through the steps of configuring a PolyBase Group using:
   
 3. On the Server Configuration page, use the **domain account** PQTH4A\PolyBaseUser for SQL Server PolyBase Engine and SQL Server PolyBase Data Movement Service.
   
-4. On the PolyBase Configuration page, select the option **Use the SQL Server instance as part of a PolyBase scale-out group**. This opens  the firewall  to allow incoming connections to the PolyBase services.
+4. On the PolyBase Configuration page, select the option **Use the SQL Server instance as part of a PolyBase scale-out group**. This opens  the firewall  to allow incoming connections to the PolyBase services.(Please note, for named instance, you need to configure windows firewall manually to expose the port of SQL Server instance)
   
 5. After setup is complete, run **services.msc**. Verify that SQL Server, PolyBase Engine and PolyBase Data Movement Service are running.
   


### PR DESCRIPTION
There is a defect that 1433 is added into Windows firewall even it's a named instance.
I added following statement:
the Please note, for named instance, you need to configure windows firewall manually to expose the port of SQL Server instance