### PR TITLE
Update sys-dm-hadr-availability-group-states-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-hadr-availability-group-states-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-hadr-availability-group-states-transact-sql.md
@@ -32,7 +32,7 @@ ms.author: wiassaf
 |Column name|Data type|Description|  
 |-----------------|---------------|-----------------|  
 |**group_id**|**uniqueidentifier**|Unique identifier of the availability group.|  
-|**primary_replica**|**varchar(128)**|Name of the server instance that is hosting the current primary replica.<br /><br /> NULL = Not the primary replica or unable to communicate with the WSFC failover cluster.|  
+|**primary_replica**|**varchar(128)**|Name of the server instance that is hosting the current primary replica.<br /><br /> NULL = Not the primary replica and unable to communicate with the WSFC failover cluster.|  
 |**primary_recovery_health**|**tinyint**|Indicates the recovery health of the primary replica, one of:<br /><br /> 0 = In progress<br /><br /> 1 = Online<br /><br /> NULL<br /><br /> On secondary replicas the **primary_recovery_health** column is NULL.|  
 |**primary_recovery_health_desc**|**nvarchar(60)**|Description of **primary_replica_health**, one of:<br /><br /> ONLINE_IN_PROGRESS<br /><br /> ONLINE<br /><br /> NULL|  
 |**secondary_recovery_health**|**tinyint**|Indicates the recovery health of a secondary replica replica,one of:<br /><br /> 0 = In progress<br /><br /> 1 = Online<br /><br /> NULL<br /><br /> On the primary replica, the **secondary_recovery_health** column is NULL.|  


### PR DESCRIPTION
In "Not the primary replica OR unable to communicate with the WSFC failover cluster." the "OR" means if either condition is true. So when it's not the primary replica, I would expect to see NULL, However, I'm seeing the primary replica name when selecting the column on the secondary replica. In this case, since it _can_ communicate with the WSFC, it must be getting the primary replica name from the cluster. Therefore I believe it's NULL when 1) it's not the primary replica AND 2) it can't get the primary replica name from the WSFC failover cluster because it's unable to communicate with it.