### PR TITLE
Clarification of NUMBER Oracle datatype

### DIFF
--- a/docs/relational-databases/polybase/polybase-type-mapping.md
+++ b/docs/relational-databases/polybase/polybase-type-mapping.md
@@ -58,7 +58,8 @@ For external tables that reference files in external data sources, the column an
 | Oracle data type | SQL Server type | 
 | -------------    | --------------- |
 |Float             |Float            |
-|NUMBER            |Decimal          |
+|NUMBER            |Float            |
+|NUMBER (p,s)      |Decimal (p, s)   |
 |LONG              |Nvarchar         |
 |BINARY_FLOAT      |Real             | 
 |BINARY_DOUBLE     |Float            | 


### PR DESCRIPTION
I changed the Oracle type mapping reference section to reflect how SQL Server datatype for NUMBER Oracle datatype depends on if NUMBER is using precision or not. If Oracle datatype is NUMBER (no precision), we need to use Float for SQL Server. If Oracle NUMBER is defined with precision (NUMBER (p, s)), then SQL Server needs to use Decimal (p, s).