### PR TITLE
Include the string representation of root

### DIFF
--- a/docs/t-sql/data-types/getroot-database-engine.md
+++ b/docs/t-sql/data-types/getroot-database-engine.md
@@ -65,6 +65,8 @@ The following code snippet calls the GetRoot() method:
 ```sql
 SqlHierarchyId.GetRoot()  
 ```  
+
+If coupled with `.ToString()`, the above will return the string `'/'`.
   
 ## See also
 [hierarchyid Data Type Method Reference](./hierarchyid-data-type-method-reference.md)  


### PR DESCRIPTION
The intention here is to allow people new to the HierarchyId concept to be more rooted 🥁 by seeing the concrete human-friendly representation of the root.