### PR TITLE
Depending on physical_name it would render a conversion error

### DIFF
--- a/docs/relational-databases/system-catalog-views/sys-pdw-nodes-partitions-transact-sql.md
+++ b/docs/relational-databases/system-catalog-views/sys-pdw-nodes-partitions-transact-sql.md
@@ -57,7 +57,7 @@ JOIN sys.pdw_nodes_tables AS NTables
 AND pnp.pdw_node_id = NTables.pdw_node_id  
 JOIN sys.pdw_table_mappings AS TMap  
     ON NTables.name = TMap.physical_name 
-    AND substring(TMap.physical_name,40, 10) = pnp.distribution_id 
+    AND try_cast(substring(TMap.physical_name,40, 10) as int) = pnp.distribution_id 
 JOIN sys.objects AS o  
     ON TMap.object_id = o.object_id  
 WHERE o.name = 'myTable'  


### PR DESCRIPTION
I Addded try_cast to substring part because it avoids to generate an error if it encounters a value that is not convertible to int