### PR TITLE
Update merge-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/merge-transact-sql.md
+++ b/docs/t-sql/statements/merge-transact-sql.md
@@ -475,10 +475,8 @@ GO
 
 In this example, you create node tables `Person` and `City` and an edge table `livesIn`. You use the MERGE statement on the `livesIn` edge and insert a new row if the edge doesn't already exist between a `Person` and `City`. If the edge already exists, then you just update the StreetAddress attribute on the `livesIn` edge.
 
-This example is not valid in SQL Server 2017!
-
->Msg 102, Level 15, State 1, Procedure mergeEdge, Line 13 [Batch Start Line 36]
->Incorrect syntax near '>'.
+> [!NOTE]
+> The following example applies to SQL Server starting with 2019.
 
 ```sql
 -- CREATE node and edge tables

--- a/docs/t-sql/statements/merge-transact-sql.md
+++ b/docs/t-sql/statements/merge-transact-sql.md
@@ -475,6 +475,11 @@ GO
 
 In this example, you create node tables `Person` and `City` and an edge table `livesIn`. You use the MERGE statement on the `livesIn` edge and insert a new row if the edge doesn't already exist between a `Person` and `City`. If the edge already exists, then you just update the StreetAddress attribute on the `livesIn` edge.
 
+This example is not valid in SQL Server 2017!
+
+>Msg 102, Level 15, State 1, Procedure mergeEdge, Line 13 [Batch Start Line 36]
+>Incorrect syntax near '>'.
+
 ```sql
 -- CREATE node and edge tables
 CREATE TABLE Person


### PR DESCRIPTION
invalid example using merge into an edge-table. The example code is not working in SQL Server 2017.
A valid example is required, but I have no idea which code could work. At least a warning should be until a valid code example will be provided.
the "ON MATCH (Person-(livesIn)->City" causes the error when used in the merge statement.