### PR TITLE
Update sys-dm-io-virtual-file-stats-transact-sql.md to reflect that it's a function, not a view

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-io-virtual-file-stats-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-io-virtual-file-stats-transact-sql.md
@@ -25,7 +25,7 @@ monikerRange: "=azuresqldb-current||=azure-sqldw-latest||>=sql-server-2016||>=sq
 # sys.dm_io_virtual_file_stats (Transact-SQL)
 [!INCLUDE [sql-asdb-asdbmi-asa-pdw](../../includes/applies-to-version/sql-asdb-asdbmi-asa.md)]
 
-  Returns I/O statistics for data and log files. This dynamic management view replaces the [fn_virtualfilestats](../../relational-databases/system-functions/sys-fn-virtualfilestats-transact-sql.md) function.  
+  Returns I/O statistics for data and log files. This dynamic management function replaces the [fn_virtualfilestats](../../relational-databases/system-functions/sys-fn-virtualfilestats-transact-sql.md) function.  
   
 > [!NOTE]  
 >  To call this from [!INCLUDE[ssSDWfull](../../includes/sssdwfull-md.md)], use the name **sys.dm_pdw_nodes_io_virtual_file_stats**. 


### PR DESCRIPTION
This is a dynamic management function, not a view, because it requires parameters.

You can run a view by just saying SELECT * FROM myview, but that doesn't work here with this dynamic management function.