### PR TITLE
Bug fix: Update OrderDate and FilledDate constraints

### DIFF
--- a/docs/ssdt/walkthrough-creating-and-running-a-sql-server-unit-test.md
+++ b/docs/ssdt/walkthrough-creating-and-running-a-sql-server-unit-test.md
@@ -117,12 +117,12 @@ To complete this walkthrough, you must be able to connect to a database server (
     PRINT N'Creating Sales.CK_Orders_FilledDate...';  
     GO  
     ALTER TABLE [Sales].[Orders]  
-        ADD CONSTRAINT [CK_Orders_FilledDate] CHECK ((FilledDate >= OrderDate) AND (FilledDate < '01/01/2020'));  
+        ADD CONSTRAINT [CK_Orders_FilledDate] CHECK ((FilledDate >= OrderDate) AND (FilledDate < '01/01/2030'));  
     GO  
     PRINT N'Creating Sales.CK_Orders_OrderDate...';  
     GO  
     ALTER TABLE [Sales].[Orders]  
-        ADD CONSTRAINT [CK_Orders_OrderDate] CHECK ((OrderDate > '01/01/2005') and (OrderDate < '01/01/2020'));  
+        ADD CONSTRAINT [CK_Orders_OrderDate] CHECK ((OrderDate > '01/01/2005') and (OrderDate < '01/01/2030'));  
     GO  
     PRINT N'Creating Sales.uspCancelOrder...';  
     GO  


### PR DESCRIPTION
Currently, step 11 under "To write the SQL Server unit test for uspShowOrderDetails" will fail at the following statements:

-- place 3 orders for that customer  
EXECUTE @RC = [Sales].[uspPlaceNewOrder] @CustomerID, 100, @OrderDate, @Status;  
EXECUTE @RC = [Sales].[uspPlaceNewOrder] @CustomerID, 50, @OrderDate, @Status;  
EXECUTE @RC = [Sales].[uspPlaceNewOrder] @CustomerID, 5, @OrderDate, @Status;  

This is because @OrderDate is set to @OrderDate = getdate() which is past constraint set the OrderDate column.