### PR TITLE
Update register-a-service-principal-name-spn-for-a-report-server.md

### DIFF
--- a/docs/reporting-services/report-server/register-a-service-principal-name-spn-for-a-report-server.md
+++ b/docs/reporting-services/report-server/register-a-service-principal-name-spn-for-a-report-server.md
@@ -62,7 +62,7 @@ Setspn -s http/<computer-name>.<domain-name> <domain-user-account>
   
 6.  Open the **RsReportServer.config** file and locate the `<AuthenticationTypes>` section.  
   
-7.  Add `<RSWindowsNegotiate/>` as the first entry in this section to enable Kerberos.  
+7.  Add `<RSWindowsNegotiate />` as the first entry in this section to enable Kerberos.  
   
 ## See Also  
  [Configure a Service Account &#40;SSRS Configuration Manager&#41;](../install-windows/configure-the-report-server-service-account-ssrs-configuration-manager.md)   


### PR DESCRIPTION
In the existing rsreportserver.config file the tag <RSWindowsNTLM /> has a space between the "M" and the "/".  This is also consistent with the syntax on this [page](https://docs.microsoft.com/en-us/power-bi/report-server/connect-adfs-wap-report-server) as well.  