### PR TITLE
Fix NO_OUTPUT, should be outside cmd string

### DIFF
--- a/docs/relational-databases/system-stored-procedures/xp-cmdshell-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/xp-cmdshell-transact-sql.md
@@ -128,7 +128,7 @@ EXEC master..xp_cmdshell 'dir *.exe'
 USE master;  
   
 EXEC xp_cmdshell 'copy c:\SQLbcks\AdvWorks.bck  
-    \\server2\backups\SQLbcks, NO_OUTPUT';  
+    \\server2\backups\SQLbcks', NO_OUTPUT;  
 GO  
 ```  
   


### PR DESCRIPTION
Currently the code does not run. NO_OUTPUT option needs to be *outside* of the string command being executed.