### PR TITLE
Example for COPY INTO with MSI

### DIFF
--- a/docs/t-sql/statements/copy-into-transact-sql.md
+++ b/docs/t-sql/statements/copy-into-transact-sql.md
@@ -368,7 +368,7 @@ Set-AzSqlServer -ResourceGroupName $resourcegroupname -ServerName $servername -A
 ```sql
 COPY INTO dbo.myCOPYDemoTable
 
-FROM 'https://storlabarturv.blob.core.windows.net/test/bcpDemo.txt'
+FROM 'https://myaccount.blob.core.windows.net/myblobcontainer/folder0/*.txt'
 
 WITH (
 

--- a/docs/t-sql/statements/copy-into-transact-sql.md
+++ b/docs/t-sql/statements/copy-into-transact-sql.md
@@ -359,6 +359,35 @@ WITH (
 )
 ```
 
+### F. Load using MSI credentials
+
+Set the Synapse SQL to use “-AssignIdentity”
+
+Set-AzSqlServer -ResourceGroupName $resourcegroupname -ServerName $servername -AssignIdentity
+
+Create a Scoped credential on your Database
+
+```sql
+CREATE DATABASE SCOPED CREDENTIAL msi_cred WITH IDENTITY = 'Managed Service Identity';
+```
+
+```sql
+COPY INTO dbo.myCOPYDemoTable
+
+FROM 'https://storlabarturv.blob.core.windows.net/test/bcpDemo.txt'
+
+WITH (
+
+    FILE_TYPE = 'CSV',
+
+    CREDENTIAL = (IDENTITY = 'Managed Identity'),
+
+    FIELDQUOTE = '"',
+
+    FIELDTERMINATOR=','
+
+)
+```
 ## FAQ
 
 ### What is the performance of the COPY command compared to PolyBase?

--- a/docs/t-sql/statements/copy-into-transact-sql.md
+++ b/docs/t-sql/statements/copy-into-transact-sql.md
@@ -365,12 +365,6 @@ Set the Synapse SQL to use “-AssignIdentity”
 
 Set-AzSqlServer -ResourceGroupName $resourcegroupname -ServerName $servername -AssignIdentity
 
-Create a Scoped credential on your Database
-
-```sql
-CREATE DATABASE SCOPED CREDENTIAL msi_cred WITH IDENTITY = 'Managed Service Identity';
-```
-
 ```sql
 COPY INTO dbo.myCOPYDemoTable
 


### PR DESCRIPTION
I would like to get this example added for COPY INTO using MSI. Customer has tried to go through our documentation, and was unable to find the exact syntax to have copy only use MSI for credentialing.  Worked with Synapse Team (Artur Vieira Artur.Vieira@microsoft.com> provided this example) to get code to work with the customer.


### F. Load using MSI credentials

Set the Synapse SQL to use “-AssignIdentity”

Set-AzSqlServer -ResourceGroupName $resourcegroupname -ServerName $servername -AssignIdentity

Create a Scoped credential on your Database

CREATE DATABASE SCOPED CREDENTIAL msi_cred WITH IDENTITY = 'Managed Service Identity';

COPY INTO dbo.myCOPYDemoTable

FROM 'https://storlabarturv.blob.core.windows.net/test/bcpDemo.txt'

WITH (

    FILE_TYPE = 'CSV',

    CREDENTIAL = (IDENTITY = 'Managed Identity'),

    FIELDQUOTE = '"',

    FIELDTERMINATOR=','

)