### PR TITLE
Fixed typos; added name node requirement

### DIFF
--- a/docs/relational-databases/polybase/polybase-troubleshoot-connectivity.md
+++ b/docs/relational-databases/polybase/polybase-troubleshoot-connectivity.md
@@ -97,7 +97,7 @@ The tool runs independently of [!INCLUDE[ssNoVersion](../../includes/ssnoversion
 
 | Argument | Description|
 | --- | --- |
-| *Name Node Address* | The IP or FQDN of the name node. Refers to the "LOCATION" argument in your CREATE EXTERNAL DATA SOURCE T-SQL. Note: SQL Server 2019 version of tool requires 'hdfs://' to precede the IP or FQDN|
+| *Name Node Address* | The IP or FQDN of the name node. Refers to the "LOCATION" argument in your CREATE EXTERNAL DATA SOURCE T-SQL. Note: The SQL Server 2019 version of the tool requires *hdfs:\/\/* to precede the IP or FQDN.|
 | *Name Node Port* | The port of the name node. Refers to the "LOCATION" argument in your CREATE EXTERNAL DATA SOURCE T-SQL. For example, 8020. |
 | *Service Principal* | The admin service principal to your KDC. Matches the "IDENTITY" argument in your `CREATE DATABASE SCOPED CREDENTIAL` T-SQL.|
 | *Service Password* | Instead of typing your password at the console, store it in a file and pass the file path here. The contents of the file should match what you use as your "SECRET" argument in your `CREATE DATABASE SCOPED CREDENTIAL` T-SQL. |

--- a/docs/relational-databases/polybase/polybase-troubleshoot-connectivity.md
+++ b/docs/relational-databases/polybase/polybase-troubleshoot-connectivity.md
@@ -63,7 +63,7 @@ PolyBase has the following configuration XML files containing properties of the 
 
 These files are located under:
 
-`\[System Drive\]:{install path}\{instance}\{name}\MSSQL\Binn\PolyBase\Hadoop\conf`
+`\[System Drive\]:{install path}\{MSSQL##.INSTANCENAME}\MSSQL\Binn\PolyBase\Hadoop\conf`
 
 For example, the default for [!INCLUDE[ssSQL15](../../includes/sssql15-md.md)] is `C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Binn\PolyBase\Hadoop\conf`.
 
@@ -89,7 +89,7 @@ The other XMLs will later need to be updated as well if pushdown operations are 
 The tool runs independently of [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)], so it does not need to be running, nor does it need to be restarted if updates are made to the configuration XMLs. To run the tool, execute the following commands on the host with [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] installed:
 
 ```cmd
-> cd C:\Program Files\Microsoft [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)]\MSSQL13.MSSQLSERVER\MSSQL\Binn\PolyBase  
+> cd C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Binn\PolyBase  
 > java -classpath ".\Hadoop\conf;.\Hadoop\*;.\Hadoop\HDP2_2\*" com.microsoft.polybase.client.HdfsBridge {Name Node Address} {Name Node Port} {Service Principal} {Filepath containing Service Principal's Password} {Remote HDFS file path (optional)}
 ```
 
@@ -97,7 +97,7 @@ The tool runs independently of [!INCLUDE[ssNoVersion](../../includes/ssnoversion
 
 | Argument | Description|
 | --- | --- |
-| *Name Node Address* | The IP or FQDN of the name node. Refers to the "LOCATION" argument in your CREATE EXTERNAL DATA SOURCE T-SQL.|
+| *Name Node Address* | The IP or FQDN of the name node. Refers to the "LOCATION" argument in your CREATE EXTERNAL DATA SOURCE T-SQL. Note: SQL Server 2019 version of tool requires 'hdfs://' to precede the IP or FQDN|
 | *Name Node Port* | The port of the name node. Refers to the "LOCATION" argument in your CREATE EXTERNAL DATA SOURCE T-SQL. For example, 8020. |
 | *Service Principal* | The admin service principal to your KDC. Matches the "IDENTITY" argument in your `CREATE DATABASE SCOPED CREDENTIAL` T-SQL.|
 | *Service Password* | Instead of typing your password at the console, store it in a file and pass the file path here. The contents of the file should match what you use as your "SECRET" argument in your `CREATE DATABASE SCOPED CREDENTIAL` T-SQL. |


### PR DESCRIPTION
I fixed some typos and added requirement for SQL Server 2019 to use 'hdfs://' for the namenode argument.