### PR TITLE
Update sys-dm-os-sys-info-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-os-sys-info-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-os-sys-info-transact-sql.md
@@ -74,6 +74,8 @@ monikerRange: ">=aps-pdw-2016||=azure-sqldw-latest||>=sql-server-2016||=sqlallpr
 |**socket_count** |**int** | **Applies to:** [!INCLUDE[ssSQL15](../../includes/sssql15-md.md)] SP2 and later.<br /><br />Specifies the number of processor sockets available on the system. |  
 |**cores_per_socket** |**int** | **Applies to:** [!INCLUDE[ssSQL15](../../includes/sssql15-md.md)] SP2 and later.<br /><br />Specifies the number of processors per socket available on the system. |  
 |**numa_node_count** |**int** | **Applies to:** [!INCLUDE[ssSQL15](../../includes/sssql15-md.md)] SP2 and later.<br /><br />Specifies the number of numa nodes available on the system. This column includes physical numa nodes as well as soft numa nodes. |  
+|**container_type** |**int** | **Applies to:** <br /><br /> |  
+|**container_type_desc** |**nvarchar(60)** | **Applies to:** <br /><br /> |  
   
 ## Permissions
 


### PR DESCRIPTION
[container_type] and {container_type_description] columns are showing up in SQL Server 2017 (and later, I presume). I'm not sure what version(s) those "Applies to". I suspect the "container" is probably something like "Docker" or "Kubernetes" and _not_ the same sense in which a database is a "contained" database.

The "Applies to" and descriptions need to be completed before merging this PR.