### PR TITLE
fix conformance section format in ODBC API reference functions

### DIFF
--- a/docs/odbc/reference/syntax/sqlcancelhandle-function.md
+++ b/docs/odbc/reference/syntax/sqlcancelhandle-function.md
@@ -17,9 +17,7 @@ ms.author: v-daenge
 ---
 # SQLCancelHandle Function
 **Conformance**  
- Version Introduced: ODBC 3.8  
-  
- Standards Compliance: None  
+ Version Introduced: ODBC 3.8 Standards Compliance: None  
   
  It is expected that most ODBC 3.8 (and later) drivers will implement this function. If a driver does not, a call to **SQLCancelHandle** with a connection handle in the *Handle* parameter will return SQL_ERROR with a SQLSTATE of IM001 and message 'Driver does not support this function'' A call to **SQLCancelHandle** with a statement handle as the *Handle* parameter will be mapped to a call to **SQLCancel** by the Driver Manager and can be processed if the driver implements **SQLCancel**. An application can use **SQLGetFunctions** to determine if a driver supports **SQLCancelHandle**.  
   

--- a/docs/odbc/reference/syntax/sqlcompleteasync-function.md
+++ b/docs/odbc/reference/syntax/sqlcompleteasync-function.md
@@ -17,9 +17,7 @@ ms.author: v-daenge
 ---
 # SQLCompleteAsync Function
 **Conformance**  
- Version Introduced: ODBC 3.8  
-  
- Standards Compliance: None  
+ Version Introduced: ODBC 3.8 Standards Compliance: None  
   
  **Summary**  
  **SQLCompleteAsync** can be used to determine when an asynchronous function is complete using either notification- or polling-based processing. For more information about asynchronous operations, see [Asynchronous Execution](../../../odbc/reference/develop-app/asynchronous-execution.md).  


### PR DESCRIPTION
Fixed formatting of Conformance section for `SQLCancelHandle` and `SQLCompleteAsync` API reference to match formatting of other function API references.