### PR TITLE
Fixing quotation marks to copy/paste friendly

### DIFF
--- a/docs/language-extensions/install/windows-java.md
+++ b/docs/language-extensions/install/windows-java.md
@@ -144,7 +144,7 @@ If you did not install the default Zulu Open JRE that was included with SQL Serv
 1. Give AppContainer permissions
 
     ```cmd
-    icacls “<PATH to JRE>” /grant *S-1-15-2-1:(OI)(CI)RX /T
+    icacls "<PATH to JRE>" /grant *S-1-15-2-1:(OI)(CI)RX /T
     ```
 
     > [!NOTE]


### PR DESCRIPTION
Fixing quotation marks to copy/paste friendly so can be pasted in command line