### PR TITLE
Fixed incorrect credential name in example

### DIFF
--- a/docs/t-sql/statements/drop-database-scoped-credential-transact-sql.md
+++ b/docs/t-sql/statements/drop-database-scoped-credential-transact-sql.md
@@ -48,7 +48,7 @@ DROP DATABASE SCOPED CREDENTIAL credential_name
  The following example removes the database scoped credential called `SalesAccess`.  
   
 ```sql  
-DROP DATABASE SCOPED CREDENTIAL AppCred;  
+DROP DATABASE SCOPED CREDENTIAL SalesAccess;  
 GO  
 ```  
   


### PR DESCRIPTION
The example stated the credential as "AppCred" - the description used "SalesAccess". Corrected the example to show the same credential name