### PR TITLE
Update release-notes-ssms.md

### DIFF
--- a/docs/ssms/release-notes-ssms.md
+++ b/docs/ssms/release-notes-ssms.md
@@ -97,6 +97,7 @@ SSMS 18.6 is the latest general availability (GA) release of SSMS. If you need a
 | General SSMS | New Server Audit Specification dialog may cause SSMS to crash with an access violation error. | N/A |
 | General SSMS | SSMS Extensions using SMO should be recompiled targeting the new SSMS-specific SMO v161 package. A preview version is available at https://www.nuget.org/packages/Microsoft.SqlServer.SqlManagementObjects.SSMS/ </br></br> Extensions compiled against previous 160 versions of Microsoft.SqlServer.SqlManagementObjects package will still function. | N/A |
 | Integration Services | When importing or exporting packages in Integration Services or exporting packages in Azure-SSIS Integration Runtime, scripts are lost for packages containing script tasks/components. Workaround: Remove folder "C:\Program Files (x86)\Microsoft SQL Server Management Studio 18\Common7\IDE\CommonExtensions\MSBuild". | N/A|
+| Integration Services | Remote connections to Integration services may fail with "The specified service does not exist as an installed service." on newer Operating system. Workaround: Identify the Integration services related registry location under Computer\HKEY_CLASSES_ROOT\AppID & Computer\HKEY_CLASSES_ROOT\ WOW6432Node\AppID and within these hives, rename the registry key named 'LocalService' to 'LocalService_A' for the specific version of Integration services that we are trying to connect | N/A|
 
 
 You can reference [SQL Server user feedback](https://feedback.azure.com/forums/908035-sql-server) for other known issues and to provide feedback to the product team.
@@ -144,6 +145,7 @@ Download previous SSMS versions by selecting the download link in the related se
 | General SSMS | New Server Audit Specification dialog may cause SSMS to crash with an access violation error. | N/A ||
 | SMO/Scripting | SSMS Extensions using SMO need to be recompiled targeting the new SMO v160. | N/A |
 | Integration Services | When importing or exporting packages in Integration Services or exporting packages in Azure-SSIS Integration Runtime, scripts are lost for packages containing script tasks/components. Workaround: | Remove folder "C:\Program Files (x86)\Microsoft SQL Server Management Studio 18\Common7\IDE\CommonExtensions\MSBuild". |
+
 
 ### 18.5
 


### PR DESCRIPTION
Added one of the known issues with SSMS with respect to remote connections to Integration services (SSIS). The SSMS installation shouldn't add these registries for local Integration services as discussed above. The installation of Integration services are supposed to add them. Due to a new bug with Windows DCOM, any new SSIS connection request have now started using these registry keys to initiate a local connection rather than a remote RPC call.  Previously they used to ignore these values. Functionality to add these registry keys during SSMS installation will be removed for the future versions and SSIS product team is working with the SSMS team to get this corrected.