### PR TITLE
REQUIRED_SYNCHRONIZED_SECONDARIES_TO_COMMIT=0 with 3 replicas incorre…

### DIFF
--- a/docs/linux/sql-server-linux-availability-group-ha.md
+++ b/docs/linux/sql-server-linux-availability-group-ha.md
@@ -56,7 +56,7 @@ An availability group with three synchronous replicas can provide read-scale, hi
 |Availability behavior |read-scale|High availability & </br> data protection | Data protection|
 |:---|---|---|---|
 |`REQUIRED_SYNCHRONIZED_SECONDARIES_TO_COMMIT=`|0 |1<sup>\*</sup>|2|
-|Primary outage |Automatic failover. New primary is R/W. |Automatic failover. New primary is R/W. |Automatic failover. New primary is not available for user transactions until former primary recovers and joins availability group as secondary. |
+|Primary outage |Manual failover. Might have data loss. New primary is R/W. |Automatic failover. New primary is R/W. |Automatic failover. New primary is not available for user transactions until former primary recovers and joins availability group as secondary. |
 |One secondary replica outage  | Primary is R/W. No automatic failover if primary fails. |Primary is R/W. No automatic failover if primary fails as well. | Primary is not available for user transactions. |
 
 <sup>\*</sup> Default


### PR DESCRIPTION
…ctly indicates automatic failover