### PR TITLE
Distribution databases used in merge or peer to peer replication aren…

### DIFF
--- a/docs/database-engine/availability-groups/windows/configure-replication-for-always-on-availability-groups-sql-server.md
+++ b/docs/database-engine/availability-groups/windows/configure-replication-for-always-on-availability-groups-sql-server.md
@@ -24,7 +24,7 @@ monikerRange: ">=sql-server-2016||=sqlallproducts-allversions"
 ##  <a name="step1"></a> 1. Configure the Database Publications and Subscriptions  
  **Configure the distributor**  
   
- The distribution database cannot be placed in an availability group with SQL Server 2012 and SQL Server 2014. Placing the distribution database into an availability group is supported with SQL 2016 and greater, except for distribution databases used in merge or peer to peer replication topologies. For more information, see [Configure distribution database in an availability group](../../../relational-databases/replication/configure-distribution-availability-group.md).
+ The distribution database cannot be placed in an availability group with SQL Server 2012 and SQL Server 2014. Placing the distribution database into an availability group is supported with SQL 2016 and greater, except for distribution databases used in merge, bidirectional, or peer-to-peer replication topologies. For more information, see [Configure distribution database in an availability group](../../../relational-databases/replication/configure-distribution-availability-group.md).
   
 1.  Configure distribution at the distributor. If stored procedures are being used for configuration, run **sp_adddistributor**. Use the *\@password* parameter to identify the password that will be used when a remote publisher connects to the distributor. The password will also be needed at each remote publisher when the remote distributor is set up.  
   

--- a/docs/database-engine/availability-groups/windows/configure-replication-for-always-on-availability-groups-sql-server.md
+++ b/docs/database-engine/availability-groups/windows/configure-replication-for-always-on-availability-groups-sql-server.md
@@ -24,7 +24,7 @@ monikerRange: ">=sql-server-2016||=sqlallproducts-allversions"
 ##  <a name="step1"></a> 1. Configure the Database Publications and Subscriptions  
  **Configure the distributor**  
   
- The distribution database cannot be placed in an availability group with SQL Server 2012 and SQL Server 2014. Placing the distribution database into an availability group is supported with SQL 2016 and greater. For more information, see [Configure distribution database in an availability group](../../../relational-databases/replication/configure-distribution-availability-group.md).
+ The distribution database cannot be placed in an availability group with SQL Server 2012 and SQL Server 2014. Placing the distribution database into an availability group is supported with SQL 2016 and greater, except for distribution databases used in merge or peer to peer replication topologies. For more information, see [Configure distribution database in an availability group](../../../relational-databases/replication/configure-distribution-availability-group.md).
   
 1.  Configure distribution at the distributor. If stored procedures are being used for configuration, run **sp_adddistributor**. Use the *\@password* parameter to identify the password that will be used when a remote publisher connects to the distributor. The password will also be needed at each remote publisher when the remote distributor is set up.  
   


### PR DESCRIPTION
…'t supported in AGs.

See: https://docs.microsoft.com/en-us/sql/relational-databases/replication/configure-distribution-availability-group?view=sql-server-2017#limitations-or-exclusions  

There several exceptions to distribution databases being able to be used in AGs.  See 'Limitations or exclusions' at URL above.   I've noted the Peer to Peer and Merge exceptions above.  Perhaps the specific transactional replication exception should also be noted?