### PR TITLE
needs to change tag for Azure SQL DB

### DIFF
--- a/docs/relational-databases/databases/increase-the-size-of-a-database.md
+++ b/docs/relational-databases/databases/increase-the-size-of-a-database.md
@@ -19,7 +19,7 @@ ms.author: "sstein"
 monikerRange: "=azuresqldb-current||>=sql-server-2016||=sqlallproducts-allversions||>=sql-server-linux-2017||=azuresqldb-mi-current"
 ---
 # Increase the Size of a Database
-[!INCLUDE [SQL Server Azure SQL Database](../../includes/applies-to-version/sql-asdb.md)]
+[!INCLUDE [SQL Server](../../includes/applies-to-version/sql-asdb.md)]
   This topic describes how to increase the size of a database in [!INCLUDE[ssCurrent](../../includes/sscurrent-md.md)] by using [!INCLUDE[ssManStudioFull](../../includes/ssmanstudiofull-md.md)] or [!INCLUDE[tsql](../../includes/tsql-md.md)]. The database is expanded by either increasing the size of an existing data or log file or by adding a new file to the database.  
   
  **In This Topic**  


### PR DESCRIPTION
Following alter statement does not works in Azure SQL DB. Please remove azure sqldb tag from doc

ALTER DATABASE shshakya MODIFY FILE (NAME = data_0, SIZE = 512MB);

Msg 5008, Level 16, State 2, Line 3
This ALTER DATABASE statement is not supported. Correct the syntax and execute the statement again.

Completion time: 2020-09-07T10:34:11.5829622+05:30