### PR TITLE
Updated Read-Scale restrictions in table

### DIFF
--- a/docs/sql-server/editions-and-components-of-sql-server-2017.md
+++ b/docs/sql-server/editions-and-components-of-sql-server-2017.md
@@ -160,7 +160,7 @@ The Developer edition continues to support only 1 client for [SQL Server Distrib
 |Database recovery advisor|Yes|Yes|Yes|Yes|Yes|
 |Encrypted backup|Yes|Yes|No|No|No|
 |Hybrid backup to Azure (backup to URL)|Yes|Yes|No|No|No|
-|Read-scale availability group|Yes|Yes|No|No|No|No|
+|Read-scale availability group<sup>3,4</sup>|Yes|Yes|No|No|No|No|
 
 <sup>1</sup> For more information on installing SQL Server on Server Core,  see [Install SQL Server on Server Core](../database-engine/install-windows/install-sql-server-on-server-core.md). 
 


### PR DESCRIPTION
Updated the read-scale restrictions in the rdbms high availability table by adding in 3,4 due to CSS customer questions and calls. There were questions stating that the document did not accurately reflect the limitations imposed. Added per already existing data.