### PR TITLE
Fix sample notebook download script

### DIFF
--- a/docs/big-data-cluster/notebooks-tutorial-spark.md
+++ b/docs/big-data-cluster/notebooks-tutorial-spark.md
@@ -39,7 +39,7 @@ Use the following instructions to load the sample notebook file **spark-sql.ipyn
 1. Run the following **curl** command to download the notebook file from GitHub:
 
    ```bash
-   curl "https://raw.githubusercontent.com/Microsoft/sql-server-samples/master/samples/features/sql-big-data-cluster/spark/data-loading/transform-csv-files.ipynb" -o transform-csv-files.ipynb
+   curl https://raw.githubusercontent.com/Microsoft/sql-server-samples/master/samples/features/sql-big-data-cluster/spark/data-loading/transform-csv-files.ipynb -o transform-csv-files.ipynb
    ```
 
 ## Open the notebook

--- a/docs/big-data-cluster/notebooks-tutorial-spark.md
+++ b/docs/big-data-cluster/notebooks-tutorial-spark.md
@@ -39,7 +39,7 @@ Use the following instructions to load the sample notebook file **spark-sql.ipyn
 1. Run the following **curl** command to download the notebook file from GitHub:
 
    ```bash
-   curl 'https://raw.githubusercontent.com/Microsoft/sql-server-samples/master/samples/features/sql-big-data-cluster/spark/data-loading/transform-csv-files.ipynb' -o transform-csv-files.ipynb
+   curl "https://raw.githubusercontent.com/Microsoft/sql-server-samples/master/samples/features/sql-big-data-cluster/spark/data-loading/transform-csv-files.ipynb" -o transform-csv-files.ipynb
    ```
 
 ## Open the notebook


### PR DESCRIPTION
Single quotes causes curl to throw an error about https protocol not being supported or disabled in libcurl. Double quotes does not cause this issue.