### PR TITLE
Update manage-authentication-in-database-engine-powershell.md

### DIFF
--- a/docs/powershell/manage-authentication-in-database-engine-powershell.md
+++ b/docs/powershell/manage-authentication-in-database-engine-powershell.md
@@ -61,10 +61,10 @@ function sqldrive
 }  
   
 ## Use the sqldrive function to create a SQLAuth virtual drive.  
-sqldrive SQLAuth  
+sqldrive SQLAuth
   
-## CD to the virtual drive, which invokes the supplied authentication credentials.  
-cd SQLAuth  
+## Set-Location to the virtual drive, which invokes the supplied authentication credentials.  
+sl SQLAuth:
 ```
 
 ## SQL Server Authentication Using Invoke-Sqlcmd


### PR DESCRIPTION
On line 67. in the Set-Location statement, the drive name needs to have a colon to be recognized as a drive name.
Also, I changed the DOS commands to PoSh commands (lines 66, 67), since this is PoSh.