### PR TITLE
Make table name in stored procedure consistent

### DIFF
--- a/docs/machine-learning/tutorials/sqldev-explore-and-visualize-the-data.md
+++ b/docs/machine-learning/tutorials/sqldev-explore-and-visualize-the-data.md
@@ -73,7 +73,7 @@ To create the plot, use [rxHistogram](https://docs.microsoft.com/machine-learnin
     BEGIN
       SET NOCOUNT ON;
       DECLARE @query nvarchar(max) =  
-      N'SELECT tipped FROM nyctaxi_sample'  
+      N'SELECT tipped FROM [dbo].[nyctaxi_sample]'  
       EXECUTE sp_execute_external_script @language = N'R',  
                                          @script = N'  
        image_file = tempfile();  


### PR DESCRIPTION
Both `RxPlotHistogram` and `RPlotHist` use the same source table `nyctaxi_sample` but reference it with a different name which can be confusing to people going through the tutorial. This change makes the table names consistent.