### PR TITLE
Remove Space After Decimal Point

### DIFF
--- a/docs/t-sql/data-types/date-transact-sql.md
+++ b/docs/t-sql/data-types/date-transact-sql.md
@@ -209,7 +209,7 @@ SELECT
 |**date**|2007-05-08|  
 |**smalldatetime**|2007-05-08 12:35:00|  
 |**datetime**|2007-05-08 12:35:29.123|  
-|**datetime2**|2007-05-08 12:35:29. 1234567|  
+|**datetime2**|2007-05-08 12:35:29.1234567|  
 |**datetimeoffset**|2007-05-08 12:35:29.1234567 +12:15|  
 
 First introduced in SQL Server 2008.


### PR DESCRIPTION
While reading this doc, I found a datetime2 example with space after the decimal that should not be there. I removed it.