### PR TITLE
Value for polybase.kerberos.realm property needs to be all upper case.

### DIFF
--- a/docs/relational-databases/polybase/polybase-troubleshoot-connectivity.md
+++ b/docs/relational-databases/polybase/polybase-troubleshoot-connectivity.md
@@ -83,6 +83,7 @@ Update **core-site.xml**, add the three properties below. Set the values accordi
     <value>KERBEROS</value>
 </property>
 ```
+NOTE: the value for polybase.kerberos.realm property needs to be all upper case.
 
 The other XMLs will later need to be updated as well if pushdown operations are desired, but with just this file configured, the HDFS file system should at least be able to be accessed.
 

--- a/docs/relational-databases/polybase/polybase-troubleshoot-connectivity.md
+++ b/docs/relational-databases/polybase/polybase-troubleshoot-connectivity.md
@@ -83,7 +83,8 @@ Update **core-site.xml**, add the three properties below. Set the values accordi
     <value>KERBEROS</value>
 </property>
 ```
-NOTE: the value for polybase.kerberos.realm property needs to be all upper case.
+> [!NOTE]
+> The value for `polybase.kerberos.realm` property needs to be all upper case.
 
 The other XMLs will later need to be updated as well if pushdown operations are desired, but with just this file configured, the HDFS file system should at least be able to be accessed.
 


### PR DESCRIPTION
This is to make sure our customers put this value in upper case. Many SQL DBAs will not know this requirement.