### PR TITLE
Added important call out for block blobs

### DIFF
--- a/docs/relational-databases/backup-restore/sql-server-backup-to-url.md
+++ b/docs/relational-databases/backup-restore/sql-server-backup-to-url.md
@@ -81,6 +81,9 @@ Backup of a large database to blob storage is subject to the limitations listed 
   
 -   SQL Server limits the maximum backup size supported using a page blob to 1 TB. The maximum backup size supported using block blobs is limited to approximately 200 GB (50,000 blocks * 4MB MAXTRANSFERSIZE). Block blobs support striping to support substantially larger backup sizes.  
   
+    > [!IMPORTANT]  
+    >  When using block blobs the MAXTRANSFERSIZE is not a guarantee. There are situations where [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] will write a block smaller than the MAXTRANSFERSIZE which can cause the 50,000 block limit to be reached before the approximately 200 GB size necessitating striping backups less than 200 GB. This can be especially true when using differential and/or uncompressed backups.
+
 -   You can issue backup or restore statements by using TSQL, SMO, PowerShell cmdlets, SQL Server Management Studio Backup or Restore wizard.   
   
 -   Creating a logical device name is not supported. So adding URL as a backup device using sp_dumpdevice or through SQL Server Management Studio is not supported.  

--- a/docs/relational-databases/backup-restore/sql-server-backup-to-url.md
+++ b/docs/relational-databases/backup-restore/sql-server-backup-to-url.md
@@ -82,7 +82,7 @@ Backup of a large database to blob storage is subject to the limitations listed 
 -   SQL Server limits the maximum backup size supported using a page blob to 1 TB. The maximum backup size supported using block blobs is limited to approximately 200 GB (50,000 blocks * 4MB MAXTRANSFERSIZE). Block blobs support striping to support substantially larger backup sizes.  
   
     > [!IMPORTANT]  
-    >  Although the maximum backup size supported by a single block blob is 200 GB, it is possible for [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] to write in smaller block sizes, which can lead [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] to reach the 50,000 block limit before the entire backup is transferred. Stripe backups (even if they're smaller than 200 GB) to avoid the block limit, especially when using differential and/or uncompressed backups.
+    >  Although the maximum backup size supported by a single block blob is 200 GB, it's possible for [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] to write in smaller block sizes, which can lead [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] to reach the 50,000 block limit before the entire backup is transferred. Stripe backups (even if they're smaller than 200 GB) to avoid the block limit, especially when if you use differential or uncompressed backups.
 
 -   You can issue backup or restore statements by using TSQL, SMO, PowerShell cmdlets, SQL Server Management Studio Backup or Restore wizard.   
   

--- a/docs/relational-databases/backup-restore/sql-server-backup-to-url.md
+++ b/docs/relational-databases/backup-restore/sql-server-backup-to-url.md
@@ -82,7 +82,7 @@ Backup of a large database to blob storage is subject to the limitations listed 
 -   SQL Server limits the maximum backup size supported using a page blob to 1 TB. The maximum backup size supported using block blobs is limited to approximately 200 GB (50,000 blocks * 4MB MAXTRANSFERSIZE). Block blobs support striping to support substantially larger backup sizes.  
   
     > [!IMPORTANT]  
-    >  When using block blobs the MAXTRANSFERSIZE is not a guarantee. There are situations where [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] will write a block smaller than the MAXTRANSFERSIZE which can cause the 50,000 block limit to be reached before the approximately 200 GB size necessitating striping backups less than 200 GB. This can be especially true when using differential and/or uncompressed backups.
+    >  Although the maximum backup size supported by a single block blob is 200 GB, it is possible for [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] to write in smaller block sizes, which can lead [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] to reach the 50,000 block limit before the entire backup is transferred. Stripe backups (even if they're smaller than 200 GB) to avoid the block limit, especially when using differential and/or uncompressed backups.
 
 -   You can issue backup or restore statements by using TSQL, SMO, PowerShell cmdlets, SQL Server Management Studio Backup or Restore wizard.   
   


### PR DESCRIPTION
Internal discussion with Pam Lahoud to add explicit important call out that the possibility that blocks written are smaller than MAXTRANSFERSIZE.