### PR TITLE
Remove 250MB from the list of supported sizes for DTU-base databases

### DIFF
--- a/docs/t-sql/statements/create-database-transact-sql.md
+++ b/docs/t-sql/statements/create-database-transact-sql.md
@@ -1027,7 +1027,6 @@ Specifies the maximum size of the database. MAXSIZE must be valid for the specif
 |**MAXSIZE**|**Basic**|**S0-S2**|**S3-S12**|**P1-P6**| **P11-P15** |
 |:---|:---|:---|:---|:---|:---|
 |100 MB|√|√|√|√|√|
-|250 MB|√|√|√|√|√|
 |500 MB|√|√|√|√|√|
 |1 GB|√|√|√|√|√|
 |2 GB|√ (D)|√|√|√|√|

--- a/docs/t-sql/statements/create-database-transact-sql.md
+++ b/docs/t-sql/statements/create-database-transact-sql.md
@@ -934,7 +934,7 @@ CREATE DATABASE database_name [ COLLATE collation_name ]
 <edition_options> ::=
 {
 
-  MAXSIZE = { 100 MB | 250 MB | 500 MB | 1 ... 1024 ... 4096 GB }
+  MAXSIZE = { 100 MB | 500 MB | 1 ... 1024 ... 4096 GB }
   | ( EDITION = { 'Basic' | 'Standard' | 'Premium' | 'GeneralPurpose' | 'BusinessCritical' | 'Hyperscale' }
   | SERVICE_OBJECTIVE =
     { 'Basic' | 'S0' | 'S1' | 'S2' | 'S3' | 'S4'| 'S6'| 'S7'| 'S9'| 'S12'


### PR DESCRIPTION
Trying to use this value was returning errors from the fail-fast path when trying to create a database.

Per examination of the backend code, this values does not appear to be actually supported.