### PR TITLE
Typo "*@runincluster*"→"*\@runincluster*"

### DIFF
--- a/docs/sql-server/sql-server-2017-release-notes.md
+++ b/docs/sql-server/sql-server-2017-release-notes.md
@@ -70,7 +70,7 @@ There are no release notes for SQL Server on Windows related to this release. Se
 - **Issue and customer impact:** The parameter *runincluster* of the stored procedure **[catalog].[create_execution]** is renamed to *runinscaleout* for consistency and readability.
 - **Work around:** If you have existing scripts to run packages in Scale Out, you have to change the parameter name from *runincluster* to *runinscaleout* to make the scripts work in RC1.
 
-- **Issue and customer impact:** SQL Server Management Studio (SSMS) 17.1 and earlier versions can't trigger package execution in Scale Out in RC1. The error message is: "*@runincluster* is not a parameter for procedure **create_execution**." This issue is fixed in the next release of SSMS, version 17.2. Versions 17.2 and later of SSMS support the new parameter name and package execution in Scale Out. 
+- **Issue and customer impact:** SQL Server Management Studio (SSMS) 17.1 and earlier versions can't trigger package execution in Scale Out in RC1. The error message is: "*\@runincluster* is not a parameter for procedure **create_execution**." This issue is fixed in the next release of SSMS, version 17.2. Versions 17.2 and later of SSMS support the new parameter name and package execution in Scale Out. 
 - **Work around:** Until SSMS version 17.2 is available:
   1. Use your existing version of SSMS to generate the package execution script.
   2. Change the name of the *runincluster* parameter to *runinscaleout* in the script.


### PR DESCRIPTION
Italic with escape characters

https://docs.microsoft.com/en-us/sql/sql-server/sql-server-2017-release-notes?view=sql-server-2017