### PR TITLE
Contract schema URLs are not signed, not HTTP; clarity on Security needs

### DIFF
--- a/docs/relational-databases/service-broker/implement-event-notifications.md
+++ b/docs/relational-databases/service-broker/implement-event-notifications.md
@@ -37,7 +37,7 @@ https://schemas.microsoft.com/SQL/Notifications/PostEventNotification
 1.  Create a queue to receive messages.  
   
     > [!NOTE]  
-    >  The queue receives the following message type: `https://schemas.microsoft.com/SQL/Notifications/QueryNotification`.  
+    >  The queue receives the following message type: `http://schemas.microsoft.com/SQL/Notifications/QueryNotification`.  
   
 2.  Create a service on the queue that references the event notifications contract.  
   
@@ -54,7 +54,7 @@ GO
 CREATE SERVICE NotifyService  
 ON QUEUE NotifyQueue  
 (  
-[https://schemas.microsoft.com/SQL/Notifications/PostEventNotification]  
+[http://schemas.microsoft.com/SQL/Notifications/PostEventNotification]  
 );  
 GO  
 CREATE ROUTE NotifyRoute  


### PR DESCRIPTION
CREATE SERVICE NotifyService  
ON QUEUE NotifyQueue  
(  
[http://schemas.microsoft.com/SQL/Notifications/PostEventNotification]  
);  
GO   
this succeeds, while

CREATE SERVICE NotifyService  
ON QUEUE NotifyQueue  
(  
[https://schemas.microsoft.com/SQL/Notifications/PostEventNotification]  
);  
GO  
fails.

Security:
CREATE SCHEMA [SqlUser] AUTHORIZATION [SqlUser]
ALTER USER [SqlUser] WITH DEFAULT_SCHEMA = [SqlUser]

 GRANT REFERENCES ON CONTRACT::[http://schemas.microsoft.com/SQL/Notifications/PostQueryNotification] TO [SqlUser];

    -- for Start()
    GRANT CREATE PROCEDURE to [SqlUser];
    GRANT CREATE QUEUE to [SqlUser];
    GRANT CREATE SERVICE to [SqlUser];
    GRANT VIEW DEFINITION TO [SqlUser];

    -- for subscribe
    GRANT SUBSCRIBE QUERY NOTIFICATIONS TO [SqlUser];
    GRANT RECEIVE ON QueryNotificationErrorsQueue TO [SqlUser];