### PR TITLE
Add repeat to CREATE INDEX filter_predicate syntax

### DIFF
--- a/docs/t-sql/statements/create-index-transact-sql.md
+++ b/docs/t-sql/statements/create-index-transact-sql.md
@@ -138,7 +138,7 @@ CREATE [ UNIQUE ] [ CLUSTERED | NONCLUSTERED ] INDEX index_name
 }
 
 <filter_predicate> ::=
-    <conjunct> [ AND <conjunct> ]
+    <conjunct> [ AND ] [ ...n ]
 
 <conjunct> ::=
     <disjunct> | <comparison>


### PR DESCRIPTION
The [current syntax](https://docs.microsoft.com/en-us/sql/t-sql/statements/create-index-transact-sql?view=sql-server-ver15#syntax-for-sql-server-and-azure-sql-database) for CREATE INDEX's `filter_predicate` appears to imply that only one or two conditions (joined with `AND`) are supported:

```
[snip]

    [ WHERE <filter_predicate> ]

[snip]

<filter_predicate> ::=
    <conjunct> [ AND <conjunct> ]

<conjunct> ::=
    <disjunct> | <comparison>

[snip]
```

In other words, one `conjunct` is required and a second may optionally be provided.  However, in testing with SQL Server 2019 (spun up using Docker), an arbitrary number of `conjunct`s are allowed, with a query such as this succeeding and creating the index:

```sql
CREATE UNIQUE INDEX [constraint] ON [test_table] ([_type])
WHERE
  ([status] = 'in_progress'
  AND [status] IN ('needs_changes', 'published')
  AND [status] = 'foo'
  AND [status] = 'bar'
  AND [status] = 'baz'
  AND [status] IN ('more', 'disjuncts'));
```

Given the above syntax works, a `[...n]` convention needs to be added to
indicate multiple conditions are acceptable
(https://docs.microsoft.com/en-us/sql/t-sql/language-elements/transact-sql-syntax-conventions-transact-sql?view=sql-server-ver15).  This PR follows https://docs.microsoft.com/en-us/sql/powershell/query-expressions-and-uniform-resource-names?view=sql-server-ver15#syntax - the one example in this repo's BNF syntax.

Let me know if further changes are necessary.