### PR TITLE
removing COMPRESSION_DELAY from ALTER INDEX REBUIL

### DIFF
--- a/docs/t-sql/statements/alter-index-transact-sql.md
+++ b/docs/t-sql/statements/alter-index-transact-sql.md
@@ -95,7 +95,6 @@ ALTER INDEX { index_name | ALL } ON <object>
     | ALLOW_ROW_LOCKS = { ON | OFF }  
     | ALLOW_PAGE_LOCKS = { ON | OFF }  
     | MAXDOP = max_degree_of_parallelism  
-    | COMPRESSION_DELAY = {0 | delay [Minutes]}  
     | DATA_COMPRESSION = { NONE | ROW | PAGE | COLUMNSTORE | COLUMNSTORE_ARCHIVE }   
         [ ON PARTITIONS ( {<partition_number> [ TO <partition_number>] } [ , ...n ] ) ]  
 }  


### PR DESCRIPTION
It doesn't actually work on SQL Server 2019 or Azure SQL Database.

select * into Sales.SalesOrderDetail2 from Sales.SalesOrderDetail
go
CREATE CLUSTERED COLUMNSTORE INDEX cci_SalesOrderDetail2 ON Sales.SalesOrderDetail2

go
alter index cci_SalesOrderDetail2 on Sales.SalesOrderDetail2
rebuild WITH ( COMPRESSION_DELAY = 10 Minutes );