### PR TITLE
Add prominent warning note to RAISERROR doc

### DIFF
--- a/docs/t-sql/language-elements/raiserror-transact-sql.md
+++ b/docs/t-sql/language-elements/raiserror-transact-sql.md
@@ -34,6 +34,9 @@ monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-s
 # RAISERROR (Transact-SQL)
 [!INCLUDE[tsql-appliesto-ss2008-all_md](../../includes/tsql-appliesto-ss2008-all-md.md)]
 
+> [!NOTE]
+> The **RAISERROR** statement does not honor **SET XACT_ABORT**. New applications should use **THROW** instead of **RAISERROR**.
+
   Generates an error message and initiates error processing for the session. RAISERROR can either reference a user-defined message stored in the sys.messages catalog view or build a message dynamically. The message is returned as a server error message to the calling application or to an associated CATCH block of a TRY...CATCH construct. New applications should use [THROW](../../t-sql/language-elements/throw-transact-sql.md) instead.  
   
  ![Topic link icon](../../database-engine/configure-windows/media/topic-link.gif "Topic link icon") [Transact-SQL Syntax Conventions](../../t-sql/language-elements/transact-sql-syntax-conventions-transact-sql.md)  


### PR DESCRIPTION
SET_XACT_ABORT has a nice, prominent warning about an important difference between RAISERROR and THROW (and why THROW should be used in all new applications). Unfortunately, the RAISERROR page has only a single sentence that is easy to miss.

I added a very similar note to the top of RAISERROR. Hopefully, this will help point people to THROW instead.