### PR TITLE
Clarifying that both SELECT...INTO and INSERT...SELECT ignore ORDER BY

### DIFF
--- a/docs/t-sql/queries/select-order-by-clause-transact-sql.md
+++ b/docs/t-sql/queries/select-order-by-clause-transact-sql.md
@@ -140,7 +140,7 @@ ORDER BY SchemaName + ''; -- wrong
  In a SELECT TOP (*N*) statement, always use an ORDER BY clause. This is the only way to predictably indicate which rows are affected by TOP. For more information, see [TOP &#40;Transact-SQL&#41;](../../t-sql/queries/top-transact-sql.md).  
   
 ## Interoperability  
- When used with a SELECT...INTO statement to insert rows from another source, the ORDER BY clause does not guarantee the rows are inserted in the specified order.  
+ When used with a SELECT...INTO or INSERT...SELECT statement to insert rows from another source, the ORDER BY clause does not guarantee the rows are inserted in the specified order.  
   
  Using OFFSET and FETCH in a view does not change the updateability property of the view.  
   


### PR DESCRIPTION
You can easilly see this example:

```
drop table if exists test 
go
select *
into test 
from FactInternetSales where 1=0

create clustered columnstore index cci_test on test

insert into test --with (tablock)
select s.* from FactInternetSales s
order by ProductKey 
```

And look at the actual execution plan, which lacks a sort operator.  And if the source table is large enough, you can verify that the column segments don't end up sorted.


```
select object_name(p.object_id) table_name, s.segment_id, c.name column_name,  s.min_data_id, s.max_data_id
from sys.column_store_segments s
join sys.partitions p
  on s.hobt_id = p.hobt_id 
left join sys.columns c
  on c.object_id = p.object_id 
  and c.column_id = s.column_id
where c.name = 'ProductKey'
```