### PR TITLE
Updated hyperlink display to Managed Instance

### DIFF
--- a/docs/includes/azure-sql-db-replication-supportability-note.md
+++ b/docs/includes/azure-sql-db-replication-supportability-note.md
@@ -6,4 +6,4 @@ ms.date: 05/30/2019
 ms.author: mathoma
 ---
   > [!NOTE] 
-  > Azure SQL Managed Instance can be a publisher, distributor, and subscriber for snapshot and transactional replication. Databases in Azure SQL Database can only be push subscribers for snapshot and transactional replication. For more information, see [Transactional replication with Azure SQL Database](/azure/sql-database/sql-database-managed-instance-transactional-replication). 
+  > Azure SQL Managed Instance can be a publisher, distributor, and subscriber for snapshot and transactional replication. Databases in Azure SQL Database can only be push subscribers for snapshot and transactional replication. For more information, see [Transactional replication with Azure SQL Managed Instance](/azure/sql-database/sql-database-managed-instance-transactional-replication). 

--- a/docs/includes/azure-sql-db-replication-supportability-note.md
+++ b/docs/includes/azure-sql-db-replication-supportability-note.md
@@ -6,4 +6,4 @@ ms.date: 05/30/2019
 ms.author: mathoma
 ---
   > [!NOTE] 
-  > Azure SQL Managed Instance can be a publisher, distributor, and subscriber for snapshot and transactional replication. Databases in Azure SQL Database can only be push subscribers for snapshot and transactional replication. For more information, see [Transactional replication with Azure SQL Managed Instance](/azure/sql-database/sql-database-managed-instance-transactional-replication). 
+  > Azure SQL Managed Instance can be a publisher, distributor, and subscriber for snapshot and transactional replication. Databases in Azure SQL Database can only be push subscribers for snapshot and transactional replication. For more information, see Transactional replication with [Azure SQL Database](/azure/azure-sql/database/replication-to-sql-database) and [Azure SQL Managed Instance](/azure/azure-sql/managed-instance/replication-transactional-overview).


### PR DESCRIPTION
The hyperlink redirects to Transaction Replication with **Azure SQL Managed Instance** - whereas the description showed **Azure SQL Database** - which are different. Transaction Replication to **Azure SQL Database** should rather point [here](https://docs.microsoft.com/en-us/azure/azure-sql/database/replication-to-sql-database), in which case the hyperlink should be updated.