### PR TITLE
fix typo in unicode-function-arguments document

### DIFF
--- a/docs/odbc/reference/develop-app/unicode-function-arguments.md
+++ b/docs/odbc/reference/develop-app/unicode-function-arguments.md
@@ -30,7 +30,7 @@ The ODBC 3.5 (or higher) Driver Manager supports both ANSI and Unicode versions 
 |**SQLColAttribute**|**SQLGetInfo**|  
 |**SQLColAttributes**|**SQLGetStmtAttr**|  
 |**SQLColumnPrivileges**|**SQLGetTypeInfo**|  
-|**SQLColumns**|**SQLNativeSQL**|  
+|**SQLColumns**|**SQLNativeSql**|  
 |**SQLConnect**|**SQLPrepare**|  
 |**SQLDataSources**|**SQLPrimaryKeys**|  
 |**SQLDescribeCol**|**SQLProcedureColumns**|  


### PR DESCRIPTION
Name of the ODBC function was spelled incorrectly