### PR TITLE
update sys-sp-cdc-add-job-transact-sql.md for pollinginterval setting

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sys-sp-cdc-add-job-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sys-sp-cdc-add-job-transact-sql.md
@@ -70,7 +70,7 @@ sys.sp_cdc_add_job [ @job_type = ] 'job_type'
 `[ @pollinginterval ] = polling\_interval_`
  Number of seconds between log scan cycles. *polling_interval* is **bigint** with a default of 5.  
   
- *polling_interval* is valid only for capture jobs when *continuous* is set to 1. If specified, the value cannot be negative and cannot exceed 24 hours. If a value of 0 is specified, there is no wait between log scans.  
+ *polling_interval* is valid only for capture jobs when *continuous* is set to 1. If specified, the value must be greater than or equal to 0 and less than 24 hours(Max: 86399 seconds). If a value of 0 is specified, there is no wait between log scans.  
   
 `[ @retention ] = retention_`
  Number of minutes that change data rows are to be retained in change tables. *retention* is **bigint** with a default of 4320 (72 hours). The maximum value is 52494800 (100 years). If specified, the value must be a positive integer.  


### PR DESCRIPTION
CDC pollinginterval can only be greater than or equal to 0 and less than 24 hours(Max: 86399 seconds)