### PR TITLE
Small changes with formatting

### DIFF
--- a/docs/relational-databases/databases/model-database.md
+++ b/docs/relational-databases/databases/model-database.md
@@ -84,37 +84,23 @@ For SQL Server 2014, see [model Database](/previous-versions/sql/2014/relational
 ## Restrictions  
  The following operations cannot be performed on the **model** database:  
   
--   Adding files or filegroups.  
-  
--   Changing collation. The default collation is the server collation.  
-  
--   Changing the database owner. **model** is owned by **sa**.  
-  
--   Dropping the database.  
-  
--   Dropping the **guest** user from the database.  
-  
--   Enabling change data capture.  
-  
--   Participating in database mirroring.  
-  
--   Removing the primary filegroup, primary data file, or log file.  
-  
--   Renaming the database or primary filegroup.  
-  
--   Setting the database to OFFLINE.  
-  
--   Setting the primary filegroup to READ_ONLY.  
-  
--   Creating procedures, views, or triggers using the WITH ENCRYPTION option. The encryption key is tied to the database in which the object is created. Encrypted objects created in the **model** database can only be used in **model**.  
+- Adding files or filegroups.  
+- Changing collation. The default collation is the server collation.  
+- Changing the database owner. **model** is owned by **sa**.  
+- Dropping the database.  
+- Dropping the **guest** user from the database.  
+- Enabling change data capture.  
+- Participating in database mirroring.  
+- Removing the primary filegroup, primary data file, or log file.  
+- Renaming the database or primary filegroup.  
+- Setting the database to OFFLINE.  
+- Setting the primary filegroup to READ_ONLY.  
+- Creating procedures, views, or triggers using the WITH ENCRYPTION option. The encryption key is tied to the database in which the object is created. Encrypted objects created in the **model** database can only be used in **model**.  
   
 ## Related Content  
- [System Databases](../../relational-databases/databases/system-databases.md)  
-  
- [sys.databases &#40;Transact-SQL&#41;](../../relational-databases/system-catalog-views/sys-databases-transact-sql.md)  
-  
- [sys.master_files &#40;Transact-SQL&#41;](../../relational-databases/system-catalog-views/sys-master-files-transact-sql.md)  
-  
- [Move Database Files](../../relational-databases/databases/move-database-files.md)  
+- [System Databases](../../relational-databases/databases/system-databases.md)  
+- [sys.databases &#40;Transact-SQL&#41;](../../relational-databases/system-catalog-views/sys-databases-transact-sql.md)  
+- [sys.master_files &#40;Transact-SQL&#41;](../../relational-databases/system-catalog-views/sys-master-files-transact-sql.md)  
+- [Move Database Files](../../relational-databases/databases/move-database-files.md)  
   
   


### PR DESCRIPTION
For having the same formatting as for documentation about the master database, I suggest:
- eliminating empty rows between row 87 and 109 for part ## Restrictions
- eliminating empty rows between row 100 and 107 and adding 'dash' for part Related Content

It will make page formatted in the same way (without empty lines and with dashes) as on master-database.md