### PR TITLE
Update xp-cmdshell-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-stored-procedures/xp-cmdshell-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/xp-cmdshell-transact-sql.md
@@ -118,7 +118,7 @@ REVERT ;
  The following example shows the `xp_cmdshell` extended stored procedure executing a directory command.  
   
 ```  
-EXEC master..xp_cmdshell 'dir *.exe''  
+EXEC master..xp_cmdshell 'dir *.exe'  
 ```  
   
 ### B. Returning no output  


### PR DESCRIPTION
Example A has an extra single quote at the end which results in parsing error as copied from the code block. Need this fixed.