### PR TITLE
Adjustment for read-scale availability in standard

### DIFF
--- a/docs/sql-server/editions-and-components-of-sql-server-2017.md
+++ b/docs/sql-server/editions-and-components-of-sql-server-2017.md
@@ -161,7 +161,7 @@ The Developer edition continues to support only 1 client for [SQL Server Distrib
 |Database recovery advisor|Yes|Yes|Yes|Yes|Yes|
 |Encrypted backup|Yes|Yes|No|No|No|
 |Hybrid backup to Azure (backup to URL)|Yes|Yes|No|No|No|
-|Read-scale availability group<sup>3,4</sup>|Yes|Yes|No|No|No|No|
+|Read-scale availability group<sup>3,4</sup>|Yes|No|No|No|No|No|
 
 <sup>1</sup> For more information on installing SQL Server on Server Core,  see [Install SQL Server on Server Core](../database-engine/install-windows/install-sql-server-on-server-core.md). 
 


### PR DESCRIPTION
Change the support for read-scale availability groups in Standard edition to No - Standard edition only includes support for Basic availability groups that don't offer any readable secondaries, so in fact we will throw an error when trying to create a readable secondary in Basic availability group. This causes confusion for customers: https://feedback.azure.com/forums/908035-sql-server/suggestions/39254050-documentation-update-read-scale-availability-grou