### PR TITLE
Typo on text from 'two' to 'three'

### DIFF
--- a/docs/relational-databases/security/auditing/write-sql-server-audit-events-to-the-security-log.md
+++ b/docs/relational-databases/security/auditing/write-sql-server-audit-events-to-the-security-log.md
@@ -22,7 +22,7 @@ ms.author: vanto
 
 In a high security environment, the Windows Security log is the appropriate location to write events that record object access. Other audit locations are supported but are more subject to tampering.  
   
- There are two key requirements for writing [!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)] server audits to the Windows Security log:  
+ There are three key requirements for writing [!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)] server audits to the Windows Security log:  
   
 -   The audit object access setting must be configured to capture the events. The audit policy tool (`auditpol.exe`) exposes a variety of sub-policies settings in the **audit object access** category. To allow [!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)] to audit object access, configure the **application generated** setting.  
 -   The account that the [!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)] service is running under must have the **generate security audits** permission to write to the Windows Security log. By default, the LOCAL SERVICE and the NETWORK SERVICE accounts have this permission. This step is not required if [!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)] is running under one of those accounts.  


### PR DESCRIPTION
The bulleted list has three items, not two. Updating a typo.