### PR TITLE
Update cdc-captured-columns-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-tables/cdc-captured-columns-transact-sql.md
+++ b/docs/relational-databases/system-tables/cdc-captured-columns-transact-sql.md
@@ -28,7 +28,7 @@ ms.author: maghan
    
 |Column name|Data type|Description|  
 |-----------------|---------------|-----------------|  
-|**object_id**|**int**|ID of the source table to which the captured column belongs.|  
+|**object_id**|**int**|ID of the change table to which the captured column belongs.|  
 |**column_name**|**sysname**|Name of the captured column.|  
 |**column_id**|**int**|ID of the captured column within the source table.|  
 |**column_type**|**sysname**|Type of the captured column.|  


### PR DESCRIPTION
The documentation seems to be incorrect the object_id in the table corresponds to the object id of the change table and not the source table