### PR TITLE
Drop Hadoop Name Node High Availability section

### DIFF
--- a/docs/relational-databases/polybase/polybase-troubleshooting.md
+++ b/docs/relational-databases/polybase/polybase-troubleshooting.md
@@ -246,13 +246,6 @@ After configuring a set of machines as part of a PolyBase scale out group, you c
 
 3. Run the DMV [sys.dm_exec_compute_node_status &#40;Transact-SQL&#41;](../../relational-databases/system-dynamic-management-views/sys-dm-exec-compute-node-status-transact-sql.md) to view the status of all the nodes in the PolyBase Group.
 
-## Hadoop Name Node High Availability
-
-PolyBase does not interface with Name Node HA services like Zookeeper or Knox today. However, there is a proven workaround that can be used to provide the functionality.
-
-Work Around:
-Use DNS name to reroute connections to the active Name Node. In order to do this, you will need to ensure that the External Data Source is using a DNS name to communicate with the Name Node. When Name Node Failover occurs, you will need to change the IP address associated with the DNS name used in the External Data Source definition. This will reroute all new connections to the correct Name Node. Existing connections will fail when failover occurs. To automate this process, a "heartbeat" can ping the active Name Node. If the heart beat fails, one can assume a failover has occurred and automatically switch to the secondaries IP address.
-
 ## Error messages and possible solutions
 
 To troubleshoot external table errors, see Murshed Zaman's blog [https://blogs.msdn.microsoft.com/sqlcat/2016/06/21/polybase-setup-errors-and-possible-solutions/](/archive/blogs/sqlcat/polybase-setup-errors-and-possible-solutions "PolyBase setup errors and possible solutions").


### PR DESCRIPTION
We do, in fact, support name node high availability, so I removed the section "Hadoop Name Node High Availability" section. We will need to make a corresponding change to CREATE EXTERNAL DATA SOURCE to make support for Name Node HA clearer.