### PR TITLE
Update run-packages-in-integration-services-ssis-scale-out.md

### DIFF
--- a/docs/integration-services/scale-out/run-packages-in-integration-services-ssis-scale-out.md
+++ b/docs/integration-services/scale-out/run-packages-in-integration-services-ssis-scale-out.md
@@ -6,8 +6,8 @@ ms.date: "12/13/2017"
 ms.prod: sql
 ms.technology: integration-services
 ms.topic: conceptual
-author: "haoqian"
-ms.author: "haoqian"
+author: HaoQian-MS
+ms.author: haoqian
 ms.reviewer: maghan
 f1_keywords: 
   - "sql13.ssis.ssms.ispackageexecuteinscaleout.f1"

--- a/docs/integration-services/scale-out/run-packages-in-integration-services-ssis-scale-out.md
+++ b/docs/integration-services/scale-out/run-packages-in-integration-services-ssis-scale-out.md
@@ -121,7 +121,7 @@ To switch the default execution mode back so that packages no longer run by defa
 In a SQL Server Agent job, you can run an SSIS package as one step of the job. To run the package in Scale Out, set the default execution mode to **Scale Out**. After you set the default execution mode to **Scale Out**, packages in SQL Server Agent jobs run in Scale Out mode.
 
 > [!NOTE]
-> Scale Out package executions cannot be stopped by cancelling the SQL Server Agent Job. The recommended way to stop the Scale Out execution is with the stored procedure "catalog.stop_operation" or using "Active Operation" window. 
+> You can't stop Scale Out package execution by canceling the SQL Server Agent job. To stop Scale Out execution, we recommend that you use the catalog.stop_operation stored procedure or use the **Active Operations** pane. 
 
 ## Next steps
 -   [Troubleshoot Scale Out](troubleshooting-scale-out.md)

--- a/docs/integration-services/scale-out/run-packages-in-integration-services-ssis-scale-out.md
+++ b/docs/integration-services/scale-out/run-packages-in-integration-services-ssis-scale-out.md
@@ -120,5 +120,8 @@ To switch the default execution mode back so that packages no longer run by defa
 ## <a name="sql_agent"></a> Run package in SQL Server Agent job
 In a SQL Server Agent job, you can run an SSIS package as one step of the job. To run the package in Scale Out, set the default execution mode to **Scale Out**. After you set the default execution mode to **Scale Out**, packages in SQL Server Agent jobs run in Scale Out mode.
 
+> [!NOTE]
+> Scale Out package executions cannot be stopped by cancelling the SQL Server Agent Job. The recommended way to stop the Scale Out execution is with the stored procedure "catalog.stop_operation" or using "Active Operation" window. 
+
 ## Next steps
 -   [Troubleshoot Scale Out](troubleshooting-scale-out.md)


### PR DESCRIPTION
Added the known limitation -  Scale Out that the package execution can’t be stopped by cancelling agent job. We will add this to our document. 
The way to stop scale out execution is with stored procedure “catalog.stop_operation” or the “Active Operation” UI.
as per product engineer comments.