### PR TITLE
IP address is not supported

### DIFF
--- a/docs/relational-databases/replication/tutorial-preparing-the-server-for-replication.md
+++ b/docs/relational-databases/replication/tutorial-preparing-the-server-for-replication.md
@@ -176,7 +176,8 @@ Configuring a publisher with a remote distributor is outside the scope of this t
    !["Configure Distribution" command on the shortcut menu](media/tutorial-preparing-the-server-for-replication/configuredistribution.png)
   
    > [!NOTE]  
-   > If you have connected to [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] by using **localhost** rather than the actual server name, you'll be prompted with a warning that [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] cannot connect to **localhost**. Select **OK** in the warning dialog box. In the **Connect to Server** dialog box, change **Server name** from **localhost** to the name of your server. Then select **Connect**.  
+   > If you have connected to [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] by using **localhost** rather than the actual server name, you'll be prompted with a warning that [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] cannot connect to **localhost or IP Address**. Select **OK** in the warning dialog box. In the **Connect to Server** dialog box, change **Server name** from **localhost or IP Address** to the name of your server. Then select **Connect**.  
+   > Currently, SSMS 18.0 – 18.4 has issue, which does not show the error message, so please use the actual server name to connect Object Explorer before configuring a Distributer.
   
    The Distribution Configuration Wizard starts.  
   

--- a/docs/relational-databases/replication/tutorial-preparing-the-server-for-replication.md
+++ b/docs/relational-databases/replication/tutorial-preparing-the-server-for-replication.md
@@ -177,8 +177,8 @@ Configuring a publisher with a remote distributor is outside the scope of this t
   
    > [!NOTE]  
    > If you have connected to [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] by using **localhost** rather than the actual server name, you'll be prompted with a warning that [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] cannot connect to **localhost or IP Address**. Select **OK** in the warning dialog box. In the **Connect to Server** dialog box, change **Server name** from **localhost or IP Address** to the name of your server. Then select **Connect**.  
-   > Currently, SSMS 18.0 – 18.4 has issue, which does not show the error message, so please use the actual server name to connect Object Explorer before configuring a Distributer.
-  
+   > There is currently a known issue with SQL Server Management Studio (SSMS) 18.0 (and greater) where a warning message is _not_ displayed when connecting to the Distributor with the IP address, but this is still invalid. The actual server name should be used when connecting to the Distributor. 
+   
    The Distribution Configuration Wizard starts.  
   
 3. On the **Distributor** page, select <*'ServerName'*> **will act as its own Distributor; SQL Server will create a distribution database and log**. Then select **Next**.  

--- a/docs/relational-databases/replication/tutorial-preparing-the-server-for-replication.md
+++ b/docs/relational-databases/replication/tutorial-preparing-the-server-for-replication.md
@@ -176,8 +176,8 @@ Configuring a publisher with a remote distributor is outside the scope of this t
    !["Configure Distribution" command on the shortcut menu](media/tutorial-preparing-the-server-for-replication/configuredistribution.png)
   
    > [!NOTE]  
-   > If you have connected to [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] by using **localhost** rather than the actual server name, you'll be prompted with a warning that [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] cannot connect to **localhost or IP Address**. Select **OK** in the warning dialog box. In the **Connect to Server** dialog box, change **Server name** from **localhost or IP Address** to the name of your server. Then select **Connect**.  
-   > There is currently a known issue with SQL Server Management Studio (SSMS) 18.0 (and greater) where a warning message is _not_ displayed when connecting to the Distributor with the IP address, but this is still invalid. The actual server name should be used when connecting to the Distributor. 
+   > - If you connected to [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] by using **localhost** rather than the actual server name, you'll be prompted with a warning that [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] cannot connect to **localhost or IP Address**. Select **OK** in the warning dialog box. In the **Connect to Server** dialog box, change **Server name** from **localhost or IP Address** to the name of your server. Then select **Connect**.  
+   > - There is currently a known issue with SQL Server Management Studio (SSMS) 18.0 (and later) where a warning message is _not_ displayed when connecting to the Distributor with the IP address, but this is still invalid. The actual server name should be used when connecting to the Distributor. 
    
    The Distribution Configuration Wizard starts.  
   


### PR DESCRIPTION
As RFC 13373362, IP address is not supported, and SSMS 17 was producing the same message as localhost, it should mention IP address in the note. SSMS 18 has bug which does not stop customer to use IP address, so it should mention in this.