### PR TITLE
Update querying-data-in-a-system-versioned-temporal-table.md

### DIFF
--- a/docs/relational-databases/tables/querying-data-in-a-system-versioned-temporal-table.md
+++ b/docs/relational-databases/tables/querying-data-in-a-system-versioned-temporal-table.md
@@ -26,7 +26,7 @@ To perform any type of time-based analysis, use the new **FOR SYSTEM_TIME** clau
 - CONTAINED IN (<start_date_time> , <end_date_time>)
 - ALL
 
-**FOR SYSTEM_TIME** can be specified independently for each table in a query. It can be used inside common table expressions, table-valued functions and stored procedures.
+**FOR SYSTEM_TIME** can be specified independently for each table in a query. It can be used inside common table expressions, table-valued functions and stored procedures. When using a table alias with a temporal tables, the **FOR SYSTEM_TIME** clause must included between the temporal table name and the alias (see "Query for a specific time using the AS OF sub-clause" second example, below).
 
 ## Query for a specific time using the AS OF sub-clause
 


### PR DESCRIPTION
Line 29: added "When using a table alias with a temporal tables, the **FOR SYSTEM_TIME** clause must included between the temporal table name and the alias (see "Query for a specific time using the AS OF sub-clause" second example, below)."
If someone can make "Query for a specific time using the AS OF sub-clause" a hyperlink, that would be cool.