### PR TITLE
Link to Error Severities from RAISERROR page

### DIFF
--- a/docs/t-sql/language-elements/raiserror-transact-sql.md
+++ b/docs/t-sql/language-elements/raiserror-transact-sql.md
@@ -127,7 +127,7 @@ RAISERROR ( { msg_str | @local_variable }
  Is a variable of any valid character data type that contains a string formatted in the same manner as *msg_str*. *\@local_variable* must be **char** or **varchar**, or be able to be implicitly converted to these data types.  
   
  *severity*  
- Is the user-defined severity level associated with this message. When using *msg_id* to raise a user-defined message created using sp_addmessage, the severity specified on RAISERROR overrides the severity specified in sp_addmessage.  
+ Is the user-defined [severity level](../../relational-databases/errors-events/database-engine-error-severities.md) associated with this message. When using *msg_id* to raise a user-defined message created using sp_addmessage, the severity specified on RAISERROR overrides the severity specified in sp_addmessage.  
   
  Severity levels from 0 through 18 can be specified by any user. Severity levels from 19 through 25 can only be specified by members of the sysadmin fixed server role or users with ALTER TRACE permissions. For severity levels from 19 through 25, the WITH LOG option is required. Severity levels less than 0 are interpreted as 0. Severity levels greater than 25 are interpreted as 25.  
   


### PR DESCRIPTION
Adding a link to the Database Engine Error Severities page from the severity section of the RAISERROR page.