### PR TITLE
Fixed broken links

### DIFF
--- a/docs/database-engine/availability-groups/windows/always-on-availability-groups-interoperability-sql-server.md
+++ b/docs/database-engine/availability-groups/windows/always-on-availability-groups-interoperability-sql-server.md
@@ -65,7 +65,7 @@ The following features interoperate with [!INCLUDE[ssHADR](../../../includes/ssh
 
   [Migration Guide: Migrating to Always On Availability Groups from Prior Deployments Combining Database Mirroring and Log Shipping](https://msdn.microsoft.com/library/jj635217)
   [Microsoft SQL Server Always On Solutions Guide for High Availability and Disaster Recovery](https://go.microsoft.com/fwlink/?LinkId=227600)
-  [Microsoft White Papers for SQL Server 2012](https://msdn.microsoft.com/library/hh403491.aspx)
+  [Microsoft White Papers for SQL Server 2012](https://social.technet.microsoft.com/wiki/contents/articles/13146.white-paper-gallery-for-sql-server.aspx#[Category]SQLServer2012)
   [SQL Server Customer Advisory Team Whitepapers](https://techcommunity.microsoft.com/t5/DataCAT/bg-p/DataCAT/)
 
 ## See Also

--- a/docs/database-engine/availability-groups/windows/always-on-availability-groups-sql-server.md
+++ b/docs/database-engine/availability-groups/windows/always-on-availability-groups-sql-server.md
@@ -165,7 +165,7 @@ ms.author: mathoma
   
      [Microsoft SQL Server Always On Solutions Guide for High Availability and Disaster Recovery](https://go.microsoft.com/fwlink/?LinkId=227600)  
   
-     [Microsoft White Papers for SQL Server 2012](https://msdn.microsoft.com/library/hh403491.aspx)  
+     [Microsoft White Papers for SQL Server 2012](https://social.technet.microsoft.com/wiki/contents/articles/13146.white-paper-gallery-for-sql-server.aspx#[Category]SQLServer2012)  
   
      [SQL Server Customer Advisory Team Whitepapers](https://techcommunity.microsoft.com/t5/DataCAT/bg-p/DataCAT/)  
   

--- a/docs/database-engine/availability-groups/windows/configuration-of-a-server-instance-for-always-on-availability-groups-sql-server.md
+++ b/docs/database-engine/availability-groups/windows/configuration-of-a-server-instance-for-always-on-availability-groups-sql-server.md
@@ -76,7 +76,7 @@ ms.author: mathoma
   
      [Microsoft SQL Server Always On Solutions Guide for High Availability and Disaster Recovery](https://go.microsoft.com/fwlink/?LinkId=227600)  
   
-     [Microsoft White Papers for SQL Server 2012](https://msdn.microsoft.com/library/hh403491.aspx)  
+     [Microsoft White Papers for SQL Server 2012](https://social.technet.microsoft.com/wiki/contents/articles/13146.white-paper-gallery-for-sql-server.aspx#[Category]SQLServer2012)  
   
      [SQL Server Customer Advisory Team Whitepapers](https://techcommunity.microsoft.com/t5/DataCAT/bg-p/DataCAT/)  
   

--- a/docs/database-engine/availability-groups/windows/configure-read-only-routing-for-an-availability-group-sql-server.md
+++ b/docs/database-engine/availability-groups/windows/configure-read-only-routing-for-an-availability-group-sql-server.md
@@ -250,7 +250,7 @@ Server=tcp:MyAgListener,1433;Database=Db1;IntegratedSecurity=SSPI;ApplicationInt
   
 **White papers:**  
   
--    [Microsoft White Papers for SQL Server 2012](https://msdn.microsoft.com/library/hh403491.aspx)  
+-    [Microsoft White Papers for SQL Server 2012](https://social.technet.microsoft.com/wiki/contents/articles/13146.white-paper-gallery-for-sql-server.aspx#[Category]SQLServer2012)  
   
 -    [SQL Server Customer Advisory Team Whitepapers](https://techcommunity.microsoft.com/t5/DataCAT/bg-p/DataCAT/)  
 

--- a/docs/database-engine/availability-groups/windows/create-an-availability-group-sql-server-powershell.md
+++ b/docs/database-engine/availability-groups/windows/create-an-availability-group-sql-server-powershell.md
@@ -224,7 +224,7 @@ Add-SqlAvailabilityDatabase -Path "SQLSERVER:\SQL\SecondaryComputer\Instance\Ava
   
      [Microsoft SQL Server Always On Solutions Guide for High Availability and Disaster Recovery](https://go.microsoft.com/fwlink/?LinkId=227600)  
   
-     [Microsoft White Papers for SQL Server 2012](https://msdn.microsoft.com/library/hh403491.aspx)  
+     [Microsoft White Papers for SQL Server 2012](https://social.technet.microsoft.com/wiki/contents/articles/13146.white-paper-gallery-for-sql-server.aspx#[Category]SQLServer2012)  
   
      [SQL Server Customer Advisory Team Whitepapers](https://techcommunity.microsoft.com/t5/DataCAT/bg-p/DataCAT/)  
   

--- a/docs/database-engine/availability-groups/windows/create-an-availability-group-transact-sql.md
+++ b/docs/database-engine/availability-groups/windows/create-an-availability-group-transact-sql.md
@@ -511,7 +511,7 @@ GO
   
      [Microsoft SQL Server Always On Solutions Guide for High Availability and Disaster Recovery](https://go.microsoft.com/fwlink/?LinkId=227600)  
   
-     [Microsoft White Papers for SQL Server 2012](https://msdn.microsoft.com/library/hh403491.aspx)  
+     [Microsoft White Papers for SQL Server 2012](https://social.technet.microsoft.com/wiki/contents/articles/13146.white-paper-gallery-for-sql-server.aspx#[Category]SQLServer2012)  
   
      [SQL Server Customer Advisory Team Whitepapers](https://techcommunity.microsoft.com/t5/DataCAT/bg-p/DataCAT/)  
   

--- a/docs/database-engine/availability-groups/windows/creation-and-configuration-of-availability-groups-sql-server.md
+++ b/docs/database-engine/availability-groups/windows/creation-and-configuration-of-availability-groups-sql-server.md
@@ -100,7 +100,7 @@ ms.author: mathoma
   
      [Microsoft SQL Server Always On Solutions Guide for High Availability and Disaster Recovery](https://go.microsoft.com/fwlink/?LinkId=227600)  
   
-     [Microsoft White Papers for SQL Server 2012](https://msdn.microsoft.com/library/hh403491.aspx)  
+     [Microsoft White Papers for SQL Server 2012](https://social.technet.microsoft.com/wiki/contents/articles/13146.white-paper-gallery-for-sql-server.aspx#[Category]SQLServer2012)  
   
      [SQL Server Customer Advisory Team Whitepapers](https://techcommunity.microsoft.com/t5/DataCAT/bg-p/DataCAT/)  
   

--- a/docs/database-engine/availability-groups/windows/monitoring-of-availability-groups-sql-server.md
+++ b/docs/database-engine/availability-groups/windows/monitoring-of-availability-groups-sql-server.md
@@ -49,7 +49,7 @@ ms.author: mathoma
   
 -   **Whitepapers:**  
   
-     [Microsoft White Papers for SQL Server 2012](https://msdn.microsoft.com/library/hh403491.aspx)  
+     [Microsoft White Papers for SQL Server 2012](https://social.technet.microsoft.com/wiki/contents/articles/13146.white-paper-gallery-for-sql-server.aspx#[Category]SQLServer2012)  
   
      [SQL Server Customer Advisory Team Whitepapers](https://techcommunity.microsoft.com/t5/DataCAT/bg-p/DataCAT/)  
   

--- a/docs/database-engine/availability-groups/windows/overview-of-always-on-availability-groups-sql-server.md
+++ b/docs/database-engine/availability-groups/windows/overview-of-always-on-availability-groups-sql-server.md
@@ -166,7 +166,7 @@ The availability mode is a property of each availability replica. The availabili
   
      [Microsoft SQL Server Always On Solutions Guide for High Availability and Disaster Recovery](https://go.microsoft.com/fwlink/?LinkId=227600)  
   
-     [Microsoft White Papers for SQL Server 2012](https://msdn.microsoft.com/library/hh403491.aspx)  
+     [Microsoft White Papers for SQL Server 2012](https://social.technet.microsoft.com/wiki/contents/articles/13146.white-paper-gallery-for-sql-server.aspx#[Category]SQLServer2012)  
   
      [SQL Server Customer Advisory Team Whitepapers](https://techcommunity.microsoft.com/t5/DataCAT/bg-p/DataCAT/)  
   

--- a/docs/database-engine/availability-groups/windows/perform-a-forced-manual-failover-of-an-availability-group-sql-server.md
+++ b/docs/database-engine/availability-groups/windows/perform-a-forced-manual-failover-of-an-availability-group-sql-server.md
@@ -320,7 +320,7 @@ ms.author: mathoma
   
      [Microsoft SQL Server Always On Solutions Guide for High Availability and Disaster Recovery](https://go.microsoft.com/fwlink/?LinkId=227600)  
   
-     [Microsoft White Papers for SQL Server 2012](https://msdn.microsoft.com/library/hh403491.aspx)  
+     [Microsoft White Papers for SQL Server 2012](https://social.technet.microsoft.com/wiki/contents/articles/13146.white-paper-gallery-for-sql-server.aspx#[Category]SQLServer2012)  
   
      [SQL Server Customer Advisory Team Whitepapers](https://techcommunity.microsoft.com/t5/DataCAT/bg-p/DataCAT/)  
   

--- a/docs/database-engine/availability-groups/windows/prereqs-migrating-log-shipping-to-always-on-availability-groups.md
+++ b/docs/database-engine/availability-groups/windows/prereqs-migrating-log-shipping-to-always-on-availability-groups.md
@@ -92,7 +92,7 @@ ms.author: mathoma
   
      [Migration Guide: Migrating to Always On Availability Groups from Prior Deployments Combining Database Mirroring and Log Shipping](https://msdn.microsoft.com/library/jj635217)  
   
-     [Microsoft White Papers for SQL Server 2012](https://msdn.microsoft.com/library/hh403491.aspx)  
+     [Microsoft White Papers for SQL Server 2012](https://social.technet.microsoft.com/wiki/contents/articles/13146.white-paper-gallery-for-sql-server.aspx#[Category]SQLServer2012)  
   
      [SQL Server Customer Advisory Team Whitepapers](https://techcommunity.microsoft.com/t5/DataCAT/bg-p/DataCAT/)  
   


### PR DESCRIPTION
The links with the text "Microsoft White Papers for SQL Server 2012" were auto-redirecting to the Microsoft Docs homepage. I updated the broken links to [this](https://social.technet.microsoft.com/wiki/contents/articles/13146.white-paper-gallery-for-sql-server.aspx#[Category]SQLServer2012).