### PR TITLE
Update load-data-to-from-excel-with-ssis.md

### DIFF
--- a/docs/integration-services/load-data-to-from-excel-with-ssis.md
+++ b/docs/integration-services/load-data-to-from-excel-with-ssis.md
@@ -248,8 +248,6 @@ Before you can successfully save strings longer than 255 characters to an Excel 
 
 -   If an existing destination table already contains rows of data, then the first few rows that are sampled by the driver must contain at least one instance of a value longer than 255 characters in the memo column.
 
--   If a new destination table is created during package design or at run time or by the Import and Export Wizard, then the `CREATE TABLE` statement must use LONGTEXT (or one of its synonyms) as the data type of the destination memo column. In the wizard, check the `CREATE TABLE` statement and revise it, if necessary, by clicking **Edit SQL** next to the **Create destination table** option on the **Column Mappings** page.
-
 ## Related content
 
 For more information about the components and procedures described in this article, see the following articles:


### PR DESCRIPTION
Under "Export long text values" the second option to create the excel file using a sql statement and columns of type LONGTEXT does NOT appear to work.  Only the first option works - having at least one row with data in each column > 255 double byte characters (i.e. 512 normal ones) _already_ before writing anymore rows works.  So one can only make this work with an initial, manually created, dummy row.

Delete the second option - it may work for other data destinations but not for Excel.