### PR TITLE
Removed the section "By default the SSIS service does not support del…

### DIFF
--- a/docs/2014/integration-services/connect-to-a-remote-integration-services-server-ssis-service.md
+++ b/docs/2014/integration-services/connect-to-a-remote-integration-services-server-ssis-service.md
@@ -91,13 +91,6 @@ ms.author: chugu
 ## Connecting by using a Local Account  
  If you are working in a local Windows account on a client computer, you can connect to the [!INCLUDE[ssISnoversion](../includes/ssisnoversion-md.md)] service on a remote computer only if a local account that has the same name and password and the appropriate rights exists on the remote computer.  
   
-## By default the SSIS service does not support delegation  
-By default the [!INCLUDE[ssNoVersion](../includes/ssnoversion-md.md)] [!INCLUDE[ssISnoversion](../includes/ssisnoversion-md.md)] service does not support the delegation of credentials, or what is sometimes referred to as a double hop. In this scenario, you are working on a client computer, the [!INCLUDE[ssISnoversion](../includes/ssisnoversion-md.md)] service is running on a second computer, and [!INCLUDE[ssNoVersion](../includes/ssnoversion-md.md)] is running on a third computer. First, [!INCLUDE[ssManStudioFull](../includes/ssmanstudiofull-md.md)] successfully passes your credentials from the client computer to the second computer on which the [!INCLUDE[ssISnoversion](../includes/ssisnoversion-md.md)] service is running. Then, however, the [!INCLUDE[ssISnoversion](../includes/ssisnoversion-md.md)] service cannot delegate your credentials from the second computer to the third computer on which [!INCLUDE[ssNoVersion](../includes/ssnoversion-md.md)] is running.
-
-You can enable delegation of credentials by granting the **Trust this user for delegation to any service (Kerberos Only)** right to the SQL Server service account, which launches the Integration Services service (ISServerExec.exe) as a child process. Before you grant this right, consider whether it meets the security requirements of your organization.
-
-For more info, see [Getting Cross Domain Kerberos and Delegation working with SSIS Package](https://blogs.msdn.microsoft.com/psssql/2014/06/26/getting-cross-domain-kerberos-and-delegation-working-with-ssis-package/).
-  
 ## See Also  
  [Configure a Windows Firewall for Access to the SSIS Service](../../2014/integration-services/configure-a-windows-firewall-for-access-to-the-ssis-service.md)  
   


### PR DESCRIPTION
…egation" which is incorrectly added to this page.

This page is about SSIS Windows Service (MsDtsSrvr.exe) which is used for managing packages which are deployed and stored under MSDB, File System & SSIS package store using the old legacy package deployment model. The content on this section (which is proposed for deletion) is not relevant to the page. This section talks about SSIS Execution Runtime process (ISSERVEREXEC.exe) which is not related to SSIS Windows Service (MsDtsSrvr.exe). ISSERVEREXEC.exe is used only when executing the packages stored under SSISDB catalog using the new project deployment model.