### PR TITLE
SSIS catalog stored procedures - minor changes in sample call scripts

### DIFF
--- a/docs/integration-services/system-stored-procedures/catalog-add-data-tap-by-guid.md
+++ b/docs/integration-services/system-stored-procedures/catalog-add-data-tap-by-guid.md
@@ -23,7 +23,7 @@ ms.author: chugu
 ## Syntax  
   
 ```sql  
-catalog add_data_tap_by_guid [ @execution_id = ] execution_id  
+catalog.add_data_tap_by_guid [ @execution_id = ] execution_id  
 , [ @dataflow_task_guid = ] dataflow_task_guid   
 , [ @dataflow_path_id_string = ] dataflow_path_id_string  
 , [ @data_filename = ] data_filename  

--- a/docs/integration-services/system-stored-procedures/catalog-add-execution-worker-ssisdb-database.md
+++ b/docs/integration-services/system-stored-procedures/catalog-add-execution-worker-ssisdb-database.md
@@ -24,7 +24,7 @@ Adds a [!INCLUDE[ssISnoversion](../../includes/ssisnoversion-md.md)] Scale Out W
 ## Syntax
 
 ```sql
-catalog.add_execution_worker [@execution_id = ] execution_id, [@workeragent_id = ] workeragent_id
+catalog.add_execution_worker [ @execution_id = ] execution_id, [ @workeragent_id = ] workeragent_id
 ```
 
 ## Arguments

--- a/docs/integration-services/system-stored-procedures/catalog-check-schema-version.md
+++ b/docs/integration-services/system-stored-procedures/catalog-check-schema-version.md
@@ -27,7 +27,7 @@ ms.author: chugu
 ## Syntax  
   
 ```sql  
-catalog.check_schema_version [@use32bitruntime = ] use32bitruntime  
+catalog.check_schema_version [ @use32bitruntime = ] use32bitruntime  
 ```  
   
 ## Arguments  

--- a/docs/integration-services/system-stored-procedures/catalog-create-environment-ssisdb-database.md
+++ b/docs/integration-services/system-stored-procedures/catalog-create-environment-ssisdb-database.md
@@ -23,9 +23,9 @@ ms.author: chugu
 ## Syntax  
   
 ```sql  
-catalog.create_environment [@folder_name =] folder_name  
-     , [@environment_name =] environment_name  
-  [  , [@environment_description =] environment_description ]  
+catalog.create_environment [ @folder_name = ] folder_name  
+     , [ @environment_name = ] environment_name  
+  [  , [ @environment_description = ] environment_description ]  
 ```  
   
 ## Arguments  

--- a/docs/integration-services/system-stored-procedures/catalog-create-environment-variable-ssisdb-database.md
+++ b/docs/integration-services/system-stored-procedures/catalog-create-environment-variable-ssisdb-database.md
@@ -23,13 +23,13 @@ ms.author: chugu
 ## Syntax  
   
 ```sql  
-catalog.create_environment_variable [@folder_name =] folder_name  
-    , [@environment_name =] environment_name  
-    , [@variable_name =] variable_name  
-    , [@data_type =] data_type  
-    , [@sensitive =] sensitive  
-    , [@value =] value  
-    , [@description =] description  
+catalog.create_environment_variable [ @folder_name = ] folder_name  
+    , [ @environment_name = ] environment_name  
+    , [ @variable_name = ] variable_name  
+    , [ @data_type = ] data_type  
+    , [ @sensitive = ] sensitive  
+    , [ @value = ] value  
+    , [ @description = ] description  
 ```  
   
 ## Arguments  

--- a/docs/integration-services/system-stored-procedures/catalog-create-execution-ssisdb-database.md
+++ b/docs/integration-services/system-stored-procedures/catalog-create-execution-ssisdb-database.md
@@ -25,14 +25,14 @@ ms.author: chugu
 ## Syntax  
   
 ```sql  
