### PR TITLE
more restrictions of SQL Express Local DB and security concerns

### DIFF
--- a/docs/database-engine/configure-windows/sql-server-express-localdb.md
+++ b/docs/database-engine/configure-windows/sql-server-express-localdb.md
@@ -60,6 +60,10 @@ The instance collation for LocalDB is set to `SQL_Latin1_General_CP1_CI_AS` and 
 
 ### Restrictions
 
+- LocalDB cannot be patched beyond Service Packs. CUs and Security Updates cannot be applied manually and will not be applied via Windows Update, Windows Update for Business or other methods.
+
+- LocalDB cannot be managed remotely via SQL Management Studio
+
 - LocalDB cannot be a merge replication subscriber.
 
 - LocalDB does not support FILESTREAM.

--- a/docs/database-engine/configure-windows/sql-server-express-localdb.md
+++ b/docs/database-engine/configure-windows/sql-server-express-localdb.md
@@ -60,9 +60,9 @@ The instance collation for LocalDB is set to `SQL_Latin1_General_CP1_CI_AS` and 
 
 ### Restrictions
 
-- LocalDB cannot be patched beyond Service Packs. CUs and Security Updates cannot be applied manually and will not be applied via Windows Update, Windows Update for Business or other methods.
+- LocalDB cannot be patched beyond Service Packs. CUs and Security Updates cannot be applied manually and will not be applied via Windows Update, Windows Update for Business, or other methods.
 
-- LocalDB cannot be managed remotely via SQL Management Studio
+- LocalDB cannot be managed remotely via SQL Management Studio.
 
 - LocalDB cannot be a merge replication subscriber.
 


### PR DESCRIPTION
Example SQL Express Local DB is on Version 12.0.6024.0. SP3 Current version is 12.6372.1, so LocalDB misses out the latest security updates 

References: 
https://stackoverflow.com/questions/57811000/patching-sql-server-localdb
https://sqlserverbuilds.blogspot.com/

Build	File version	KB / Description	Release Date
12.0.6372.1	2014.120.6372.1	4535288 Security update for SQL Server 2014 SP3 CU4: February 11, 2020  CVE-2020-0618	2020-02-11
12.0.6329.1	2014.120.6329.1	4500181 Cumulative update package 4 (CU4) for SQL Server 2014 Service Pack 3  Latest CU	2019-07-29
12.0.6293.0	2014.120.6293.0	4505422 Security update for SQL Server 2014 SP3 CU3 GDR: July 9, 2019  CVE-2019-1068	2019-07-09
12.0.6259.0	2014.120.6259.0	4491539 Cumulative update package 3 (CU3) for SQL Server 2014 Service Pack 3	2019-04-16
12.0.6214.1	2014.120.6214.1	4482960 Cumulative update package 2 (CU2) for SQL Server 2014 Service Pack 3	2019-02-19
12.0.6205.1	2014.120.6205.1	4470220 Cumulative update package 1 (CU1) for SQL Server 2014 Service Pack 3	2018-12-12
12.0.6118.4	2014.120.6118.4	4532095 Security update for SQL Server 2014 SP3 GDR: February 11, 2020  CVE-2020-0618	2020-02-11
12.0.6108.1	2014.120.6108.1	4505218 Security update for SQL Server 2014 SP3 GDR: July 9, 2019  CVE-2019-1068