### PR TITLE
Removed " pass-through authentication"

### DIFF
--- a/docs/reporting-services/report-data/sql-azure-connection-type-ssrs.md
+++ b/docs/reporting-services/report-data/sql-azure-connection-type-ssrs.md
@@ -151,7 +151,7 @@ For more information about platform and version support, see [Data Sources Suppo
 
 ## Azure SQL Database and AAD
 
-You can use the Azure SQL database with Azure Active Directory (AAD) pass-through authentication.
+You can use the Azure SQL database with Azure Active Directory (AAD).
 
 This scenario is supported when you set up the following items properly:
 


### PR DESCRIPTION
Removed "pass-through authentication" from "Azure SQL Database and AAD" section. As per my understanding this feature is supported when having federated domain. And "You can use the Azure SQL database with Azure Active Directory (AAD) pass-through authentication." sentence confuses our customers between having federated vs Managed (with PTA) domain.