### PR TITLE
Many T-SQL functions say that Synapse supports them when they do not

### DIFF
--- a/docs/t-sql/functions/concat-ws-transact-sql.md
+++ b/docs/t-sql/functions/concat-ws-transact-sql.md
@@ -18,7 +18,7 @@ helpviewer_keywords:
 ms.assetid: f1375fd7-a2fd-48bf-922a-4f778f0deb1f
 author: markingmyname
 ms.author: maghan
-monikerRange: "=azuresqldb-current||>=sql-server-2017||=sqlallproducts-allversions||>=sql-server-linux-2017||=azuresqldb-mi-current"
+monikerRange: "=azuresqldb-current||>=sql-server-2017||>=sql-server-linux-2017||=azuresqldb-mi-current"
 ---
 # CONCAT_WS (Transact-SQL)
 [!INCLUDE [sqlserver2017-asdb-asdbmi-asa](../../includes/applies-to-version/sqlserver2017-asdb-asdbmi-asa.md)]

--- a/docs/t-sql/functions/string-agg-transact-sql.md
+++ b/docs/t-sql/functions/string-agg-transact-sql.md
@@ -16,7 +16,7 @@ helpviewer_keywords:
 ms.assetid: 8860ef3f-142f-4cca-aa64-87a123e91206
 author: julieMSFT
 ms.author: jrasnick
-monikerRange: "=azuresqldb-current||=azure-sqldw-latest||>=sql-server-2017||=sqlallproducts-allversions||>=sql-server-linux-2017||=azuresqldb-mi-current"
+monikerRange: "=azuresqldb-current||=azure-sqldw-latest||>=sql-server-2017||>=sql-server-linux-2017||=azuresqldb-mi-current"
 ---
 # STRING_AGG (Transact-SQL)
 

--- a/docs/t-sql/functions/string-split-transact-sql.md
+++ b/docs/t-sql/functions/string-split-transact-sql.md
@@ -17,7 +17,7 @@ helpviewer_keywords:
 ms.assetid: 3273dbf3-0b4f-41e1-b97e-b4f67ad370b9
 author: julieMSFT
 ms.author: jrasnick
-monikerRange: "= azuresqldb-current||=azure-sqldw-latest||>= sql-server-2016 || >= sql-server-linux-2017 || = sqlallproducts-allversions" 
+monikerRange: "= azuresqldb-current||>= sql-server-2016 || >= sql-server-linux-2017 || = sqlallproducts-allversions" 
 ---
 # STRING_SPLIT (Transact-SQL)
 

--- a/docs/t-sql/functions/translate-transact-sql.md
+++ b/docs/t-sql/functions/translate-transact-sql.md
@@ -16,7 +16,7 @@ helpviewer_keywords:
 ms.assetid: 0426fa90-ef6d-4d19-8207-02ee59f74aec
 author: julieMSFT
 ms.author: jrasnick
-monikerRange: ">=sql-server-2017||=sqlallproducts-allversions||>=sql-server-linux-2017||=azuresqldb-mi-current"
+monikerRange: ">=sql-server-2017||>=sql-server-linux-2017||=azuresqldb-mi-current"
 ---
 # TRANSLATE (Transact-SQL)
 

--- a/docs/t-sql/functions/trim-transact-sql.md
+++ b/docs/t-sql/functions/trim-transact-sql.md
@@ -18,7 +18,7 @@ helpviewer_keywords:
 ms.assetid: a00245aa-32c7-4ad4-a0d1-64f3d6841153
 author: julieMSFT
 ms.author: jrasnick
-monikerRange: "= azure-sqldw-latest||=azuresqldb-current||>=sql-server-2017||=sqlallproducts-allversions||>=sql-server-linux-2017||=azuresqldb-mi-current"
+monikerRange: "= azure-sqldw-latest||=azuresqldb-current||>=sql-server-2017||>=sql-server-linux-2017||=azuresqldb-mi-current"
 ---
 # TRIM (Transact-SQL)
 


### PR DESCRIPTION
I cross referenced the pages for TSQL string functions against the [T-SQL language elements reference](https://docs.microsoft.com/en-us/azure/synapse-analytics/sql-data-warehouse/sql-data-warehouse-reference-tsql-language-elements?toc=/azure/synapse-analytics/toc.json&bc=/azure/synapse-analytics/breadcrumb/toc.json). In 5 minutes I found 5 examples of functions that are not (yet?) supported by Azure Synapse despite the docs saying it does.

I know there are more examples.

As a heavy-user of multiple MSFT SQL products, it is greater pain that there is no accurate source of truth as to what is and isn't supported by Synapse (greater even than the fact that Synapse T-SQL is missing a lot of very common T-SQL functions).

- https://github.com/MicrosoftDocs/azure-docs/issues/55713
- #4864
- #4861