### PR TITLE
Defaults in documentation are incorrect for two of the parameters

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-change-log-shipping-secondary-database-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-change-log-shipping-secondary-database-transact-sql.md
@@ -77,7 +77,7 @@ sp_change_log_shipping_secondary_database
  The number of minutes allowed to elapse between restore operations before an alert is generated. *restore_threshold* is **int** and cannot be NULL.  
   
 `[ @threshold_alert = ] 'threshold_alert'`
- Is the alert to be raised when the restore threshold is exceeded. *threshold_alert* is **int**, with a default of 14420.  
+ Is the alert to be raised when the restore threshold is exceeded. *threshold_alert* is **int**, with a default of 14421.  
   
 `[ @threshold_alert_enabled = ] 'threshold_alert_enabled'`
  Specifies whether an alert will be raised when *restore_threshold*is exceeded. 1 = enabled; 0 = disabled. *threshold_alert_enabled* is **bit** and cannot be NULL.  


### PR DESCRIPTION
In SQL Server 2017 (at least), when I execute the stored procedure with some of the parameters omitted to use the default values, the default for "threshold alert" is 14421 (not 14420) and the default for "history_retention_period" is 1440 (not 14420, as specified on the published documentation page).
![Screenshot_2021-01-18_092017](https://user-images.githubusercontent.com/323132/104933594-ba314d80-596e-11eb-952f-55c918ec6df2.png)