### PR TITLE
Updated column to reflect 2019 naming

### DIFF
--- a/docs/sql-server/editions-and-components-of-sql-server-2017.md
+++ b/docs/sql-server/editions-and-components-of-sql-server-2017.md
@@ -160,7 +160,7 @@ The Developer edition continues to support only 1 client for [SQL Server Distrib
 |Database recovery advisor|Yes|Yes|Yes|Yes|Yes|
 |Encrypted backup|Yes|Yes|No|No|No|
 |Hybrid backup to Azure (backup to URL)|Yes|Yes|No|No|No|
-|Read-scale availability group<sup>3,4</sup>|Yes|Yes|No|No|No|No|
+|Cluster-less availability group<sup>3,4</sup>|Yes|Yes|No|No|No|No|
 
 <sup>1</sup> For more information on installing SQL Server on Server Core,  see [Install SQL Server on Server Core](../database-engine/install-windows/install-sql-server-on-server-core.md). 
 


### PR DESCRIPTION
Updated the read-scale terminology column under RDBMS High Availability from "Read-Scale availability groups" to "Cluster-less availability group" as that's what's used in the 2019 version of the page. Keeping things consistent in terminology.