### PR TITLE
Added Azure SQL DB as unsupported source server for package files.

### DIFF
--- a/docs/integration-services/lift-shift/ssis-azure-deploy-run-monitor-tutorial.md
+++ b/docs/integration-services/lift-shift/ssis-azure-deploy-run-monitor-tutorial.md
@@ -85,7 +85,7 @@ To learn more about deploying packages and about the Deployment Wizard, see [Dep
 
 2. On the **Select Source** page, select the existing SSIS project to deploy.
     -   To deploy a project deployment file that you created, select **Project deployment file** and enter the path to the .ispac file.
-    -   To deploy a project that resides in an SSIS catalog, select **Integration Services catalog**, and then enter the server name and the path to the project in the catalog.
+    -   To deploy a project that resides in an SSIS catalog, select **Integration Services catalog**, and then enter the server name and the path to the project in the catalog. (This step is not unsupported with Azure SQL DB)
     -   Select **Next** to see the **Select Destination** page.
   
 3.  On the **Select Destination** page, select the destination for the project.

--- a/docs/integration-services/lift-shift/ssis-azure-deploy-run-monitor-tutorial.md
+++ b/docs/integration-services/lift-shift/ssis-azure-deploy-run-monitor-tutorial.md
@@ -85,7 +85,7 @@ To learn more about deploying packages and about the Deployment Wizard, see [Dep
 
 2. On the **Select Source** page, select the existing SSIS project to deploy.
     -   To deploy a project deployment file that you created, select **Project deployment file** and enter the path to the .ispac file.
-    -   To deploy a project that resides in an SSIS catalog, select **Integration Services catalog**, and then enter the server name and the path to the project in the catalog. Only projects residing in SSISDB hosted by SQL Server can be redeployed in this step
+    -   To deploy a project that resides in an SSIS catalog, select **Integration Services catalog**, and then enter the server name and the path to the project in the catalog. Only projects that reside in SSISDB hosted by SQL Server can be redeployed in this step.
     -   Select **Next** to see the **Select Destination** page.
   
 3.  On the **Select Destination** page, select the destination for the project.

--- a/docs/integration-services/lift-shift/ssis-azure-deploy-run-monitor-tutorial.md
+++ b/docs/integration-services/lift-shift/ssis-azure-deploy-run-monitor-tutorial.md
@@ -85,7 +85,7 @@ To learn more about deploying packages and about the Deployment Wizard, see [Dep
 
 2. On the **Select Source** page, select the existing SSIS project to deploy.
     -   To deploy a project deployment file that you created, select **Project deployment file** and enter the path to the .ispac file.
-    -   To deploy a project that resides in an SSIS catalog, select **Integration Services catalog**, and then enter the server name and the path to the project in the catalog. (This step is not unsupported with Azure SQL DB)
+    -   To deploy a project that resides in an SSIS catalog, select **Integration Services catalog**, and then enter the server name and the path to the project in the catalog. Only projects residing in SSISDB hosted by SQL Server can be redeployed in this step
     -   Select **Next** to see the **Select Destination** page.
   
 3.  On the **Select Destination** page, select the destination for the project.


### PR DESCRIPTION
Azure SQL DB cannot be utilized as source catalog for ispac files. It seems to only work with SQL Server on-premise
 - Error when using Azure SQL DB. "Failed to connect to server barcelona.database.windows.net."
 - There is no option to specify any credentials.