### PR TITLE
Clarify that varchar(max) fields can now be part of an index's includ…

### DIFF
--- a/docs/t-sql/statements/create-index-transact-sql.md
+++ b/docs/t-sql/statements/create-index-transact-sql.md
@@ -486,7 +486,7 @@ Indexes, including indexes on global temp tables, can be created online except f
 - Disabled clustered indexes
 - Columnstore indexes
 - Clustered index, if the underlying table contains LOB data types (**image**, **ntext**, **text**) and spatial data types
-- **varchar(max)** and **varbinary(max)** columns cannot be part of an index. In [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] (Starting with [!INCLUDE[ssSQL11](../../includes/sssql11-md.md)]) and [!INCLUDE[ssSDSfull](../../includes/sssdsfull-md.md)], when a table contains **varchar(max)** or **varbinary(max)** columns, a clustered index containing other columns can be built or rebuilt using the **ONLINE** option. [!INCLUDE[ssSDSfull](../../includes/sssdsfull-md.md)] does not permit the **ONLINE** option when the base table contains **varchar(max)** or **varbinary(max)** columns
+- **varchar(max)** and **varbinary(max)** columns cannot be part of an index key. In [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] (Starting with [!INCLUDE[ssSQL11](../../includes/sssql11-md.md)]) and [!INCLUDE[ssSDSfull](../../includes/sssdsfull-md.md)], when a table contains **varchar(max)** or **varbinary(max)** columns, a clustered index containing other columns can be built or rebuilt using the **ONLINE** option. 
 
 For more information, see [How Online Index Operations Work](../../relational-databases/indexes/how-online-index-operations-work.md).
 


### PR DESCRIPTION
…ed column

1. Edit to specify varchar max cannot be part of a key , it can be part of an index's included column list:
**varchar(max)** and **varbinary(max)** columns cannot be part of an index key.
2. Remove the following statment:
[!INCLUDE[ssSDSfull](../../includes/sssdsfull-md.md)] does not permit the **ONLINE** option when the base table contains **varchar(max)** or **varbinary(max)** columns

Per https://feedback.azure.com/forums/217321-sql-database/suggestions/2273663-support-rebuilding-indexes-online-for-tables-with
It is now possible to run an online index rebuild on an index with varchar (max) included columns. It is still not possible with TEXT/LOB columns, however.

You can observe this with the following sample script:
--------------------------------------------------------------
drop table dbo.TestTable
go

CREATE TABLE dbo.TestTable
(
pk  INT NOT NULL IDENTITY(1,1) , --PRIMARY KEY clustered,
fn VARCHAR(30) NOT NULL,
ln VARCHAR(max) NOT NULL, --  TEXT NOT NULL
ph VARCHAR(20)
);

Go
INSERT INTO dbo.TestTable(fn, ln, ph) VALUES('a' ,  REPLICATE('A',80000), 'phonenum1');
INSERT INTO dbo.TestTable(fn, ln, ph) VALUES('b' , REPLICATE('A',80000),'phonenum2');
GO

ALTER TABLE dbo.TestTable ADD CONSTRAINT PK_TESTABLE PRIMARY KEY CLUSTERED (ln)
/*
Msg 1919, Level 16, State 1, Line 18
Column 'LAST_NAME' in table 'TestTable' is of a type that is invalid for use as a key column in an index.
Msg 1750, Level 16, State 0, Line 18
Could not create constraint or index. See previous errors.

*/

CREATE NONCLUSTERED INDEX nctestTable0  ON TestTable(ln) WITH (ONLINE=ON)
/*
Msg 1919, Level 16, State 1, Line 29
Column 'ln' in table 'TestTable' is of a type that is invalid for use as a key column in an index.
*/


ALTER TABLE dbo.TestTable ADD CONSTRAINT PK_TESTABLE PRIMARY KEY CLUSTERED (pk)
GO
ALTER INDEX PK_TESTABLE ON dbo.TestTable REBUILD WITH (ONLINE=ON);

/*
if ln is of type text:
Msg 2725, Level 16, State 2, Line 35
An online operation cannot be performed for index 'PK_TESTABLE' because the index contains column 'ln' of data type text, ntext, image or FILESTREAM. For a non-clustered index, the column could be an include column of the index. For a clustered index, the column could be any column of the table. If DROP_EXISTING is used, the column could be part of a new or old index. The operation must be performed offline.


*/
GO
CREATE NONCLUSTERED INDEX nctestTable1  ON TestTable(ph) INCLUDE(ln) WITH (ONLINE=ON)
/*
if ln is of type text:

Msg 1999, Level 16, State 1, Line 45
Column 'ln' in table 'TestTable' is of a type that is invalid for use as included column in an index.

Completion time: 2021-02-26T16:52:42.1186715-06:00

*/
INSERT INTO dbo.TestTable(fn, ln, ph) VALUES('c' ,  REPLICATE('A',80000), 'phonenum3');
INSERT INTO dbo.TestTable(fn, ln, ph) VALUES('d' , REPLICATE('A',80000),'phonenum4');
ALTER INDEX nctestTable1 ON TestTable REBUILD WITH (ONLINE=ON);
GO
CREATE NONCLUSTERED INDEX nctestTable2 ON TestTable(ph) WITH (ONLINE=ON)
INSERT INTO dbo.TestTable(fn, ln, ph) VALUES('e' ,  REPLICATE('A',80000), 'phonenum5');
INSERT INTO dbo.TestTable(fn, ln, ph) VALUES('f' , REPLICATE('A',80000),'phonenum6');
ALTER INDEX nctestTable2 ON TestTable REBUILD WITH (ONLINE=ON);
GO
select * from sys.indexes where name like 'nctestTable%'