### PR TITLE
Corrected the description location of the syntax description

### DIFF
--- a/docs/t-sql/statements/create-database-transact-sql.md
+++ b/docs/t-sql/statements/create-database-transact-sql.md
@@ -205,7 +205,7 @@ For more information about the Windows and SQL collation names, see [COLLATE](~/
 > Contained databases are collated differently than non-contained databases. Please see [Contained Database Collations](../../relational-databases/databases/contained-database-collations.md) for more information.
 
 WITH \<option>
-**\<filestream_options>**
+**\<filestream_option>**
 
 NON_TRANSACTED_ACCESS = { **OFF** | READ_ONLY | FULL }
 **Applies to**: [!INCLUDE[ssSQL11](../../includes/sssql11-md.md)] and later.

--- a/docs/t-sql/statements/create-database-transact-sql.md
+++ b/docs/t-sql/statements/create-database-transact-sql.md
@@ -78,7 +78,7 @@ In SQL Server, this statement creates a new database and the files used and thei
 
 ## Syntax
 
-Create a database.
+Create a database
 
 ```syntaxsql
 CREATE DATABASE database_name
@@ -127,14 +127,6 @@ CREATE DATABASE database_name
 FILEGROUP filegroup name [ [ CONTAINS FILESTREAM ] [ DEFAULT ] | CONTAINS MEMORY_OPTIMIZED_DATA ]
     <filespec> [ ,...n ]
 }
-
-<service_broker_option> ::=
-{
-    ENABLE_BROKER
-  | NEW_BROKER
-  | ERROR_BROKER_CONVERSATIONS
-}
-
 ```
 
 Attach a database
@@ -151,6 +143,13 @@ CREATE DATABASE database_name
       <service_broker_option>
     | RESTRICTED_USER
     | FILESTREAM ( DIRECTORY_NAME = { 'directory_name' | NULL } )
+}
+
+<service_broker_option> ::=
+{
+    ENABLE_BROKER
+  | NEW_BROKER
+  | ERROR_BROKER_CONVERSATIONS
 }
 ```
 


### PR DESCRIPTION
Hello, Reviewers,

The syntax description of <service_broker_option> is described in syntaxsql of "Create a database", but it is correct to describe it in "Attach a database".

Thanks,