### PR TITLE
Fixed syntax in JSON_MODIFY example

### DIFF
--- a/docs/t-sql/functions/json-modify-transact-sql.md
+++ b/docs/t-sql/functions/json-modify-transact-sql.md
@@ -303,7 +303,7 @@ PRINT @info
   
 ```sql  
 UPDATE Employee
-SET jsonCol=JSON_MODIFY(jsonCol,"$.info.address.town",'London')
+SET jsonCol=JSON_MODIFY(jsonCol,'$.info.address.town','London')
 WHERE EmployeeID=17
  
 ```  


### PR DESCRIPTION
The `path` parameter needs to be in single quotes instead of double quotes.  This was correct in all of the examples except for the last one.