### PR TITLE
Add more detail about SQL Server named instance.

### DIFF
--- a/docs/relational-databases/polybase/configure-scale-out-groups-windows.md
+++ b/docs/relational-databases/polybase/configure-scale-out-groups-windows.md
@@ -55,7 +55,7 @@ This walks through the steps of configuring a PolyBase Group using:
   
 3. On the Server Configuration page, use the **domain account** PQTH4A\PolyBaseUser for SQL Server PolyBase Engine and SQL Server PolyBase Data Movement Service.
   
-4. On the PolyBase Configuration page, select the option **Use the SQL Server instance as part of a PolyBase scale-out group**. This opens  the firewall  to allow incoming connections to the PolyBase services. If the head node is a named instance, you need to manually add the port of SQL Server to Windows firewall on head node, also start the SQL Browser on head node.
+4. On the PolyBase Configuration page, select the option **Use the SQL Server instance as part of a PolyBase scale-out group**. This opens  the firewall  to allow incoming connections to the PolyBase services. If the head node is a named instance, you must manually add the SQL Server port to the Windows firewall on the head node and also start the SQL Browser on the head node.
   
 5. After setup is complete, run **services.msc**. Verify that SQL Server, PolyBase Engine and PolyBase Data Movement Service are running.
   

--- a/docs/relational-databases/polybase/configure-scale-out-groups-windows.md
+++ b/docs/relational-databases/polybase/configure-scale-out-groups-windows.md
@@ -55,7 +55,7 @@ This walks through the steps of configuring a PolyBase Group using:
   
 3. On the Server Configuration page, use the **domain account** PQTH4A\PolyBaseUser for SQL Server PolyBase Engine and SQL Server PolyBase Data Movement Service.
   
-4. On the PolyBase Configuration page, select the option **Use the SQL Server instance as part of a PolyBase scale-out group**. This opens  the firewall  to allow incoming connections to the PolyBase services.
+4. On the PolyBase Configuration page, select the option **Use the SQL Server instance as part of a PolyBase scale-out group**. This opens  the firewall  to allow incoming connections to the PolyBase services. If the head node is a named instance, you need to manually add the port of SQL Server to Windows firewall on head node, also start the SQL Browser on head node.
   
 5. After setup is complete, run **services.msc**. Verify that SQL Server, PolyBase Engine and PolyBase Data Movement Service are running.
   


### PR DESCRIPTION
The current version does not cover the named instance, which will cause the Data movement fail to start . I added following statement: If the head node is a named instance, you need to manually add the port of SQL Server to Windows firewall on head node, also start the SQL Browser on head node.