### PR TITLE
Apply to multiple versions

### DIFF
--- a/docs/relational-databases/views/modify-data-through-a-view.md
+++ b/docs/relational-databases/views/modify-data-through-a-view.md
@@ -18,7 +18,7 @@ monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-s
 ---
 # Modify Data Through a View
 [!INCLUDE[tsql-appliesto-ss2008-asdb-asdw-pdw-md](../../includes/tsql-appliesto-ss2008-all-md.md)]
-  You can modify the data of an underlying base table in [!INCLUDE[ssCurrent](../../includes/sscurrent-md.md)] by using [!INCLUDE[ssManStudioFull](../../includes/ssmanstudiofull-md.md)] or [!INCLUDE[tsql](../../includes/tsql-md.md)].  
+  You can modify the data of an underlying base table in SQL Server by using [!INCLUDE[ssManStudioFull](../../includes/ssmanstudiofull-md.md)] or [!INCLUDE[tsql](../../includes/tsql-md.md)].  
   
   
 ##  <a name="BeforeYouBegin"></a> Before You Begin  


### PR DESCRIPTION
The ability to update a base table isn't limited to current, so this inclusion is misleading. This should be in all versions of SQL Server, subject to the limitations in the CREATE VIEW item.