-catalog.create_execution [@folder_name = folder_name  
-     , [@project_name =] project_name  
-     , [@package_name =] package_name  
-  [  , [@reference_id =] reference_id ]  
-  [  , [@use32bitruntime =] use32bitruntime ] 
-  [  , [@runinscaleout =] runinscaleout ]
-  [  , [@useanyworker =] useanyworker ] 
-     , [@execution_id =] execution_id OUTPUT  
+catalog.create_execution [ @folder_name = ] folder_name  
+     , [ @project_name = ] project_name  
+     , [ @package_name = ] package_name  
+  [  , [ @reference_id = ] reference_id ]  
+  [  , [ @use32bitruntime = ] use32bitruntime ] 
+  [  , [ @runinscaleout = ] runinscaleout ]
+  [  , [ @useanyworker = ] useanyworker ] 
+     , [ @execution_id = ] execution_id OUTPUT  
 ```  
   
 ## Arguments  

--- a/docs/integration-services/system-stored-procedures/catalog-create-folder-ssisdb-database.md
+++ b/docs/integration-services/system-stored-procedures/catalog-create-folder-ssisdb-database.md
@@ -23,7 +23,7 @@ ms.author: chugu
 ## Syntax  
   
 ```sql  
-catalog.create_folder [@folder_name =] folder_name, [@folder_id =] folder_id OUTPUT  
+catalog.create_folder [ @folder_name = ] folder_name, [ @folder_id = ] folder_id OUTPUT  
 ```  
   
 ## Arguments  

--- a/docs/integration-services/system-stored-procedures/catalog-delete-customized-logging-level.md
+++ b/docs/integration-services/system-stored-procedures/catalog-delete-customized-logging-level.md
@@ -23,8 +23,7 @@ ms.author: chugu
 ## Syntax  
   
 ```sql  
-delete_customized_logging_level [ @level_name = ] level_name  
-  
+catalog.delete_customized_logging_level [ @level_name = ] level_name
 ```  
   
 ## Arguments  

--- a/docs/integration-services/system-stored-procedures/catalog-delete-environment-reference-ssisdb-database.md
+++ b/docs/integration-services/system-stored-procedures/catalog-delete-environment-reference-ssisdb-database.md
@@ -23,7 +23,7 @@ ms.author: chugu
 ## Syntax  
   
 ```sql  
-delete_environment_reference [ @reference_id = ] reference_id  
+catalog.delete_environment_reference [ @reference_id = ] reference_id  
 ```  
   
 ## Arguments  

--- a/docs/integration-services/system-stored-procedures/catalog-delete-environment-ssisdb-database.md
+++ b/docs/integration-services/system-stored-procedures/catalog-delete-environment-ssisdb-database.md
@@ -23,7 +23,7 @@ ms.author: chugu
 ## Syntax  
   
 ```sql  
-delete_environment [ @folder_name = ] folder_name , [ @environment_name = ] environment_name  
+catalog.delete_environment [ @folder_name = ] folder_name , [ @environment_name = ] environment_name  
 ```  
   
 ## Arguments  

--- a/docs/integration-services/system-stored-procedures/catalog-delete-environment-variable-ssisdb-database.md
+++ b/docs/integration-services/system-stored-procedures/catalog-delete-environment-variable-ssisdb-database.md
@@ -23,7 +23,7 @@ ms.author: chugu
 ## Syntax  
   
 ```sql  
-delete_environment_variable [ @folder_name = ] folder_name  
+catalog.delete_environment_variable [ @folder_name = ] folder_name  
     , [ @environment_name = ] environment_name  
     , [ @variable_name = ] variable_name  
 ```  

--- a/docs/integration-services/system-stored-procedures/catalog-delete-folder-ssisdb-database.md
+++ b/docs/integration-services/system-stored-procedures/catalog-delete-folder-ssisdb-database.md
@@ -23,7 +23,7 @@ ms.author: chugu
 ## Syntax  
   
 ```sql  
-delete_folder [ @folder_name = ] folder_name  
+catalog.delete_folder [ @folder_name = ] folder_name  
 ```  
   
 ## Arguments  

--- a/docs/integration-services/system-stored-procedures/catalog-deploy-packages.md
+++ b/docs/integration-services/system-stored-procedures/catalog-deploy-packages.md
@@ -23,7 +23,10 @@ ms.author: chugu
 ## Syntax  
   
 ```sql  
-[catalog].[deploy_packages]     [ @folder_name = ] folder_name,    [ @project_name = ] project_name,    [ @packages_table = ] packages_table,     [ @operation_id OUTPUT ] operation_id OUTPUT ]  
+catalog.deploy_packages [ @folder_name = ] folder_name
+    , [ @project_name = ] project_name
+    , [ @packages_table = ] packages_table
+    [, [ @operation_id OUTPUT = ] operation_id OUTPUT]
 ```  
   
 ## Arguments  

--- a/docs/integration-services/system-stored-procedures/catalog-deploy-project-ssisdb-database.md
+++ b/docs/integration-services/system-stored-procedures/catalog-deploy-project-ssisdb-database.md
@@ -24,9 +24,9 @@ ms.author: chugu
   
 ```sql  
 catalog.deploy_project [@folder_name =] folder_name   
