### PR TITLE
Update lesson-1-6-adding-and-configuring-the-lookup-transformations.md

### DIFF
--- a/docs/integration-services/lesson-1-6-adding-and-configuring-the-lookup-transformations.md
+++ b/docs/integration-services/lesson-1-6-adding-and-configuring-the-lookup-transformations.md
@@ -53,8 +53,8 @@ In both cases, the Lookup transformation uses the OLE DB connection manager you 
     2.  Select **Use results of an SQL query**, and then enter or paste the following SQL statement:  
   
         ```sql
-        SELECT * FROM [dbo].[DimCurrency]
-        WHERE [CurrencyAlternateKey]
+        SELECT * FROM [Sales].[Currency]
+        WHERE [CurrencyCode]
         IN ('ARS', 'AUD', 'BRL', 'CAD', 'CNY',
             'DEM', 'EUR', 'FRF', 'GBP', 'JPY',
 	        'MXN', 'SAR', 'USD', 'VEB')


### PR DESCRIPTION
The AdventureWorks database from 2014-2019 does not contain a dbo.DimCurrency table. The conly Currency table that exists that could go along with this tutorial is, "Sales.Currency". Also, the column for the CurrencyAlternateKey is actually "CurrencyCode".