### PR TITLE
Update the instructions for AD authentication

### DIFF
--- a/docs/big-data-cluster/data-ingestion-curl.md
+++ b/docs/big-data-cluster/data-ingestion-curl.md
@@ -44,9 +44,14 @@ For example:
 
 ## Authentication with AD
 For Deployments with Active Directory, the authentication parameter with `curl` will need to be used with negotiate . 
+
 To use `curl` with Active Directory authentication the following steps can be followed:
-1. `kinit <username>`
-This would generate a kerberos token for `curl` to use. The commands below have the parameter `--anyauth` specified for curl. For URLs which require Negotiate Authentication, `curl` would automatically detect those, and use the generated kerberos token instead of username and password to authenticate to the URLs.
+
+```
+kinit <username>
+```
+
+This generates a kerberos token for `curl` to use. The commands below have the parameter `--anyauth` specified for curl. For URLs which require Negotiate Authentication, `curl` automatically detects, and uses the generated kerberos token instead of username and password to authenticate to the URLs.
 
 ## List a file
 

--- a/docs/big-data-cluster/data-ingestion-curl.md
+++ b/docs/big-data-cluster/data-ingestion-curl.md
@@ -44,7 +44,7 @@ For example:
 
 ## Authentication with Active Directory
 
-To deploy with Active Directory, use the authentication parameter with `curl` with Negotiate authentication. 
+For deployments with Active Directory, use the authentication parameter with `curl` with Negotiate authentication. 
 
 To use `curl` with Active Directory authentication, run this command:
 
@@ -52,7 +52,7 @@ To use `curl` with Active Directory authentication, run this command:
 kinit <username>
 ```
 
-The command generates a Kerberos token for `curl` to use. The commands descibed in the next section specify the `--anyauth` parameter for `curl`. For URLs that require Negotiate authentication, `curl` automatically detects and uses the generated Kerberos token instead of username and password to authenticate to the URLs.
+The command generates a Kerberos token for `curl` to use. The commands demonstrated in the next sections specify the `--anyauth` parameter for `curl`. For URLs that require Negotiate authentication, `curl` automatically detects and uses the generated Kerberos token instead of username and password to authenticate to the URLs.
 
 ## List a file
 

--- a/docs/big-data-cluster/data-ingestion-curl.md
+++ b/docs/big-data-cluster/data-ingestion-curl.md
@@ -42,16 +42,17 @@ For example:
 
 `https://13.66.190.205:30443/gateway/default/webhdfs/v1/`
 
-## Authentication with AD
-For Deployments with Active Directory, the authentication parameter with `curl` will need to be used with negotiate . 
+## Authentication with Active Directory
 
-To use `curl` with Active Directory authentication the following steps can be followed:
+To deploy with Active Directory, use the authentication parameter with `curl` with Negotiate authentication. 
+
+To use `curl` with Active Directory authentication, run this command:
 
 ```
 kinit <username>
 ```
 
-This generates a kerberos token for `curl` to use. The commands below have the parameter `--anyauth` specified for curl. For URLs which require Negotiate Authentication, `curl` automatically detects, and uses the generated kerberos token instead of username and password to authenticate to the URLs.
+The command generates a Kerberos token for `curl` to use. The commands descibed in the next section specify the `--anyauth` parameter for `curl`. For URLs that require Negotiate authentication, `curl` automatically detects and uses the generated Kerberos token instead of username and password to authenticate to the URLs.
 
 ## List a file
 

--- a/docs/big-data-cluster/data-ingestion-curl.md
+++ b/docs/big-data-cluster/data-ingestion-curl.md
@@ -42,12 +42,18 @@ For example:
 
 `https://13.66.190.205:30443/gateway/default/webhdfs/v1/`
 
+## Authentication with AD
+For Deployments with Active Directory, the authentication parameter with `curl` will need to be used with negotiate . 
+To use `curl` with Active Directory authentication the following steps can be followed:
+1. `kinit <username>`
+This would generate a kerberos token for `curl` to use. The commands below have the parameter `--anyauth` specified for curl. For URLs which require Negotiate Authentication, `curl` would automatically detect those, and use the generated kerberos token instead of username and password to authenticate to the URLs.
+
 ## List a file
 
 To list file under **hdfs:///product_review_data**, use the following curl command:
 
 ```terminal
-curl -i -k -u root:<AZDATA_PASSWORD> -X GET 'https://<gateway-svc-external IP external address>:30443/gateway/default/webhdfs/v1/product_review_data/?op=liststatus'
+curl -i -k --anyauth -u root:<AZDATA_PASSWORD> -X GET 'https://<gateway-svc-external IP external address>:30443/gateway/default/webhdfs/v1/product_review_data/?op=liststatus'
 ```
 
 [!INCLUDE [big-data-cluster-root-user](../includes/big-data-cluster-root-user.md)]
