### PR TITLE
Remove invalid "NOUNLOAD" option from docs example

### DIFF
--- a/docs/t-sql/statements/restore-statements-headeronly-transact-sql.md
+++ b/docs/t-sql/statements/restore-statements-headeronly-transact-sql.md
@@ -164,8 +164,7 @@ FROM <backup_device>
   
 ```  
 RESTORE HEADERONLY   
-FROM DISK = N'C:\AdventureWorks-FullBackup.bak'   
-WITH NOUNLOAD;  
+FROM DISK = N'C:\AdventureWorks-FullBackup.bak';  
 GO  
 ```  
   


### PR DESCRIPTION
The NOUNLOAD option is for restoring from tape, and this example is restoring from a disk source.

I found the example code a little confusing because of that option.  It's not clear why it's there, and according to the docs the option is simply ignored in this case.

Referencing this MS Docs article:

[RESTORE Statements - Arguments (Transact-SQL)](https://docs.microsoft.com/en-us/sql/t-sql/statements/restore-statements-arguments-transact-sql?view=sql-server-ver15#arguments)

Which states:

> { UNLOAD | NOUNLOAD }
> Supported by: RESTORE, RESTORE FILELISTONLY, RESTORE HEADERONLY, RESTORE LABELONLY, RESTORE REWINDONLY, and RESTORE VERIFYONLY.
> 
> These options are used only for TAPE devices. If a non-tape device is being used, these options are ignored.