### PR TITLE
Improvements to "Set or Change the Server Collation"

### DIFF
--- a/docs/relational-databases/collations/set-or-change-the-server-collation.md
+++ b/docs/relational-databases/collations/set-or-change-the-server-collation.md
@@ -1,7 +1,7 @@
 ---
 title: "Set or Change the Server Collation | Microsoft Docs"
 ms.custom: ""
-ms.date: "12/05/2019"
+ms.date: "05/10/2020"
 ms.prod: sql
 ms.technology: 
 ms.topic: conceptual
@@ -23,8 +23,11 @@ ms.reviewer: carlrab
   
 ## Setting the server collation in SQL Server
 
-  The server collation is specified during [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] installation. Default server-level collation is **SQL_Latin1_General_CP1_CI_AS**. Unicode-only collations cannot be specified as the server-level collation. For more information, see [Collation and Unicode Support](collation-and-unicode-support.md).
-  
+  The server collation is specified during [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] installation. The default server-level collation is based upon the locale of the operating system. For example, the default collation for systems using US English (en-US) is **SQL_Latin1_General_CP1_CI_AS**. Unicode-only collations cannot be specified as the server-level collation. For more information, including the list of OS locale to default collation mappings, see the "Server-level collations" section of [Collation and Unicode Support](collation-and-unicode-support.md#Server-level-collations).
+
+> [!NOTE]  
+> The server-level collation for [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] Express LocalDB is **SQL_Latin1_General_CP1_CI_AS** and cannot be changed, either during or after installation.  
+
 ## Changing the server collation in SQL Server
 
  Changing the default collation for an instance of [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] can be a complex operation and involves the following steps:  
@@ -50,7 +53,7 @@ ms.reviewer: carlrab
 - Import all your data.  
   
 > [!NOTE]  
-> Instead of changing the default collation of an instance of [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)], you can specify a default collation for each new database you create.  
+> Instead of changing the default collation of an instance of [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)], you can specify a default collation for each new database you create via the `COLLATE` clause of the `CREATE DATABASE` and `ALTER DATABASE` statements. For more information, see [Set or Change the Database Collation](set-or-change-the-database-collation.md).  
   
 ## Setting the server collation in Managed Instance
 Server-level collation in Azure SQL Managed Instance can be specified when the instance is created and cannot be changed later. You can set server-level collation via [Azure portal](https://docs.microsoft.com/azure/sql-database/sql-database-managed-instance-get-started#create-a-managed-instance) or [PowerShell and Resource Manager template](https://docs.microsoft.com/azure/sql-database/scripts/sql-managed-instance-create-powershell-azure-resource-manager-template) while you are creating the instance. Default server-level collation is **SQL_Latin1_General_CP1_CI_AS**. Unicode-only and new UTF-8 collations cannot be specified as server-level collation.


### PR DESCRIPTION
1. Fix "Setting the server collation in SQL Server" section:
    1. Clarify that `SQL_Latin1_General_CP1_CI_AS` is the default collation when the OS locale is US English (en-US), and _not_ the default regardless of OS locale.
    1. Added anchor to link to "Collation and Unicode Support" page to take user directly to "Server-level collations" section. ( **please check to make sure that anchors can be added to URLs that point to an .md file** )
    1. This fixes Issue # 4103.

1. Add "Note" mentioning server-level collation for SQL Server Express LocalDB.

1. Improve note recommending changing collation of new DBs:
    1. Clarify that it's the `COLLATE` clause of the `CREATE DATABASE` and `ALTER DATABASE` statements.
    1. This fixes Issue # 2524.


Take care,
Solomon...
https://SqlQuantumLift.com/
https://SqlQuantumLeap.com/
https://SQLsharp.com/
