### PR TITLE
Update drop-table-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/drop-table-transact-sql.md
+++ b/docs/t-sql/statements/drop-table-transact-sql.md
@@ -71,7 +71,7 @@ DROP TABLE { database_name.schema_name.table_name | schema_name.table_name | tab
  Azure SQL Database supports the three-part name format database_name.[schema_name].object_name when the database_name is the current database or the database_name is tempdb and the object_name starts with #. Azure SQL Database does not support four-part names.  
   
  *IF EXISTS*  
- **Applies to**: [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] ( [!INCLUDE[ssSQL15](../../includes/sssql15-md.md)] through [current version](https://go.microsoft.com/fwlink/p/?LinkId=299658)).  
+ **Applies to**: [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] ( [!INCLUDE[ssSQL15](../../includes/sssql15-md.md)] through [current version](https://go.microsoft.com/fwlink/p/?LinkId=299658)).  Not supported in Synapse.
   
  Conditionally drops the table only if it already exists.  
   


### PR DESCRIPTION
An attempt to run DROP TABLE IF EXISTS on Synapse SQL Pool returns " Incorrect syntax near 'IF'." error.