### PR TITLE
Upgraded secondary replicas non-readable warning

### DIFF
--- a/docs/database-engine/availability-groups/windows/active-secondaries-readable-secondary-replicas-always-on-availability-groups.md
+++ b/docs/database-engine/availability-groups/windows/active-secondaries-readable-secondary-replicas-always-on-availability-groups.md
@@ -54,9 +54,13 @@ ms.author: mathoma
      The database administrator needs to configure one or more replicas so that, when running under the secondary role, they allow either all connections (just for read-only access) or only read-intent connections.  
   
     > [!NOTE]  
-    >  Optionally, the database administrator can configure any of the availability replicas to exclude read-only connections when running under the primary role.  
+    >  Optionally, the database administrator can configure any of the availability replicas to exclude read-only connections when running under the primary role.
   
      For more information, see [About Client Connection Access to Availability Replicas &#40;SQL Server&#41;](../../../database-engine/availability-groups/windows/about-client-connection-access-to-availability-replicas-sql-server.md).  
+  
+    >[!WARNING]
+    >  Only replicas that are on the same major build of SQL Server will be readable. Please see [Rolling Upgrade Basics for more information](https://docs.microsoft.com/en-us/sql/database-engine/availability-groups/windows/upgrading-always-on-availability-group-replica-instances?view=sql-server-ver15#rolling-upgrade-basics-for-always-on-ags).
+  
   
 -   **Availability group listener**  
   

--- a/docs/database-engine/availability-groups/windows/active-secondaries-readable-secondary-replicas-always-on-availability-groups.md
+++ b/docs/database-engine/availability-groups/windows/active-secondaries-readable-secondary-replicas-always-on-availability-groups.md
@@ -59,7 +59,7 @@ ms.author: mathoma
      For more information, see [About Client Connection Access to Availability Replicas &#40;SQL Server&#41;](../../../database-engine/availability-groups/windows/about-client-connection-access-to-availability-replicas-sql-server.md).  
   
     >[!WARNING]
-    >  Only replicas that are on the same major build of SQL Server will be readable. Please see [Rolling Upgrade Basics for more information](https://docs.microsoft.com/en-us/sql/database-engine/availability-groups/windows/upgrading-always-on-availability-group-replica-instances?view=sql-server-ver15#rolling-upgrade-basics-for-always-on-ags).
+    >  Only replicas that are on the same major build of SQL Server will be readable. See [Rolling upgrade basics](upgrading-always-on-availability-group-replica-instances.md#rolling-upgrade-basics-for-always-on-ags) for more information.
   
   
 -   **Availability group listener**  


### PR DESCRIPTION
Specifically added a warning to call out that upgraded secondary replicas will not be readable even when marked so if they are upgraded to a newer version. Added the hyperlink to the page describing this in more detail.