-      , [@project_name =] project_name   
-      , [@project_stream =] projectstream   
-    [ , [@operation_id ] = operation_id OUTPUT ]   
+      , [ @project_name = ] project_name   
+      , [ @project_stream = ] projectstream   
+    [ , [ @operation_id = ] operation_id OUTPUT ]   
 ```  
   
 ## Arguments  

--- a/docs/integration-services/system-stored-procedures/catalog-disable-worker-agent-ssisdb-database.md
+++ b/docs/integration-services/system-stored-procedures/catalog-disable-worker-agent-ssisdb-database.md
@@ -23,7 +23,7 @@ Disable a Scale Out Worker for Scale Out Master working with this [!INCLUDE[ssIS
 ## Syntax
 
 ```sql
-catalog.disable_worker_agent [@WorkerAgentId =] WorkerAgentId
+catalog.disable_worker_agent [ @WorkerAgentId = ] WorkerAgentId
 ```
 ## Arguments
 [@WorkerAgentId =] *WorkerAgentId*

--- a/docs/integration-services/system-stored-procedures/catalog-enable-worker-agent-ssisdb-database.md
+++ b/docs/integration-services/system-stored-procedures/catalog-enable-worker-agent-ssisdb-database.md
@@ -23,7 +23,7 @@ Enable a Scale Out Worker for Scale Out Master working with this [!INCLUDE[ssISn
 ## Syntax
 
 ```sql
-catalog.enable_worker_agent [@WorkerAgentId =] WorkerAgentId
+catalog.enable_worker_agent [ @WorkerAgentId = ] WorkerAgentId
 ```
 ## Arguments
 [@WorkerAgentId =] *WorkerAgentId*

--- a/docs/integration-services/system-stored-procedures/catalog-set-object-parameter-value-ssisdb-database.md
+++ b/docs/integration-services/system-stored-procedures/catalog-set-object-parameter-value-ssisdb-database.md
@@ -23,13 +23,13 @@ ms.author: chugu
 ## Syntax  
   
 ```sql  
-catalog.set_object_parameter_value [@object_type =] object_type   
-    , [@folder_name =] folder_name   
-    , [@project_name =] project_name   
-    , [@parameter_name =] parameter_name   
-    , [@parameter_value =] parameter_value   
- [  , [@object_name =] object_name ]  
- [  , [@value_type =] value_type ]  
+catalog.set_object_parameter_value [ @object_type = ] object_type   
+    , [ @folder_name = ] folder_name   
+    , [ @project_name = ] project_name   
+    , [ @parameter_name = ] parameter_name   
+    , [ @parameter_value = ] parameter_value   
+ [  , [ @object_name = ] object_name ]  
+ [  , [ @value_type = ] value_type ]  
 ```  
   
 ## Arguments  

--- a/docs/integration-services/system-stored-procedures/catalog-set-worker-agent-property-ssisdb-database.md
+++ b/docs/integration-services/system-stored-procedures/catalog-set-worker-agent-property-ssisdb-database.md
@@ -23,7 +23,9 @@ Sets the property of a [!INCLUDE[ssISnoversion](../../includes/ssisnoversion-md.
 ## Syntax
 
 ```sql
