### PR TITLE
Update openjson-transact-sql.md for JSON type clarity

### DIFF
--- a/docs/t-sql/functions/openjson-transact-sql.md
+++ b/docs/t-sql/functions/openjson-transact-sql.md
@@ -227,7 +227,7 @@ The columns that the OPENJSON function returns depend on the WITH option.
         |------------------------------|--------------------|  
         |0|null|  
         |1|string|  
-        |2|int|  
+        |2|number|  
         |3|true/false|  
         |4|array|  
         |5|object|  


### PR DESCRIPTION
Minor clarification in JSON data type table, changing "int" to "number" because in addition to integers, SQL Server returns floating point and exponential notation as type 2.
Per JSON Schema terminology, this is described as "number".
https://json-schema.org/understanding-json-schema/reference/numeric.html

SQL Code example:
```TSQL
DECLARE @json varchar(max) =
'{
	"num1": 48,
	"num2": 3.333,
	"num3": 2.99792458e8
}'
SELECT * 
FROM 
OPENJSON(@json)
```