### PR TITLE
Fix incorrect query against sys.pdw_nodes_column_store_row_groups

### DIFF
--- a/docs/relational-databases/system-catalog-views/sys-pdw-nodes-column-store-row-groups-transact-sql.md
+++ b/docs/relational-databases/system-catalog-views/sys-pdw-nodes-column-store-row-groups-transact-sql.md
@@ -70,6 +70,7 @@ JOIN sys.pdw_nodes_indexes AS NI
 JOIN sys.pdw_nodes_column_store_row_groups AS CSRowGroups  
     ON CSRowGroups.object_id = NI.object_id   
     AND CSRowGroups.pdw_node_id = NI.pdw_node_id  
+    AND CSRowGroups.distribution_id = NI.distribution_id
     AND CSRowGroups.index_id = NI.index_id      
 WHERE total_rows > 0
 --WHERE t.name = '<table_name>'   


### PR DESCRIPTION
One of the example queries for the sys.pdw_nodes_column_store_row_groups article is missing a join condition, which I discovered when trying out the query during testing. Added the extra condition to join on distribution id, not just pdw_node_id.