### PR TITLE
SELECT...OVER - ORDER BY: Typographical Error

### DIFF
--- a/docs/t-sql/queries/select-over-clause-transact-sql.md
+++ b/docs/t-sql/queries/select-over-clause-transact-sql.md
@@ -168,7 +168,7 @@ ORDER BY *order_by_expression* [COLLATE *collation_name*] [ASC|DESC]
 
  Defines the logical order of the rows within each partition of the result set. That is, it specifies the logical order in which the window function calculation is performed. 
  - If it is not specified, the default order is `ASC` and window function will use all rows in partition.
- - If it is specified, and in ROWS/RANGE is not specified, then default `RANGE UNBOUNDED PRECEDING AND CURRENT ROW` is used as default for window frame by the functions that can accept optional ROWS/RANGE specification (for example `min` or `max`). 
+ - If it is specified, and a ROWS/RANGE is not specified, then default `RANGE UNBOUNDED PRECEDING AND CURRENT ROW` is used as default for window frame by the functions that can accept optional ROWS/RANGE specification (for example `min` or `max`). 
  
 ```sql
 select 


### PR DESCRIPTION
*"and in ROWS/RANGE is not specified"* corrected to *"and a ROWS/RANGE is not specified"*.