### PR TITLE
Remove duplicate statement

### DIFF
--- a/docs/integration-services/data-flow/walkthrough-publish-an-ssis-package-as-a-sql-view.md
+++ b/docs/integration-services/data-flow/walkthrough-publish-an-ssis-package-as-a-sql-view.md
@@ -261,8 +261,6 @@ SELECT * FROM OPENQUERY(<LinkedServer Name>, N'Folder=<Folder Name from SSIS Cat
   
 -   Forward Slash (\\) - Every \ used in the query clause must use escape character. For example, \\\ is evaluated as \ in the query clause.  
   
- Forward Slash (\\) - Every \ used in the query clause must use escape character. For example, \\\ is evaluated as \ in the query clause.  
-  
 ## See Also  
  [Data Streaming Destination](../../integration-services/data-flow/data-streaming-destination.md)   
  [Configure Data Streaming Destination](../../integration-services/data-flow/configure-data-streaming-destination.md)  


### PR DESCRIPTION
Duplicate Statement:
Forward Slash (\\) - Every \ used in the query clause must use escape character. For example, \\ is evaluated as \ in the query clause.