@@ -55,7 +61,7 @@ curl -i -k -u root:<AZDATA_PASSWORD> -X GET 'https://<gateway-svc-external IP ex
 For endpoints that do not use root, use the following curl command:
 
 ```terminal
-curl -i -k -u <AZDATA_USERNAME>:<AZDATA_PASSWORD> -X GET 'https://<gateway-svc-external IP external address>:30443/gateway/default/webhdfs/v1/product_review_data/?op=liststatus'
+curl -i -k --anyauth -u <AZDATA_USERNAME>:<AZDATA_PASSWORD> -X GET 'https://<gateway-svc-external IP external address>:30443/gateway/default/webhdfs/v1/product_review_data/?op=liststatus'
 ```
 
 ## Put a local file into HDFS
@@ -63,7 +69,7 @@ curl -i -k -u <AZDATA_USERNAME>:<AZDATA_PASSWORD> -X GET 'https://<gateway-svc-e
 To put a new file **test.csv** from local directory to product_review_data directory, use the following curl command (the **Content-Type** parameter is required):
 
 ```terminal
-curl -i -L -k -u root:<AZDATA_PASSWORD> -X PUT 'https://<gateway-svc-external IP external address>:30443/gateway/default/webhdfs/v1/product_review_data/test.csv?op=create' -H 'Content-Type: application/octet-stream' -T 'test.csv'
+curl -i -L -k --anyauth -u root:<AZDATA_PASSWORD> -X PUT 'https://<gateway-svc-external IP external address>:30443/gateway/default/webhdfs/v1/product_review_data/test.csv?op=create' -H 'Content-Type: application/octet-stream' -T 'test.csv'
 ```
 
 [!INCLUDE [big-data-cluster-root-user](../includes/big-data-cluster-root-user.md)]
@@ -71,7 +77,7 @@ curl -i -L -k -u root:<AZDATA_PASSWORD> -X PUT 'https://<gateway-svc-external IP
 For endpoints that do not use root, use the following curl command:
 
 ```terminal
-curl -i -L -k -u <AZDATA_USERNAME>:<AZDATA_PASSWORD> -X PUT 'https://<gateway-svc-external IP external address>:30443/gateway/default/webhdfs/v1/product_review_data/test.csv?op=create' -H 'Content-Type: application/octet-stream' -T 'test.csv'
+curl -i -L -k --anyauth -u <AZDATA_USERNAME>:<AZDATA_PASSWORD> -X PUT 'https://<gateway-svc-external IP external address>:30443/gateway/default/webhdfs/v1/product_review_data/test.csv?op=create' -H 'Content-Type: application/octet-stream' -T 'test.csv'
 ```
 
 ## Create a directory
@@ -79,14 +85,14 @@ curl -i -L -k -u <AZDATA_USERNAME>:<AZDATA_PASSWORD> -X PUT 'https://<gateway-sv
 To create a directory **test** under `hdfs:///`, use the following command:
 
 ```terminal
-curl -i -L -k -u root:<AZDATA_PASSWORD> -X PUT 'https://<gateway-svc-external IP external address>:30443/gateway/default/webhdfs/v1/test?op=MKDIRS'
+curl -i -L -k --anyauth -u root:<AZDATA_PASSWORD> -X PUT 'https://<gateway-svc-external IP external address>:30443/gateway/default/webhdfs/v1/test?op=MKDIRS'
 ```
 
 [!INCLUDE [big-data-cluster-root-user](../includes/big-data-cluster-root-user.md)]
 For endpoints that do not use root, use the following curl command:
 
 ```terminal
-curl -i -L -k -u <AZDATA_USERNAME>:<AZDATA_PASSWORD> -X PUT 'https://<gateway-svc-external IP external address>:30443/gateway/default/webhdfs/v1/test?op=MKDIRS'
+curl -i -L -k --anyauth -u <AZDATA_USERNAME>:<AZDATA_PASSWORD> -X PUT 'https://<gateway-svc-external IP external address>:30443/gateway/default/webhdfs/v1/test?op=MKDIRS'
 ```
 
 ## Next steps


### PR DESCRIPTION
The change updates the documentation to show how `curl` can be used with AD authentication while calling webHdfs APIs in a deployment of Big Data Clusters with Active Directory.

Fixes https://github.com/MicrosoftDocs/sql-docs/issues/5544