### PR TITLE
Update Examples FILE_TYPE comma

### DIFF
--- a/docs/t-sql/statements/copy-into-transact-sql.md
+++ b/docs/t-sql/statements/copy-into-transact-sql.md
@@ -356,7 +356,7 @@ WITH (
 COPY INTO test_parquet
 FROM 'https://myaccount.blob.core.windows.net/myblobcontainer/folder1/*.parquet'
 WITH (
-    FILE_FORMAT = myFileFormat
+    FILE_FORMAT = myFileFormat,
     CREDENTIAL=(IDENTITY= 'Shared Access Signature', SECRET='<Your_SAS_Token>')
 )
 ```
@@ -369,7 +369,7 @@ FROM
 'https://myaccount.blob.core.windows.net/myblobcontainer/folder0/*.txt', 
 	'https://myaccount.blob.core.windows.net/myblobcontainer/folder1'
 WITH ( 
-	FILE_TYPE = 'CSV'
+	FILE_TYPE = 'CSV',
 	CREDENTIAL=(IDENTITY= '<client_id>@<OAuth_2.0_Token_EndPoint>',SECRET='<key>'),
 	FIELDTERMINATOR = '|'
 )


### PR DESCRIPTION
Some of the examples did not have a comma after specifying the FILE_TYPE parameter. This was inconsistent within the page and incorrect syntax - a comma is required following the FILE_TYPE parameter for the credential to be correct parsed.

Unsure if D should read _FILE_FORMAT = 'myFileFormat',_ to ensure it is correctly understood that it must be quoted.
