### PR TITLE
Updating verbiage for (lack of) SQL FCI support

### DIFF
--- a/docs/machine-learning/install/sql-r-services-windows-install.md
+++ b/docs/machine-learning/install/sql-r-services-windows-install.md
@@ -25,7 +25,7 @@ In SQL Server 2017, R integration is offered in [Machine Learning Services](../r
 
 + For business continuity, [Always On Availability Groups](https://docs.microsoft.com/sql/database-engine/availability-groups/windows/overview-of-always-on-availability-groups-sql-server) are supported for R Services. You have to install R Services, and configure packages, on each node.
 
-+ Do not install R Services on a failover cluster. The security mechanism used for isolating R processes is not compatible with a Windows Server failover cluster environment.
++ Do not install R Services on a SQL failover cluster (FCI). The security mechanism used for isolating R processes is not compatible with a SQL failover cluster (FCI) environment.
 
 + Do not install R Services on a domain controller. The R Services portion of setup will fail.
 


### PR DESCRIPTION
Currently we say this:
Do not install R Services on a failover cluster. The security mechanism used for isolating R processes is not compatible with a Windows Server failover cluster environment.

But our 2017 docs say this:
Installing Machine Learning Services isn't supported on a failover cluster in SQL Server 2017. It's supported with SQL Server 2019.

When we say: "The security mechanism used for isolating R processes is not compatible with a Windows Server failover cluster environment." We really mean that is not supported in an FCI environment.

Since AGs use WSFC, this is misleading verbiage, when we really mean that it is not supported on SQL FCI.

Updating verbiage to be more clear.