### PR TITLE
Update todatetimeoffset-transact-sql.md

### DIFF
--- a/docs/t-sql/functions/todatetimeoffset-transact-sql.md
+++ b/docs/t-sql/functions/todatetimeoffset-transact-sql.md
@@ -36,20 +36,21 @@ monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-s
 ## Syntax  
   
 ```syntaxsql
-TODATETIMEOFFSET ( expression , offset )  
+TODATETIMEOFFSET ( datetime_expression , timezoneoffset_expression )  
 ```  
   
 [!INCLUDE[sql-server-tsql-previous-offline-documentation](../../includes/sql-server-tsql-previous-offline-documentation.md)]
 
 ## Arguments
- *expression*  
+ *datetime_expression*  
  Is an [expression](../../t-sql/language-elements/expressions-transact-sql.md) that resolves to a [datetime2](../../t-sql/data-types/datetime2-transact-sql.md) value.  
   
 > [!NOTE]  
 >  The expression cannot be of type **text**, **ntext**, or **image** because these types cannot be implicitly converted to **varchar** or **nvarchar**.  
   
- *offset*  
- Is an expression that represents the time zone offset in minutes (if an integer), for example -120, or hours and minutes (if a string), for example '+13:00'. The range is +14 to -14 (in hours). The expression is interpreted as a local time including the specified offset.  
+ *timezoneoffset_expression*  
+ Is an expression that represents the time zone offset in minutes (if an integer), for example -120, or hours and minutes (if a string), for example '+13:00'. The range is +14 to -14 (in hours). The expression is interpreted in local time for the specified timezoneoffset_expression.  
+
   
 > [!NOTE]  
 >  If expression is a character string, it must be in the format {+|-}TZH:THM.  

--- a/docs/t-sql/functions/todatetimeoffset-transact-sql.md
+++ b/docs/t-sql/functions/todatetimeoffset-transact-sql.md
@@ -36,7 +36,7 @@ monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-s
 ## Syntax  
   
 ```syntaxsql
-TODATETIMEOFFSET ( expression , time_zone )  
+TODATETIMEOFFSET ( expression , offset )  
 ```  
   
 [!INCLUDE[sql-server-tsql-previous-offline-documentation](../../includes/sql-server-tsql-previous-offline-documentation.md)]
@@ -48,8 +48,8 @@ TODATETIMEOFFSET ( expression , time_zone )
 > [!NOTE]  
 >  The expression cannot be of type **text**, **ntext**, or **image** because these types cannot be implicitly converted to **varchar** or **nvarchar**.  
   
- *time_zone*  
- Is an expression that represents the time zone offset in minutes (if an integer), for example -120, or hours and minutes (if a string), for example '+13:00'. The range is +14 to -14 (in hours). The expression is interpreted in local time for the specified time_zone.  
+ *offset*  
+ Is an expression that represents the time zone offset in minutes (if an integer), for example -120, or hours and minutes (if a string), for example '+13:00'. The range is +14 to -14 (in hours). The expression is interpreted as a local time including the specified offset.  
   
 > [!NOTE]  
 >  If expression is a character string, it must be in the format {+|-}TZH:THM.  


### PR DESCRIPTION
The parameter is not a time zone, not even in SQL Server's own terminology, as used by "AT TIME ZONE". It's an offset. The same error occurs in SSMS Intellisense