### PR TITLE
Improve examples

### DIFF
--- a/docs/relational-databases/collations/write-international-transact-sql-statements.md
+++ b/docs/relational-databases/collations/write-international-transact-sql-statements.md
@@ -53,7 +53,7 @@ monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-s
         ```sql  
         SELECT *  
         FROM AdventureWorks2012.Sales.SalesOrderHeader  
-        WHERE OrderDate = CONVERT(DATETIME, '20060719', 101)  
+        WHERE OrderDate = CONVERT(DATETIME, '07/19/2006', 101)  
         ```  
   
 ## See also


### PR DESCRIPTION
- According to the documentation of CAST and CONVERT, 101 is U.S. style.
- The two last bullet points have the same introduction, so that it is unclear what to use. Maybe the penultimate bullet point should be deleted?