### PR TITLE
Update the `See Also` Section

### DIFF
--- a/docs/t-sql/data-types/char-and-varchar-transact-sql.md
+++ b/docs/t-sql/data-types/char-and-varchar-transact-sql.md
@@ -175,10 +175,17 @@ String                                       TruncatedValue
 ## See also
 
 [nchar and nvarchar &#40;Transact-SQL&#41;](../../t-sql/data-types/nchar-and-nvarchar-transact-sql.md)
+
 [CAST and CONVERT &#40;Transact-SQL&#41;](../../t-sql/functions/cast-and-convert-transact-sql.md)
+
 [COLLATE &#40;Transact-SQL&#41;](../../t-sql/statements/collations.md)
+
 [Data Type Conversion &#40;Database Engine&#41;](../../t-sql/data-types/data-type-conversion-database-engine.md)
+
 [Data Types &#40;Transact-SQL&#41;](../../t-sql/data-types/data-types-transact-sql.md)
+
 [Estimate the Size of a Database](../../relational-databases/databases/estimate-the-size-of-a-database.md)
+
 [Collation and Unicode Support](../../relational-databases/collations/collation-and-unicode-support.md)
+
 [Single-Byte and Multibyte Character Sets](/cpp/c-runtime-library/single-byte-and-multibyte-character-sets)


### PR DESCRIPTION
Without a newline separating these articles, they appear on one run-on line. That ends up being very difficult to read.