### PR TITLE
Fix both lists of "Supported .NET Framework Libraries" (re: SQLCLR)

### DIFF
--- a/docs/relational-databases/clr-integration/assemblies-designing.md
+++ b/docs/relational-databases/clr-integration/assemblies-designing.md
@@ -2,7 +2,7 @@
 title: "Designing Assemblies | Microsoft Docs"
 description: This article describes factors to consider when you design an assembly to host on SQL Server, including packaging, managing, and restrictions on assemblies.
 ms.custom: ""
-ms.date: "03/14/2017"
+ms.date: "04/24/2020"
 ms.prod: sql
 ms.reviewer: ""
 ms.technology: clr
@@ -96,19 +96,22 @@ eUI
  Any assembly that is referenced by your custom assembly must be loaded into [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] by using CREATE ASSEMBLY. The following [!INCLUDE[dnprdnshort](../../includes/dnprdnshort-md.md)] assemblies are already loaded into [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] and, therefore, can be referenced by custom assemblies without having to use CREATE ASSEMBLY.  
   
 ```  
-custommarshallers.dll  
-Microsoft.visualbasic.dll  
-Microsoft.visualc.dll  
+CustomMarshalers.dll  
+Microsoft.VisualBasic.dll  
+Microsoft.VisualC.dll  
 mscorlib.dll  
-system.data.dll  
+System.dll  
+System.Configuration.dll  
+System.Core.dll  
+System.Data.dll  
+System.Data.OracleClient.dll  
 System.Data.SqlXml.dll  
-system.dll  
-system.security.dll  
-system.web.services.dll  
-system.xml.dll  
-System.Transactions  
-System.Data.OracleClient  
-System.Configuration  
+System.Deployment.dll  
+System.Security.dll  
+System.Transactions.dll  
+System.Web.Services.dll  
+system.Xml.dll  
+System.Xml.Linq.dll  
 ```  
   
 ## See Also  

--- a/docs/relational-databases/clr-integration/database-objects/supported-net-framework-libraries.md
+++ b/docs/relational-databases/clr-integration/database-objects/supported-net-framework-libraries.md
@@ -27,37 +27,27 @@ ms.author: "jroth"
  The libraries/namespaces supported by CLR integration in [!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)] are:  
   
 -   CustomMarshalers  
-  
 -   Microsoft.VisualBasic  
-  
 -   Microsoft.VisualC  
-  
 -   mscorlib  
-  
 -   System  
-  
 -   System.Configuration  
-  
+-   System.Core  
 -   System.Data  
-  
 -   System.Data.OracleClient  
-  
 -   System.Data.SqlXml  
-  
 -   System.Deployment  
-  
 -   System.Security  
-  
 -   System.Transactions  
-  
 -   System.Web.Services  
-  
 -   System.Xml  
-  
--   System.Core.dll  
-  
--   System.Xml.Linq.dll  
-  
+-   System.Xml.Linq  
+
+<!--
+Any modifications to the list above should be duplicated on the following page:
+https://docs.microsoft.com/en-us/sql/relational-databases/clr-integration/assemblies-designing#supported-net-framework-assemblies
+-->
+
 ## Unsupported Libraries  
  Unsupported libraries can still be called from your managed stored procedures, triggers, user-defined functions, user-defined types, and user-defined aggregates. The unsupported library must first be registered in the [!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)] database, using the **CREATE ASSEMBLY** statement, before it can be used in your code. Any unsupported library that is registered and run on the server should be reviewed and tested for security and reliability.  
   


### PR DESCRIPTION
This fixes #4614  

On the **Designing Assemblies** page:

1. Added:
    1. System.Deployment.dll  (added in SP1 for SQL Server 2005)
    1. System.Core.dll  (added in SQL Server 2008)
    1. System.Xml.Linq.dll  (added in SQL Server 2008)
1. Rearranged list of assemblies to be in their proper (expected) order.
1. Fixed incorrect casing for several library names.

On the **Supported .NET Framework Libraries** page:

1. Moved **System.Core** to the proper/expected position.
1. Removed ".dll" extension from **System.Core** and **System.Xml.Linq** to match the rest of the list.
1. Removed extraneous newline between each library that made the list harder to read as you had to scroll to see all of the items.
1. Added HTML comment below the "Supported Libraries" list indicating the other page containing the same list (i.e. the "Designing Assemblies" page that hasn't been updated since SQL Server 2005 went RTM) so that hopefully it will be easier to maintain consistency across future updates.


Take care,
Solomon...
https://SqlQuantumLift.com/
https://SqlQuantumLeap.com/
https://SQLsharp.com/
