### PR TITLE
Update SP_WHO CMD column

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-who-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-who-transact-sql.md
@@ -59,7 +59,7 @@ sp_who [ [ @loginame = ] 'login' | session ID | 'ACTIVE' ]
 |**hostname**|**nchar(128)**|Host or computer name for each process.|  
 |**blk**|**char(5)**|Session ID for the blocking process, if one exists. Otherwise, this column is zero.<br /><br /> When a transaction associated with a specified session ID is blocked by an orphaned distributed transaction, this column will return a '-2' for the blocking orphaned transaction.|  
 |**dbname**|**nchar(128)**|Database used by the process.|  
-|**cmd**|**nchar(32)**|[!INCLUDE[ssDE](../../includes/ssde-md.md)] command ([!INCLUDE[tsql](../../includes/tsql-md.md)] statement, internal [!INCLUDE[ssDE](../../includes/ssde-md.md)] process, and so on) executing for the process.|  
+|**cmd**|**nchar(52)**|[!INCLUDE[ssDE](../../includes/ssde-md.md)] command ([!INCLUDE[tsql](../../includes/tsql-md.md)] statement, internal [!INCLUDE[ssDE](../../includes/ssde-md.md)] process, and so on) executing for the process.|  
 |**request_id**|**int**|ID for requests running in a specific session.|  
   
  In case of parallel processing, subthreads are created for the specific session ID. The main thread is indicated as `spid = <xxx>` and `ecid =0`. The other subthreads have the same `spid = <xxx>`, but with **ecid** > 0.  

--- a/docs/relational-databases/system-stored-procedures/sp-who-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-who-transact-sql.md
@@ -59,7 +59,7 @@ sp_who [ [ @loginame = ] 'login' | session ID | 'ACTIVE' ]
 |**hostname**|**nchar(128)**|Host or computer name for each process.|  
 |**blk**|**char(5)**|Session ID for the blocking process, if one exists. Otherwise, this column is zero.<br /><br /> When a transaction associated with a specified session ID is blocked by an orphaned distributed transaction, this column will return a '-2' for the blocking orphaned transaction.|  
 |**dbname**|**nchar(128)**|Database used by the process.|  
-|**cmd**|**nchar(16)**|[!INCLUDE[ssDE](../../includes/ssde-md.md)] command ([!INCLUDE[tsql](../../includes/tsql-md.md)] statement, internal [!INCLUDE[ssDE](../../includes/ssde-md.md)] process, and so on) executing for the process.|  
+|**cmd**|**nchar(32)**|[!INCLUDE[ssDE](../../includes/ssde-md.md)] command ([!INCLUDE[tsql](../../includes/tsql-md.md)] statement, internal [!INCLUDE[ssDE](../../includes/ssde-md.md)] process, and so on) executing for the process.|  
 |**request_id**|**int**|ID for requests running in a specific session.|  
   
  In case of parallel processing, subthreads are created for the specific session ID. The main thread is indicated as `spid = <xxx>` and `ecid =0`. The other subthreads have the same `spid = <xxx>`, but with **ecid** > 0.  


### PR DESCRIPTION
Example: run SP_WHO- in the output will see a CMD like XIO_LEASE_RENEWAL_WORKER; which is > 16 characters;
I have verified it with the sp_helptext and the length should be 52 characters