### PR TITLE
Change to quoting of column aliases

### DIFF
--- a/docs/t-sql/language-elements/nullif-transact-sql.md
+++ b/docs/t-sql/language-elements/nullif-transact-sql.md
@@ -72,7 +72,7 @@ INSERT budgets VALUES(300000, 250000);
 GO    
 SET NOCOUNT OFF;  
 SELECT AVG(NULLIF(COALESCE(current_year,  
-   previous_year), 0.00)) AS 'Average Budget'  
+   previous_year), 0.00)) AS [Average Budget]  
 FROM budgets;  
 GO  
 ```  
@@ -93,12 +93,12 @@ GO
 USE AdventureWorks2012;  
 GO  
 SELECT ProductID, MakeFlag, FinishedGoodsFlag,   
-   NULLIF(MakeFlag,FinishedGoodsFlag) AS 'Null if Equal'  
+   NULLIF(MakeFlag,FinishedGoodsFlag) AS [Null if Equal]  
 FROM Production.Product  
 WHERE ProductID < 10;  
 GO  
   
-SELECT ProductID, MakeFlag, FinishedGoodsFlag,'Null if Equal' =  
+SELECT ProductID, MakeFlag, FinishedGoodsFlag, [Null if Equal] =  
    CASE  
        WHEN MakeFlag = FinishedGoodsFlag THEN NULL  
        ELSE MakeFlag  


### PR DESCRIPTION
Just proposing a change to use standard quoting for column aliases, rather than using a quoted identifier method that does/does not work depending upon session settings.