### PR TITLE
Fix returns section formatting in ODBC API reference

### DIFF
--- a/docs/odbc/reference/syntax/sqlgetinfo-function.md
+++ b/docs/odbc/reference/syntax/sqlgetinfo-function.md
@@ -66,7 +66,7 @@ SQLRETURN SQLGetInfo(
   
  For all other types of data, the value of *BufferLength* is ignored and the driver assumes the size of \**InfoValuePtr* is SQLUSMALLINT or SQLUINTEGER, depending on the *InfoType*.  
   
-## Return Value  
+## Returns  
 
  SQL_SUCCESS, SQL_SUCCESS_WITH_INFO, SQL_ERROR, or SQL_INVALID_HANDLE.  
   

--- a/docs/odbc/reference/syntax/sqlsetpos-function.md
+++ b/docs/odbc/reference/syntax/sqlsetpos-function.md
@@ -65,7 +65,7 @@ SQLRETURN SQLSetPos(
   
  For more information, see "Comments."  
   
- **Returns**  
+## Returns  
   
  SQL_SUCCESS, SQL_SUCCESS_WITH_INFO, SQL_NEED_DATA, SQL_STILL_EXECUTING, SQL_ERROR, or SQL_INVALID_HANDLE.  
   


### PR DESCRIPTION
Fixed formatting of `Returns` section in ODBC API reference for `SQLGetInfo` and `SQLSetPos` functions