### PR TITLE
Fixing the Example Code for Azure Key Vault

### DIFF
--- a/docs/connect/jdbc/using-always-encrypted-with-the-jdbc-driver.md
+++ b/docs/connect/jdbc/using-always-encrypted-with-the-jdbc-driver.md
@@ -145,15 +145,15 @@ The following examples show how the connection properties are used in a connecti
 
 #### Use Managed Identity to authenticate to AKV
 ```
-"jdbc:sqlserver://<server>:<port>;columnEncryptionSetting=Enabled;keyStoreAuthentication=keyStoreManagedIdentity;"
+"jdbc:sqlserver://<server>:<port>;columnEncryptionSetting=Enabled;keyStoreAuthentication=KeyVaultManagedIdentity;"
 ```
 #### Use Managed Identity and the principal ID to authenticate to AKV
 ```
-"jdbc:sqlserver://<server>:<port>;columnEncryptionSetting=Enabled;keyStoreAuthentication=keyStoreManagedIdentity;keyStorePrincipal=<principalId>"
+"jdbc:sqlserver://<server>:<port>;columnEncryptionSetting=Enabled;keyStoreAuthentication=KeyVaultManagedIdentity;keyStorePrincipal=<principalId>"
 ```
 #### Use clientId and clientSecret to authentication to AKV
 ```
-"jdbc:sqlserver://<server>:<port>;columnEncryptionSetting=Enabled;keyStoreAuthentication=keyStoreSecret;keyStorePrincipalId=<clientId>;keyStoreSecret=<clientSecret>"
+"jdbc:sqlserver://<server>:<port>;columnEncryptionSetting=Enabled;keyStoreAuthentication=KeyVaultClientSecret;keyStorePrincipalId=<clientId>;keyStoreSecret=<clientSecret>"
 ```
 Users are encouraged to use these connection properties to specify the type of authentication used for the Key Stores instead of using the `SQLServerColumnEncryptionAzureKeyVaultProvider`.
 


### PR DESCRIPTION
Fixed the possible values for *keyStoreAuthentication* parameter.
It should be *KeyVaultClientSecret* (or) *KeyVaultManagedIdentity*
This was mentioned as keyStoreClientSecret and keyStoreManagedIdentity in the examples and I proposing the fix after verification