### PR TITLE
Add seconds freq_subday_type

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-add-jobschedule-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-add-jobschedule-transact-sql.md
@@ -97,6 +97,7 @@ sp_add_jobschedule [ @job_id = ] job_id, | [ @job_name = ] 'job_name', [ @name =
 |Value|Description (unit)|  
 |-----------|--------------------------|  
 |**0x1**|At the specified time|  
+|**0x2**|Seconds|  
 |**0x4**|Minutes|  
 |**0x8**|Hours|  
   


### PR DESCRIPTION
Missing possible value 2 to @freq_subday_type, like defined in [sysschedules](https://docs.microsoft.com/en-us/sql/relational-databases/system-tables/dbo-sysschedules-transact-sql?view=sql-server-ver15)