### PR TITLE
Fix broken link

### DIFF
--- a/docs/database-engine/configure-windows/server-properties-database-settings-page.md
+++ b/docs/database-engine/configure-windows/server-properties-database-settings-page.md
@@ -54,7 +54,7 @@ In [!INCLUDE[ssEnterpriseEd10](../../includes/ssenterpriseed10-md.md)] (or later
 - If the **Compress backup** box is checked, new backups are compressed by default.
   
     > [!IMPORTANT]
-    >  By default, compression significantly increases CPU usage, and the additional CPU consumed by the compression process might adversely affect concurrent operations. Therefore, you might want to create low-priority compressed backups in a session whose CPU usage is limited by [Resource Governor](../../relational-databases/resource-governor/resource-governor.md). For more information, see [Use Resource Governor to Limit CPU Usage by Backup Compression &#40;Transact-SQL&#41;](../.. relational-databases/backup-restore/use-resource-governor-to-limit-cpu-usage-by-backup-compression-transact-sql.md).
+    >  By default, compression significantly increases CPU usage, and the additional CPU consumed by the compression process might adversely affect concurrent operations. Therefore, you might want to create low-priority compressed backups in a session whose CPU usage is limited by [Resource Governor](../../relational-databases/resource-governor/resource-governor.md). For more information, see [Use Resource Governor to Limit CPU Usage by Backup Compression &#40;Transact-SQL&#41;](../../relational-databases/backup-restore/use-resource-governor-to-limit-cpu-usage-by-backup-compression-transact-sql.md).
   
 If you are a member of the **sysadmin** or **serveradmin** fixed server role, you can change the setting by clicking the **Compress backup** box.  
   


### PR DESCRIPTION
Add missing slash in URL which had a space instead and broke the URL.

The change in the last line of the document is unintended. I suspect a trailing newline being added by the GitHub editor. Is that a problem?