### PR TITLE
Contracts are not signed, not using HTTPS

### DIFF
--- a/docs/t-sql/statements/create-event-notification-transact-sql.md
+++ b/docs/t-sql/statements/create-event-notification-transact-sql.md
@@ -97,7 +97,7 @@ TO SERVICE 'broker_service' , { 'broker_instance_specifier' | 'current database'
 >  This option is not available in a contained database.  
   
 ## Remarks  
- [!INCLUDE[ssSB](../../includes/sssb-md.md)] includes a message type and contract specifically for event notifications. Therefore, a Service Broker initiating service does not have to be created because one already exists that specifies the following contract name: `https://schemas.microsoft.com/SQL/Notifications/PostEventNotification`  
+ [!INCLUDE[ssSB](../../includes/sssb-md.md)] includes a message type and contract specifically for event notifications. Therefore, a Service Broker initiating service does not have to be created because one already exists that specifies the following contract name: `http://schemas.microsoft.com/SQL/Notifications/PostEventNotification`  
   
  The target service that receives event notifications must honor this preexisting contract.  
   
@@ -140,7 +140,7 @@ GO
 --the event notifications contract.  
 CREATE SERVICE NotifyService  
 ON QUEUE NotifyQueue  
-([https://schemas.microsoft.com/SQL/Notifications/PostEventNotification]);  
+([http://schemas.microsoft.com/SQL/Notifications/PostEventNotification]);  
 GO  
 
 --Create a route on the service to define the address   


### PR DESCRIPTION
CREATE SERVICE NotifyService  
ON QUEUE NotifyQueue  
(  
[http://schemas.microsoft.com/SQL/Notifications/PostEventNotification]  
);  
GO   
succeeds, while

CREATE SERVICE NotifyService  
ON QUEUE NotifyQueue  
(  
[https://schemas.microsoft.com/SQL/Notifications/PostEventNotification]  
);  
GO  
fails.