### PR TITLE
Addition to CONNECTION_OPTIONS; semi-colon separator

### DIFF
--- a/docs/t-sql/statements/create-external-data-source-transact-sql.md
+++ b/docs/t-sql/statements/create-external-data-source-transact-sql.md
@@ -119,7 +119,8 @@ Additional notes and guidance when setting the location:
 
 ### CONNECTION_OPTIONS = *key_value_pair*
 
-Specifies additional options when connecting over `ODBC` to an external data source. To specify multiple connection options, separate them by a semi-colon.
+Specifies additional options when connecting over `ODBC` to an external data source. To use multiple connection options, separate them by a semi-colon.
+
 
 The name of the driver is required as a minimum, but there are other options such as `APP='<your_application_name>'` or `ApplicationIntent= ReadOnly|ReadWrite` that are also useful to set and can assist with troubleshooting.
 

--- a/docs/t-sql/statements/create-external-data-source-transact-sql.md
+++ b/docs/t-sql/statements/create-external-data-source-transact-sql.md
@@ -119,7 +119,7 @@ Additional notes and guidance when setting the location:
 
 ### CONNECTION_OPTIONS = *key_value_pair*
 
-Specifies additional options when connecting over `ODBC` to an external data source.
+Specifies additional options when connecting over `ODBC` to an external data source. To specify multiple connection options, separate them by a semi-colon.
 
 The name of the driver is required as a minimum, but there are other options such as `APP='<your_application_name>'` or `ApplicationIntent= ReadOnly|ReadWrite` that are also useful to set and can assist with troubleshooting.
 


### PR DESCRIPTION
To specify multiple connection options, separate them by a semi-colon.