-catalog.set_worker_agent_property [@WorkerAgentId =] WorkerAgentId, [@PropertyName =] PropertyName, [@PropertyValue =] PropertyValue 
+catalog.set_worker_agent_property [ @WorkerAgentId = ] WorkerAgentId
+    , [ @PropertyName = ] PropertyName
+    , [ @PropertyValue = ] PropertyValue 
 ```
 
 ## Arguments

--- a/docs/integration-services/system-stored-procedures/catalog-start-execution-ssisdb-database.md
+++ b/docs/integration-services/system-stored-procedures/catalog-start-execution-ssisdb-database.md
@@ -23,7 +23,7 @@ ms.author: chugu
 ## Syntax  
   
 ```sql  
-catalog.start_execution [@execution_id =] execution_id [, [@retry_count =] retry_count]  
+catalog.start_execution [ @execution_id = ] execution_id [, [ @retry_count = ] retry_count]  
 ```  
   
 ## Arguments  

--- a/docs/integration-services/system-stored-procedures/catalog-update-logdb-info.md
+++ b/docs/integration-services/system-stored-procedures/catalog-update-logdb-info.md
@@ -23,7 +23,7 @@ Update the [!INCLUDE[ssISnoversion](../../includes/ssisnoversion-md.md)] Scale O
 ## Syntax
 
 ```sql
-catalog.update_logdb_info [@server_name = ] server_name, [@connection_string = ] connection_string
+catalog.update_logdb_info [ @server_name = ] server_name, [ @connection_string = ] connection_string
 ```
 
 ## Arguments

--- a/docs/integration-services/system-stored-procedures/catalog-update-master-address.md
+++ b/docs/integration-services/system-stored-procedures/catalog-update-master-address.md
@@ -23,7 +23,7 @@ Update the [!INCLUDE[ssISnoversion](../../includes/ssisnoversion-md.md)] Scale O
 ## Syntax
 
 ```sql
-catalog.update_master_address [@MasterAddress = ] masterAddress
+catalog.update_master_address [ @MasterAddress = ] masterAddress
 ```
 
 ## Arguments


### PR DESCRIPTION
Minor fixes:

- Some sample script depicts the name of the catalog stored procedure without any schema. For example [here](https://docs.microsoft.com/en-us/sql/integration-services/system-stored-procedures/catalog-delete-folder-ssisdb-database?view=sql-server-ver15), you can see the following script:
![image](https://user-images.githubusercontent.com/2568107/83759173-786bc500-a673-11ea-9ac5-bb123908e629.png)

- sometimes, the script misses the "." separator in the full name:
![image](https://user-images.githubusercontent.com/2568107/83759296-a224ec00-a673-11ea-8999-03c9748d0047.png)

- there are two ways of representing params (case 1 NO SPACES and 2 WITH SPACES, pictures below):
![image](https://user-images.githubusercontent.com/2568107/83759463-dc8e8900-a673-11ea-9aca-5d1ee6982b26.png)

![image](https://user-images.githubusercontent.com/2568107/83759539-fd56de80-a673-11ea-834a-4332dc29b4f0.png)

- finally, wrong square brackets and "=" (a little here and a little there):
  - [wrong syntax](https://docs.microsoft.com/en-us/sql/integration-services/system-stored-procedures/catalog-deploy-packages?view=sql-server-ver15)
  - [missing "=" and wrong syntax](https://docs.microsoft.com/en-us/sql/integration-services/system-stored-procedures/catalog-create-execution-ssisdb-database?view=sql-server-ver15)