### PR TITLE
Manually updating password for Grafana and Kibana

### DIFF
--- a/docs/big-data-cluster/change-azdata-password.md
+++ b/docs/big-data-cluster/change-azdata-password.md
@@ -80,3 +80,69 @@ If the cluster is operating in non-Active Directory mode, update the Apache Knox
    ```sql
    ALTER LOGIN <AZDATA_USERNAME> WITH PASSWORD = 'newPassword'
    ```
+### Manually updating password for Grafana and Kibana
+After following the steps to update AZDATA_PASSWORD we would see that Grafana and Kibana are still accepting the old password and not the new password. This is because Grafana and Kibana does not have the ability to pick the new k8s secret. So we need to manually update the password for both of them separately.
+
+### Steps to update Grafana Password:
+ 
+
+- We will need htpasswd utility. You can install this on any client machine.
+    - [ ] For Ubuntu: 
+		`sudo apt install apache2-utils`
+    - [ ] For RHEL:
+		`sudo yum install httpd-tools`
+	
+- Generate the new password , where 'admin' is the user and 'Test@12345' is its new password:
+
+                htpasswd -nbs admin Test@12345
+                admin:{SHA}W/5VKRjIzjusUJ0ih0gHyEPjC/s=
+
+- Now encode the password:
+
+		echo "admin:{SHA}W/5VKRjIzjusUJ0ih0gHyEPjC/s=" | base64
+		IGFkbWluOntTSEF9Vy81VktSakl6anVzVUowaWgwZ0h5RVBqQy9zPQo= 
+			 
+
+- Now we need to edit the mgmtproxy-secret:
+
+		kubectl edit secret -n mssql-cluster mgmtproxy-secret
+		 
+
+- Update the controller-login-htpasswd with the new value generated above:
+
+		# Please edit the object below. Lines beginning with a '#' will be ignored,
+		# and an empty file will abort the edit. If an error occurs while saving this file will be
+		# reopened with the relevant failures.
+		#
+		apiVersion: v1
+		data:
+		  controller-login-htpasswd: IGFkbWluOntTSEF9Vy81VktSakl6anVzVUowaWgwZ0h5RVBqQy9zPQo=
+		  mssql-internal-controller-password: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+		  mssql-internal-controller-username: xxxxxxxxxxxxxxxxxx
+		 
+
+- Delete the mgmtproxy pod:
+
+		kubectl delete pod mgmtproxy-xxxxx -n mssql-clutser
+			 
+
+- Wait for the mgmtproxy pod to come online and Grafana Dashboard to start. 
+
+- Now login to Grafana using new password.
+
+### Steps to update Kibana Password:
+
+- Open kibana URL:
+
+			https://11.111.111.111:30777/kibana/app/kibana#/discover
+		 
+
+- Go to -> Security -> Internal User Database -> Edit -> Reset Password:
+
+    ![image](https://user-images.githubusercontent.com/54091686/108350492-4783ee00-720a-11eb-927d-d08c2b73fa60.png)
+    
+    ![image](https://user-images.githubusercontent.com/54091686/108350588-684c4380-720a-11eb-9d22-e3c73f00cc07.png)
+    
+    ![image](https://user-images.githubusercontent.com/54091686/108350595-6b473400-720a-11eb-9477-6601106807c2.png)
+
+- Now reconnect to Kibana using the new password.


### PR DESCRIPTION
Manually updating AZDATA_PASSWORD does not update the password for Grafana and Kibana and we need to update those manually. Adding the steps to update the  password for Grafana and Kibana.