### PR TITLE
Cardinality 25,000 should be replaced with 19,682

### DIFF
--- a/docs/relational-databases/statistics/statistics.md
+++ b/docs/relational-databases/statistics/statistics.md
@@ -123,8 +123,8 @@ ORDER BY s.name;
   |Temporary|*n* < 6|6|
   |Temporary|6 <= *n* <= 500|500|
   |Permanent|*n* <= 500|500|
-  |Temporary or permanent|500 <= *n* <= 25,000|500 + (0.20 * *n*)|
-  |Temporary or permanent|*n* > 25,000|SQRT(1,000 * *n*)|
+  |Temporary or permanent|500 <= *n* <= 19,682|500 + (0.20 * *n*)|
+  |Temporary or permanent|*n* > 19,682|SQRT(1,000 * *n*)|
 
   For example if your table contains 2 million rows, then the calculation is `SQRT(1,000 * 2,000,000) = 44,721` and the statistics will be updated every 44,721 modifications.
 


### PR DESCRIPTION
The function name is CStatsUtil::SetStatsRefreshThreshold in statutil.cpp - OpenGrok cross reference for /Sql/Ntdbms/query/qeoptim/util/statutil.cpp
It compares the value of both sublinear threshold and old threshold, pick up the minimal one.  Line 8166~line 8173 in sql 2019.
There are ranges that sqrt(1000∗n)>500+0.2n, the value is 19,682 instead of 25,000.  I tested in sql 2014 sp1, sql 2016 sp2 cu15, sql 2019 cu8 have the same result .

https://sqlbuvsts01:8443/Main/SQL%20Server/_workitems#_a=edit&id=13952114