### PR TITLE
Add missing word and fix spelling

### DIFF
--- a/docs/relational-databases/user-defined-functions/user-defined-functions.md
+++ b/docs/relational-databases/user-defined-functions/user-defined-functions.md
@@ -36,7 +36,7 @@ Why use user-defined functions (UDFs)?
   
 -   They can reduce network traffic.  
   
-     An operation that filters data based on some complex constraint that cannot be expressed in a single scalar expression can be expressed as a function. The function can then invoked in the WHERE clause to reduce the number or rows sent to the client.  
+     An operation that filters data based on some complex constraint that cannot be expressed in a single scalar expression can be expressed as a function. The function can then be invoked in the WHERE clause to reduce the number of rows sent to the client.  
   
 > [!IMPORTANT]
 > [!INCLUDE[tsql](../../includes/tsql-md.md)] UDFs in queries can only be executed on a single thread (serial execution plan). Therefore using UDFs inhibits parallel query processing. For more information about parallel query processing, see the [Query Processing Architecture Guide](../../relational-databases/query-processing-architecture-guide.md#parallel-query-processing).


### PR DESCRIPTION
In the user-defined-functions.md file, a sentence is missing the word "be" and the word "of" has been misspelled as "or". This change adds "be" and fixes the misspelled word.