### PR TITLE
Remove duplicate SQL_INSTALL_AGENT environment variable export

### DIFF
--- a/docs/linux/sample-unattended-install-ubuntu.md
+++ b/docs/linux/sample-unattended-install-ubuntu.md
@@ -212,7 +212,6 @@ export MSSQL_PID='evaluation'
 export SQL_INSTALL_AGENT='y'
 export SQL_INSTALL_USER='<Username>'
 export SQL_INSTALL_USER_PASSWORD='<YourStrong!Passw0rd>'
-export SQL_INSTALL_AGENT='y'
 ```
 
 Then run the Bash script as follows:


### PR DESCRIPTION
The `SQL_INSTALL_AGENT` environment variable is exported twice in the sample script which is unnecessary.