### PR TITLE
Update set-query-governor-cost-limit-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/set-query-governor-cost-limit-transact-sql.md
+++ b/docs/t-sql/statements/set-query-governor-cost-limit-transact-sql.md
@@ -41,9 +41,9 @@ SET QUERY_GOVERNOR_COST_LIMIT value
 
 ## Arguments
  *value*  
- Is a numeric or integer value specifying the longest time in which a query can run. Values are rounded down to the nearest integer. Negative values are rounded up to 0. The query governor disallows execution of any query that has an estimated cost exceeding that value. Specifying 0 (the default) for this option turns off the query governor, and all queries are allowed to run indefinitely.  
+ Is a numeric or integer value specifying the highest estimated cost allowed for a given query to run. Values are rounded down to the nearest integer. Negative values are rounded up to 0. The query governor disallows execution of any query that has an estimated cost exceeding that value. Specifying 0 (the default) for this option turns off the query governor, and all queries of any cost are allowed to execute.  
   
- "Query cost" refers to the estimated elapsed time, in seconds, required to complete a query on a specific hardware configuration.  
+ Query cost is an abstract figure determined by the query optimizer based on estimated execution requirements such as cpu time, memory, and disk IO and refers to the estimated elapsed time, in seconds, that would be required to complete a query on a specific hardware configuration. This abstract figure does not equate to the time required to complete a query on the running instance, and should instead be treated as a relative measure.
   
 ## Remarks  
  Using SET QUERY_GOVERNOR_COST_LIMIT applies to the current connection only and lasts the duration of the current connection. Use the [Configure the query governor cost limit Server Configuration Option](../../database-engine/configure-windows/configure-the-query-governor-cost-limit-server-configuration-option.md)option of **sp_configure** to change the server-wide query governor cost limit value. For more information about configuring this option, see [sp_configure](../../relational-databases/system-stored-procedures/sp-configure-transact-sql.md) and [Server Configuration Options &#40;SQL Server&#41;](../../database-engine/configure-windows/server-configuration-options-sql-server.md).  


### PR DESCRIPTION
Related to my previous PR #5308 for the server configuration setting. This session configuration documentation misleadingly infers that the query cost is a measure of execution time when in fact this value is really the execution time on "Nick's machine". I have updated this document to reflect and clarify that the setting is not a measure of seconds on it's running instance to avoid the scenario where someone is using it to prevent queries for running for X seconds. I have also underlined the fact that the cost is based on estimations, not actuals. It also does not cancel running queries (like the documentation suggests) but instead will not execute a query over the threshold. I have fixed these issues.