### PR TITLE
Remove unnecessary "in" prefix

### DIFF
--- a/docs/t-sql/functions/context-info-transact-sql.md
+++ b/docs/t-sql/functions/context-info-transact-sql.md
@@ -42,8 +42,8 @@ CONTEXT_INFO()
 The **context_info** value.
   
 If **context_info** was not set:
--   In [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] returns NULL.  
--   In [!INCLUDE[ssSDS](../../includes/sssds-md.md)] returns a unique session-specific GUID.  
+-   [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] returns NULL.  
+-   [!INCLUDE[ssSDS](../../includes/sssds-md.md)] returns a unique session-specific GUID.  
   
 ## Remarks  
 The Multiple Active Result Sets (MARS) feature enables applications to run multiple batches, or requests, at the same time, on the same connection. When one of the MARS connection batches runs SET CONTEXT_INFO, the `CONTEXT_INFO` function returns the new context value, when the `CONTEXT_INFO` function runs in the same batch as the SET statement. If the `CONTEXT_INFO` function runs in one or more of the other connection batches, the `CONTEXT_FUNCTION` does not return the new value unless those batches started after completion of the batch that ran the SET statement.


### PR DESCRIPTION
Currently this section says "In SQL Server..." which doesn't read well. This PR removes the "in" prefix from each product name.

![image](https://user-images.githubusercontent.com/441085/97609385-eb425780-19e9-11eb-8f40-0ca5b24fd98b.png)
