### PR TITLE
Update create-availability-group-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/create-availability-group-transact-sql.md
+++ b/docs/t-sql/statements/create-availability-group-transact-sql.md
@@ -383,12 +383,12 @@ For more information, see [Secondary to primary replica read/write connection re
  You need to join the secondary availability group to the distributed availability group. For more information, see [ALTER AVAILABILITY GROUP &#40;Transact-SQL&#41;](../../t-sql/statements/alter-availability-group-transact-sql.md).  
   
  \<ag_name> 
- Specifies the name  of the availability group that makes up one half of the distributed availability group.  
+ Specifies the name of the availability group that makes up one half of the distributed availability group.  
   
- LISTENER **='**TCP**://**_system-address_**:**_port_**'**  
+ LISTENER_URL **='**TCP**://**_system-address_**:**_port_**'**  
  Specifies the URL path for the listener associated with the availability group.  
   
- The LISTENER clause is required.  
+ The LISTENER_URL clause is required.  
   
  **'**TCP**://**_system-address_**:**_port_**'**  
  Specifies a URL for the listener associated with the availability group. The URL parameters are as follows:  


### PR DESCRIPTION
The option should be LISTENER_URL, not LISTENER. Trying to create using just LISTENER will fail with the following:
Msg 155, Level 15, State 1, Line 7
'LISTENER' is not a recognized CREATE AVAILABILITY GROUP option.
Msg 35236, Level 15, State 1, Line 11
The endpoint URL was not specified for the availability replica hosted by server instance 'xxx'.  Reenter the command, specifying the endpoint URL of this instance of SQL Server.