### PR TITLE
Fix permission grammar spec: TYPE

### DIFF
--- a/docs/t-sql/statements/grant-transact-sql.md
+++ b/docs/t-sql/statements/grant-transact-sql.md
@@ -64,7 +64,8 @@ GRANT
     | DATABASE  
     | OBJECT  
     | ROLE  
-    | SCHEMA  
+    | SCHEMA
+    | TYPE
     | USER  
 }  
 ```  


### PR DESCRIPTION
For user-defined types, permissions should be scoped to the TYPE:: they operate on.