### PR TITLE
Add "priority boost" deprecation warning

### DIFF
--- a/docs/relational-databases/thread-and-task-architecture-guide.md
+++ b/docs/relational-databases/thread-and-task-architecture-guide.md
@@ -175,6 +175,9 @@ The [priority boost](../database-engine/configure-windows/configure-the-priority
 
 If you are running multiple instances of [!INCLUDE[ssNoVersion](../includes/ssnoversion-md.md)] on a computer, and turn on priority boost for only some of the instances, the performance of any instances running at normal priority can be adversely affected. Also, the performance of other applications and components on the server can decline if priority boost is turned on. Therefore, it should only be used under tightly controlled conditions.
 
+> [!IMPORTANT]  
+>  [!INCLUDE[ssNoteDepFutureDontUse](../../includes/ssnotedepfuturedontuse-md.md)]  
+
 ## Hot add CPU
 Hot add CPU is the ability to dynamically add CPUs to a running system. Adding CPUs can occur physically by adding new hardware, logically by online hardware partitioning, or virtually through a virtualization layer. Starting with [!INCLUDE[ssKatmai](../includes/ssKatmai-md.md)], [!INCLUDE[ssNoVersion](../includes/ssnoversion-md.md)] supports hot add CPU.
 


### PR DESCRIPTION
There is a deprecation warning for priority boost here:
https://docs.microsoft.com/en-us/sql/database-engine/configure-windows/configure-the-priority-boost-server-configuration-option?view=sql-server-ver15
To make documentation consistent, I suggest adding the same warning after that topic.