### PR TITLE
Small changes with formatting

### DIFF
--- a/docs/relational-databases/databases/msdb-database.md
+++ b/docs/relational-databases/databases/msdb-database.md
@@ -80,34 +80,21 @@ ms.author: "sstein"
  The following operations cannot be performed on the **msdb** database:  
   
 -   Changing collation. The default collation is the server collation.  
-  
 -   Dropping the database.  
-  
 -   Dropping the **guest** user from the database.  
-  
 -   Enabling change data capture.  
-  
 -   Participating in database mirroring.  
-  
 -   Removing the primary filegroup, primary data file, or log file.  
-  
 -   Renaming the database or primary filegroup.  
-  
 -   Setting the database to OFFLINE.  
-  
 -   Setting the primary filegroup to READ_ONLY.  
   
 ## Related Content  
- [System Databases](../../relational-databases/databases/system-databases.md)  
-  
- [sys.databases &#40;Transact-SQL&#41;](../../relational-databases/system-catalog-views/sys-databases-transact-sql.md)  
-  
- [sys.master_files &#40;Transact-SQL&#41;](../../relational-databases/system-catalog-views/sys-master-files-transact-sql.md)  
-  
- [Move Database Files](../../relational-databases/databases/move-database-files.md)  
-  
- [Database Mail](../../relational-databases/database-mail/database-mail.md)  
-  
- [SQL Server Service Broker](../../database-engine/configure-windows/sql-server-service-broker.md)  
+- [System Databases](../../relational-databases/databases/system-databases.md)  
+- [sys.databases &#40;Transact-SQL&#41;](../../relational-databases/system-catalog-views/sys-databases-transact-sql.md)  
+- [sys.master_files &#40;Transact-SQL&#41;](../../relational-databases/system-catalog-views/sys-master-files-transact-sql.md)  
+- [Move Database Files](../../relational-databases/databases/move-database-files.md)  
+- [Database Mail](../../relational-databases/database-mail/database-mail.md)  
+- [SQL Server Service Broker](../../database-engine/configure-windows/sql-server-service-broker.md)  
   
   


### PR DESCRIPTION
For having the same formatting as for documentation about the master database, I suggest:
- eliminating empty rows and spaces between row 82 and 98 for part ## Restrictions
- eliminating empty rows between row 93 and 99 and adding 'dash' for part Related Content

It will make page formatted in the same way (without empty lines and with dashes) as on master-database.md