### PR TITLE
Adding in correct qualifiers for clusterless HA table item

### DIFF
--- a/docs/sql-server/editions-and-components-of-sql-server-version-15.md
+++ b/docs/sql-server/editions-and-components-of-sql-server-version-15.md
@@ -164,7 +164,7 @@ The Developer edition continues to support only 1 client for [[!INCLUDE[ssNoVers
 |Database recovery advisor|Yes|Yes|Yes|Yes|Yes|
 |Encrypted backup|Yes|Yes|No|No|No|
 |Hybrid backup to Windows Azure (backup to URL)|Yes|Yes|No|No|No|
-|Cluster-less availability group|Yes|Yes|No|No|No|
+|Cluster-less availability group <sup>5,6</sup>|Yes|Yes|No|No|No|
 |Failover servers for disaster recovery<sup>7</sup>|Yes|Yes|No|No|No|
 |Failover servers for high availability<sup>7</sup>|Yes|Yes|No|No|No|
 |Failover servers for disaster recovery in Azure<sup>7</sup>|Yes|Yes|No|No|No|


### PR DESCRIPTION
Added in the 5 and 6 call outs for clusterless (read-scale) items to match the changes made for the 2017 (PR 4702). This keeps them in line and identical to each other and should cause less confusion.