### PR TITLE
Mismatching: group by sales order, instead: group by category

### DIFF
--- a/docs/reporting-services/tutorial-creating-a-basic-table-report-report-builder.md
+++ b/docs/reporting-services/tutorial-creating-a-basic-table-report-report-builder.md
@@ -170,7 +170,7 @@ After you create groups, you can add and format rows on which to display aggrega
   
     2.  The second row will repeat once for each line item in the sales order and display the product name, order quantity, and line total.  
   
-    3.  The third row will repeat once for each sales order to display subtotals per order.  
+    3.  The third row will repeat once for each sales order category to display subtotals per category.  
   
     4.  The fourth row will repeat once for each order date to display the subtotals per day.  
   


### PR DESCRIPTION
Wording error: In the code used for this report there is no order id's to group by, instead we group by categories as guided earlier by docs.