### PR TITLE
Update polybase-scale-out-groups.md

### DIFF
--- a/docs/relational-databases/polybase/polybase-scale-out-groups.md
+++ b/docs/relational-databases/polybase/polybase-scale-out-groups.md
@@ -27,11 +27,11 @@ See [Get started with PolyBase](./polybase-guide.md) and [PolyBase Guide](../../
   
 ## Head node  
 
-The head node contains the SQL Server instance to which PolyBase queries are submitted. Each PolyBase group can have only one head node. A head node is a logical group of SQL Database Engine, PolyBase Engine and PolyBase Data Movement Service on the SQL Server instance.
+The head node contains the SQL Server instance to which PolyBase queries are submitted. Each PolyBase group can have only one head node. A head node is a logical group of SQL Database Engine, PolyBase Engine and PolyBase Data Movement Service on the SQL Server instance. In SQL Server 2019 the PolyBase head node can be either an Enterprise or Standard edition.
   
 ## Compute node  
 
-A compute node contains the SQL Server instance that assists with scale-out query processing on external data. A compute node is a logical group of SQL Server and the PolyBase data movement service on the SQL Server instance. A PolyBase group can have multiple compute nodes. The head node and the compute nodes must all run the same version of SQL Server.
+A compute node contains the SQL Server instance that assists with scale-out query processing on external data. A compute node is a logical group of SQL Server and the PolyBase data movement service on the SQL Server instance. A PolyBase group can have multiple compute nodes. The head node and the compute nodes must all run the same version of SQL Server, however the compute node can be any edition of SQL Server.
 
 ## Scale-out Reads
 


### PR DESCRIPTION
Adding some clarity around what editions of SQL Server can be a head node or compute node.