### PR TITLE
Fix a link text: "Container" to "Kubernetes"

### DIFF
--- a/docs/linux/tutorial-sql-server-containers-kubernetes.md
+++ b/docs/linux/tutorial-sql-server-containers-kubernetes.md
@@ -46,7 +46,7 @@ In the following diagram, the node hosting the `mssql-server` container has fail
 * **Kubernetes cluster**
    - The tutorial requires a Kubernetes cluster. The steps use [kubectl](https://kubernetes.io/docs/user-guide/kubectl/) to manage the cluster. 
 
-   - See [Deploy an Azure Container Service (AKS) cluster](https://docs.microsoft.com/azure/aks/tutorial-kubernetes-deploy-cluster) to create and connect to a single-node Kubernetes cluster in AKS with `kubectl`. 
+   - See [Deploy an Azure Kubernetes Service (AKS) cluster](https://docs.microsoft.com/azure/aks/tutorial-kubernetes-deploy-cluster) to create and connect to a single-node Kubernetes cluster in AKS with `kubectl`. 
 
    >[!NOTE]
    >To protect against node failure, a Kubernetes cluster requires more than one node.


### PR DESCRIPTION
"Deploy an Azure Container Service (AKS) cluster" should be changed to "Deploy an Azure Kubernetes Service (AKS) cluster"