### PR TITLE
Clarify context of TEXTSIZE effects to just TDS

### DIFF
--- a/docs/t-sql/statements/set-textsize-transact-sql.md
+++ b/docs/t-sql/statements/set-textsize-transact-sql.md
@@ -29,7 +29,7 @@ monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-s
 # SET TEXTSIZE (Transact-SQL)
 [!INCLUDE [sql-asdb-asdbmi-asa-pdw](../../includes/applies-to-version/sql-asdb-asdbmi-asa-pdw.md)]
 
-  Specifies the size of **varchar(max)**, **nvarchar(max)**, **varbinary(max)**, **text**, **ntext**, and **image** data returned by a SELECT statement.  
+  Specifies the size, in bytes, of **varchar(max)**, **nvarchar(max)**, **varbinary(max)**, **text**, **ntext**, and **image** data returned to the client by a SELECT statement.  
   
 > [!IMPORTANT]
 >  **ntext**, **text**, and **image** data types will be removed in a future version of [!INCLUDE[msCoName](../../includes/msconame-md.md)][!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)]. Avoid using these data types in new development work, and plan to modify applications that currently use them. Use **nvarchar(max)**, **varchar(max)**, and **varbinary(max)** instead.  


### PR DESCRIPTION
I read this document this morning because I was trying to troubleshoot SQL run through sqlcmd.

The current phrasing of intro to this document leads one to believe that:
- TEXTSIZE number refers to the length of the string in characters (text)
- TEXTSIZE could have destructive effects in server-side operations (which is not the case, as this example demonstrates):

```sql
USE Test;
CREATE TABLE dbo.TextSizeTest (
    varchar50 varchar(50),
    varcharMax varchar(max),
    nvarcharMax nvarchar(max)
    ); 
INSERT dbo.TextSizeTest
VALUES (
    'five5',
    'five5',
    'five5'
    );

SELECT * FROM dbo.TextSizeTest;

SET TEXTSIZE 2048;

SELECT @@TEXTSIZE AS [Text Size];

SET TEXTSIZE 4

SELECT @@TEXTSIZE AS [Text Size];
SELECT * FROM dbo.TextSizeTest

INSERT dbo.TextSizeTest
(
    varchar50,
    varcharMax,
    nvarcharMax
)
SELECT varchar50,
       varcharMax,
       nvarcharMax
FROM dbo.TextSizeTest

SET TEXTSIZE 2046;
SELECT * FROM dbo.TextSizeTest
DROP TABLE dbo.TextSizeTest;
```