### PR TITLE
Added comma after scan_phase in the example query.

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/change-data-capture-sys-dm-cdc-log-scan-sessions.md
+++ b/docs/relational-databases/system-dynamic-management-views/change-data-capture-sys-dm-cdc-log-scan-sessions.md
@@ -61,9 +61,9 @@ ms.author: sstein
 ```  
 USE AdventureWorks2012;  
 GO  
-SELECT session_id, start_time, end_time, duration, scan_phase  
-    error_count, start_lsn, current_lsn, end_lsn, tran_count  
-    last_commit_lsn, last_commit_time, log_record_count, schema_change_count  
+SELECT session_id, start_time, end_time, duration, scan_phase,  
+    error_count, start_lsn, current_lsn, end_lsn, tran_count,  
+    last_commit_lsn, last_commit_time, log_record_count, schema_change_count,  
     command_count, first_begin_cdc_lsn, last_commit_cdc_lsn,   
     last_commit_cdc_time, latency, empty_scan_count, failed_sessions_count  
 FROM sys.dm_cdc_log_scan_sessions  


### PR DESCRIPTION
The example query did not have a commas after multiple column names, which caused the next column name to become an alias for the previous column name.  For example, no comma between scan_phase and error_count, which then made "error_count" the column alias for scan_phase.
Commas added after: scan_phase, tran_count, and schema_change_count