### PR TITLE
Remove extraneous reference to enabling script execution

### DIFF
--- a/docs/machine-learning/install/sql-machine-learning-services-windows-install.md
+++ b/docs/machine-learning/install/sql-machine-learning-services-windows-install.md
@@ -206,7 +206,7 @@ This step requires a server restart. If you are about to enable script execution
 
 ## Restart the service
 
-When the installation is complete, restart the database engine before continuing to the next, enabling script execution.
+When the installation is complete, restart the database engine.
 
 Restarting the service also automatically restarts the related [!INCLUDE[rsql_launchpad](../../includes/rsql-launchpad-md.md)] service.
 


### PR DESCRIPTION
The `enable script execution` section is now above the restart section.  This phrase doesn't make sense anymore.