### PR TITLE
Update import-bulk-data-by-using-bulk-insert-or-openrowset-bulk-sql-s…

### DIFF
--- a/docs/relational-databases/import-export/import-bulk-data-by-using-bulk-insert-or-openrowset-bulk-sql-server.md
+++ b/docs/relational-databases/import-export/import-bulk-data-by-using-bulk-insert-or-openrowset-bulk-sql-server.md
@@ -104,6 +104,9 @@ BULK INSERT AdventureWorks2012.Sales.SalesOrderDetail
 
 When importing from Azure Blob storage and the data is not public (anonymous access), create a [DATABASE SCOPED CREDENTIAL](../../t-sql/statements/create-database-scoped-credential-transact-sql.md) based on a SAS key which is encrypted with a [MASTER KEY](../../t-sql/statements/create-master-key-transact-sql.md), and then create an [external database source](../../t-sql/statements/create-external-data-source-transact-sql.md) for use in your BULK INSERT command.
 
+> [!NOTE]
+> Do not use explicit transaction or you will receive a 4861 error.
+
 ### Using BULK INSERT
 
 The following example shows how to use the BULK INSERT command to load data from a csv file in an Azure Blob storage location on which you have created a SAS key. The Azure Blob storage location is configured as an external data source. This requires a database scoped credential using a shared access signature that is encrypted using a master key in the user database.

--- a/docs/relational-databases/import-export/import-bulk-data-by-using-bulk-insert-or-openrowset-bulk-sql-server.md
+++ b/docs/relational-databases/import-export/import-bulk-data-by-using-bulk-insert-or-openrowset-bulk-sql-server.md
@@ -105,7 +105,7 @@ BULK INSERT AdventureWorks2012.Sales.SalesOrderDetail
 When importing from Azure Blob storage and the data is not public (anonymous access), create a [DATABASE SCOPED CREDENTIAL](../../t-sql/statements/create-database-scoped-credential-transact-sql.md) based on a SAS key which is encrypted with a [MASTER KEY](../../t-sql/statements/create-master-key-transact-sql.md), and then create an [external database source](../../t-sql/statements/create-external-data-source-transact-sql.md) for use in your BULK INSERT command.
 
 > [!NOTE]
-> Do not use explicit transaction or you will receive a 4861 error.
+> Do not use explicit transaction, or you receive a 4861 error.
 
 ### Using BULK INSERT
 


### PR DESCRIPTION
You will receive `Msg 4861, Level 16, State 1, Line 15
Cannot bulk load because the file "test.csv" could not be opened. Operating system error code 32(The process cannot access the file because it is being used by another process.).` when you use explicit transaction to bulk import from Azure Blob storage as below.

```sql
BEGIN TRAN;
CREATE DATABASE SCOPED CREDENTIAL credentialtest
WITH IDENTITY = 'SHARED ACCESS SIGNATURE',
SECRET = 'sv=*****';
GO

CREATE EXTERNAL DATA SOURCE datasource          
WITH (              
TYPE = BLOB_STORAGE,               
LOCATION = 'https://*****.blob.core.windows.net/test',              
CREDENTIAL = credentialtest          
)
GO
 
BULK INSERT bulktest FROM 'test.csv'      
WITH (
BATCHSIZE = 1000,    
DATA_SOURCE = 'datasource',
DATAFILETYPE = 'char',
CODEPAGE = 'ACP',     
FIELDTERMINATOR = ',',
ROWTERMINATOR = '\n'    
)
GO

--COMMIT TRAN;
ROLLBACK TRAN;
```