### PR TITLE
Clarifying that ALTER TABLE ALTER COLUMN requires UPDATE

### DIFF
--- a/docs/t-sql/statements/alter-table-transact-sql.md
+++ b/docs/t-sql/statements/alter-table-transact-sql.md
@@ -1079,7 +1079,7 @@ ALTER TABLE permissions apply to both tables involved in an ALTER TABLE SWITCH s
 
 If you've defined any columns in the ALTER TABLE statement to be of a common language runtime (CLR) user-defined type or alias data type, REFERENCES permission on the type is required.
 
-Adding a column that updates the rows of the table requires **UPDATE** permission on the table. For example, adding a **NOT NULL** column with a default value or adding an identity column when the table isn't empty.
+Adding or altering a column that updates the rows of the table requires **UPDATE** permission on the table. For example, adding a **NOT NULL** column with a default value or adding an identity column when the table isn't empty.
 
 ## <a name="Example_Top"></a> Examples
 


### PR DESCRIPTION
EG 
use tempdb
go
revert 
go
if exists(select * from sys.database_principals where name = 'fred')
  drop user fred
go
drop table if exists tablename
go
create user fred without login

create table tablename(id int, variablename varchar(20))
go
grant select on tablename to fred 
--grant update on tablename to fred  --uncomment to clear error
grant alter on schema::dbo to fred

execute as user='fred'
  ALTER TABLE dbo.tablename ALTER COLUMN variablename datetime2
revert