### PR TITLE
Update mssqlserver-8992-database-engine-error.md

### DIFF
--- a/docs/relational-databases/errors-events/mssqlserver-8992-database-engine-error.md
+++ b/docs/relational-databases/errors-events/mssqlserver-8992-database-engine-error.md
@@ -26,7 +26,8 @@ ms.author: mathoma
 |Symbolic Name|DBCC3_CHECK_CATALOG|  
 |Message Text|Check Catalog Msg ERROR Level LEVEL State STATE: MESSAGE.|  
 
-Note: 8992 Error message will reference another specific message (ranging from 3851 to 3858) about the actual inconsistency.
+> [!NOTE]
+> 8992 Error message references another specific message (ranging from 3851 to 3858) about the actual inconsistency.
 
 ## Explanation  
 DBCC CHECKCATALOG or DBCC CHECKDB found an inconsistency in the system metadata tables for the specified object. That is, there is an inconsistency between the recorded object ID and the object specified in error message.  
@@ -63,12 +64,19 @@ If the backup also contains the metadata inconsistency, you need to create a new
 This error cannot be repaired.  If you cannot restore the database from a backup, contact [!INCLUDE[msCoName](../../includes/msconame-md.md)] Customer Service and Support (CSS).  
   
 ### Do Not Manually Update System Tables  
+
 Do not make manual updates to system tables. SQL Server does not support any manual changes to system databases. If you update a system table in a SQL Server database, the following events are logged:
+
 #### When a system table is manually updated
+
 Msg 17659: Warning: System table ID <id> has been updated directly in database ID <id> and cache coherence may not have been maintained. SQL Server should be restarted.
+
 #### Starting a database with a system table that was manually updated
+
 Msg 3859: Warning: The system catalog was updated directly in database ID <id>, most recently at date_time
+
 #### when you execute the DBCC_CHECKDB command after a system table is manually updated
+
 Msg 3859: Warning: The system catalog was updated directly in database ID <id>, most recently at date_time.  
 
 ## See Also  

--- a/docs/relational-databases/errors-events/mssqlserver-8992-database-engine-error.md
+++ b/docs/relational-databases/errors-events/mssqlserver-8992-database-engine-error.md
@@ -25,7 +25,9 @@ ms.author: mathoma
 |Component|SQLEngine|  
 |Symbolic Name|DBCC3_CHECK_CATALOG|  
 |Message Text|Check Catalog Msg ERROR Level LEVEL State STATE: MESSAGE.|  
-  
+
+Note: 8992 Error message will reference another specific message (ranging from 3851 to 3858) about the actual inconsistency.
+
 ## Explanation  
 DBCC CHECKCATALOG or DBCC CHECKDB found an inconsistency in the system metadata tables for the specified object. That is, there is an inconsistency between the recorded object ID and the object specified in error message.  
   
@@ -34,23 +36,18 @@ This error can occur when one or more system tables has been manually updated in
 This error can occur when running DBCC CHECKDB against a database that has been upgraded from SQL Server 2000 to SQL Server 2005 or later. In SQL Server 2000, DBCC CHECKDB did not include DBCC CHECKCATALOG functionality, so the error would not be caught before upgrade unless DBCC CHECKCATALOG was specifically executed against the database in SQL Server 2000.  
   
 You may see any of the following errors in conjunction with error 8992:  
-  
-Msg 3851 - An invalid row (%ls) was found in the system table sys.%ls%ls.  
-  
-Msg 3852 - Row (%ls) in sys.%ls%ls does not have a matching row (%ls) in sys.%ls%ls.  
-  
-3853 - Attribute (%ls) of row (%ls) in sys.%ls%ls does not have a matching row (%ls) in sys.%ls%ls.  
-  
-3854 - Attribute (%ls) of row (%ls) in sys.%ls%ls has a matching row (%ls) in sys.%ls%ls that is invalid.  
-  
-3855 - Attribute (%ls) exists without a row (%ls) in sys.%ls%ls.  
-  
-3856 - Attribute (%ls) exists but should not for row (%ls) in sys.%ls%ls.  
-  
-3857 - The attribute (%ls) is required but is missing for row (%ls) in sys.%ls%ls.  
-  
-3858 - The attribute (%ls) of row (%ls) in sys.%ls%ls has an invalid value.  
-  
+|||
+|-|-| 
+|Msg ID|Msg text|
+|3851|An invalid row (%ls) was found in the system table sys.%ls%ls.|
+|3852|Row (%ls) in sys.%ls%ls does not have a matching row (%ls) in sys.%ls%ls.|
+|3853|Attribute (%ls) of row (%ls) in sys.%ls%ls does not have a matching row (%ls) in sys.%ls%ls.|
+|3854|Attribute (%ls) of row (%ls) in sys.%ls%ls has a matching row (%ls) in sys.%ls%ls that is invalid.|
+|3855|Attribute (%ls) exists without a row (%ls) in sys.%ls%ls.|
+|3856|Attribute (%ls) exists but should not for row (%ls) in sys.%ls%ls.|
+|3857|The attribute (%ls) is required but is missing for row (%ls) in sys.%ls%ls.|
+|3858|The attribute (%ls) of row (%ls) in sys.%ls%ls has an invalid value.|
+
 ## User Action  
   
 ### Drop and Re-create the Specified Object  
@@ -66,8 +63,14 @@ If the backup also contains the metadata inconsistency, you need to create a new
 This error cannot be repaired.  If you cannot restore the database from a backup, contact [!INCLUDE[msCoName](../../includes/msconame-md.md)] Customer Service and Support (CSS).  
   
 ### Do Not Manually Update System Tables  
-Do not make manual updates to system tables. SQL Server does not support any manual changes to system databases. If you update a system table in a SQL Server database, two events (event ID 17659 and event ID 3859) are logged. For more information, see KB article 2688307, "Event ID 17659 and event ID 3859 are logged when you update system tables in a SQL Server database".  
-  
+Do not make manual updates to system tables. SQL Server does not support any manual changes to system databases. If you update a system table in a SQL Server database, the following events are logged:
+#### When a system table is manually updated
+Msg 17659: Warning: System table ID <id> has been updated directly in database ID <id> and cache coherence may not have been maintained. SQL Server should be restarted.
+#### Starting a database with a system table that was manually updated
+Msg 3859: Warning: The system catalog was updated directly in database ID <id>, most recently at date_time
+#### when you execute the DBCC_CHECKDB command after a system table is manually updated
+Msg 3859: Warning: The system catalog was updated directly in database ID <id>, most recently at date_time.  
+
 ## See Also  
-[Event ID 17659 and event ID 3859 are logged when you update system tables in a SQL Server database](https://support.microsoft.com/kb/2688307/EN-US)  
+[System Base Tables](https://docs.microsoft.com/en-us/sql/relational-databases/system-tables/system-base-tables)  
   


### PR DESCRIPTION
removing references to KB since all relevant content is present in this article already. The 2 KB's mentioned here are getting retired in favor this docs article.
made a few inline changes and convert the msg list to table for easy readability.