### PR TITLE
Clearly documenting basic auth support only

### DIFF
--- a/docs/relational-databases/polybase/polybase-configure-mongodb.md
+++ b/docs/relational-databases/polybase/polybase-configure-mongodb.md
@@ -43,6 +43,10 @@ The following Transact-SQL commands are used in this section:
     */
     CREATE DATABASE SCOPED CREDENTIAL credential_name WITH IDENTITY = 'username', Secret = 'password';
     ```
+    
+>[!IMPORTANT] 
+>The MongoDB ODBC Connector for PolyBase only supports basic authentication, not Kerberos authentication.    
+    
 1. Create an external data source with [CREATE EXTERNAL DATA SOURCE](../../t-sql/statements/create-external-data-source-transact-sql.md).
 
     ```sql


### PR DESCRIPTION
The MongoDB ODBC Connector for PolyBase only supports basic authentication, not Kerberos authentication.