### PR TITLE
Typo correction and additional warning

### DIFF
--- a/docs/t-sql/language-elements/variables-transact-sql.md
+++ b/docs/t-sql/language-elements/variables-transact-sql.md
@@ -25,13 +25,9 @@ A Transact-SQL local variable is an object that can hold a single data value of 
 * To save a data value to be returned by a stored procedure return code or function return value.
 
 > [!NOTE]
-> The names of some Transact-SQL system functions begin with two *at* signs (\@\@). Although in earlier versions of [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)], the \@\@functions are referred to as global variables, they are not variables and do not have the same behaviors as variables. The \@\@functions are system functions, and their syntax usage follows the rules for functions.
-
-> [!NOTE]
-> Variables can notbe used in views.
-
-> [!NOTE]
-> Changes to variables are not affected by the rollback of a transaction.
+> - The names of some Transact-SQL system functions begin with two *at* signs (\@\@). Although in earlier versions of [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)], the \@\@functions are referred to as global variables, \@\@functions aren't variables, and they don't have the same behaviors as variables. The \@\@functions are system functions, and their syntax usage follows the rules for functions.
+> - You can't use variables in a view.
+> - Changes to variables aren't affected by the rollback of a transaction.
 
 The following script creates a small test table and populates it with 26 rows. The script uses a variable to do three things: 
 

--- a/docs/t-sql/language-elements/variables-transact-sql.md
+++ b/docs/t-sql/language-elements/variables-transact-sql.md
@@ -28,7 +28,10 @@ A Transact-SQL local variable is an object that can hold a single data value of 
 > The names of some Transact-SQL system functions begin with two *at* signs (\@\@). Although in earlier versions of [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)], the \@\@functions are referred to as global variables, they are not variables and do not have the same behaviors as variables. The \@\@functions are system functions, and their syntax usage follows the rules for functions.
 
 > [!NOTE]
-> Variables can not be used in views.
+> Variables can notbe used in views.
+
+> [!NOTE]
+> Changes to variables are not affected by the rollback of a transaction.
 
 The following script creates a small test table and populates it with 26 rows. The script uses a variable to do three things: 
 


### PR DESCRIPTION
The original post had "can not" instead of cannot, which is a spelling error. This page also does not mention transactions, which is an important concept for variables.