### PR TITLE
Fixed example for case sensitive collations.

### DIFF
--- a/docs/t-sql/functions/logical-functions-iif-transact-sql.md
+++ b/docs/t-sql/functions/logical-functions-iif-transact-sql.md
@@ -29,7 +29,7 @@ ms.author: maghan
 ## Syntax  
   
 ```syntaxsql
-IIF ( boolean_expression, true_value, false_value )  
+IIF( boolean_expression, true_value, false_value )
 ```  
   
 [!INCLUDE[sql-server-tsql-previous-offline-documentation](../../includes/sql-server-tsql-previous-offline-documentation.md)]
@@ -38,7 +38,7 @@ IIF ( boolean_expression, true_value, false_value )
  *boolean_expression*  
  A valid Boolean expression.  
   
- If this argument is not a Boolean expression, then a syntax error is raised.  
+ If this argument is not a Boolean expression then a syntax error is raised.  
   
  *true_value*  
  Value to return if *boolean_expression* evaluates to true.  
@@ -59,8 +59,8 @@ IIF ( boolean_expression, true_value, false_value )
 ### A. Simple IIF example  
   
 ```sql  
-DECLARE @a INT = 45, @b INT = 40;  
-SELECT IIF ( @a > @b, 'TRUE', 'FALSE' ) AS Result;  
+DECLARE @a INT = 45, @b INT = 40;
+SELECT [Result] = IIF( @a > @b, 'TRUE', 'FALSE' );
 ```  
   
  [!INCLUDE[ssResult](../../includes/ssresult-md.md)]  
@@ -69,14 +69,12 @@ SELECT IIF ( @a > @b, 'TRUE', 'FALSE' ) AS Result;
 Result  
 --------  
 TRUE  
-  
-(1 row(s) affected)  
 ```  
   
 ### B. IIF with NULL constants  
   
 ```sql 
-SELECT IIF ( 45 > 30, NULL, NULL ) AS Result;  
+SELECT [Result] = IIF( 45 > 30, NULL, NULL );
 ```  
   
  The result of this statement is an error.  
@@ -85,7 +83,7 @@ SELECT IIF ( 45 > 30, NULL, NULL ) AS Result;
   
 ```sql  
 DECLARE @P INT = NULL, @S INT = NULL;  
-SELECT IIF ( 45 > 30, @p, @s ) AS Result;  
+SELECT [Result] = IIF( 45 > 30, @P, @S );
 ```  
   
  [!INCLUDE[ssResult](../../includes/ssresult-md.md)]  
@@ -94,8 +92,6 @@ SELECT IIF ( 45 > 30, @p, @s ) AS Result;
 Result  
 --------  
 NULL  
-  
-(1 row(s) affected)  
 ```  
   
 ## See Also  


### PR DESCRIPTION
Why are there extra spaces after the SQL examples?