### PR TITLE
Update Header Title to Reflect Document Name

### DIFF
--- a/docs/t-sql/language-elements/sql-server-utilities-statements-go.md
+++ b/docs/t-sql/language-elements/sql-server-utilities-statements-go.md
@@ -1,5 +1,5 @@
 ---
-title: "GO (Transact-SQL) | Microsoft Docs"
+title: "SQL Server Utilities Statements - GO | Microsoft Docs"
 ms.custom: ""
 ms.date: "07/27/2017"
 ms.prod: sql


### PR DESCRIPTION
The Header Title of this document was still *"GO (Transact-SQL)"*. The document itself states *"GO is **not** a Transact-SQL statement"*, and the title of the document reflects this therefore the title header should also be reflective of this. The incorrect information is also displayed in things like Google Searches, which could cause confusion for users performing searches.