### PR TITLE
Update sys-pdw-nodes-column-store-row-groups-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-catalog-views/sys-pdw-nodes-column-store-row-groups-transact-sql.md
+++ b/docs/relational-databases/system-catalog-views/sys-pdw-nodes-column-store-row-groups-transact-sql.md
@@ -6,6 +6,7 @@ ms.prod: sql
 ms.technology: data-warehouse
 ms.reviewer: ""
 ms.topic: "language-reference"
+ms.custom: fasttrack-edit
 dev_langs: 
   - "TSQL"
 ms.assetid: 17a4c925-d4b5-46ee-9cd6-044f714e6f0e


### PR DESCRIPTION
The first query example does not handle the division by zero on total_rows
It would good to either filter it (total_rows>0) or warn about it in the paragraph describing it.
There are cases where the response time is very long, and finish due to this error.