### PR TITLE
Formatting changes

### DIFF
--- a/docs/relational-databases/databases/tempdb-database.md
+++ b/docs/relational-databases/databases/tempdb-database.md
@@ -347,8 +347,8 @@ GROUP BY R2.session_id, R1.internal_objects_alloc_page_count,
 ```
 
 ## Related content
-[SORT_IN_TEMPDB option for indexes](../../relational-databases/indexes/sort-in-TempDB-option-for-indexes.md)    
-[System databases](../../relational-databases/databases/system-databases.md)    
-[sys.databases](../../relational-databases/system-catalog-views/sys-databases-transact-sql.md)    
-[sys.master_files](../../relational-databases/system-catalog-views/sys-master-files-transact-sql.md)    
-[Move database files](../../relational-databases/databases/move-database-files.md)    
+- [SORT_IN_TEMPDB option for indexes](../../relational-databases/indexes/sort-in-TempDB-option-for-indexes.md)    
+- [System databases](../../relational-databases/databases/system-databases.md)    
+- [sys.databases](../../relational-databases/system-catalog-views/sys-databases-transact-sql.md)    
+- [sys.master_files](../../relational-databases/system-catalog-views/sys-master-files-transact-sql.md)    
+- [Move database files](../../relational-databases/databases/move-database-files.md)    


### PR DESCRIPTION
For having the same formatting as for documentation about the master database, I suggest:
adding dash "-" for lines 350-354  for part Related Content

It will make page formatted (for part ##Related Content) in the same way (without empty lines and with dashes) as on master-database.md