### PR TITLE
Update sys-allocation-units-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-catalog-views/sys-allocation-units-transact-sql.md
+++ b/docs/relational-databases/system-catalog-views/sys-allocation-units-transact-sql.md
@@ -32,7 +32,7 @@ monikerRange: "=azuresqldb-current||>=sql-server-2016||>=sql-server-linux-2017||
 |allocation_unit_id|**bigint**|ID of the allocation unit. Is unique within a database.|  
 |type|**tinyint**|Type of allocation unit:<br /><br /> 0 = Dropped<br /><br /> 1 = In-row data (all data types, except LOB data types)<br /><br /> 2 = Large object (LOB) data (**text**, **ntext**, **image**, **xml**, large value types, and CLR user-defined types)<br /><br /> 3 = Row-overflow data|  
 |type_desc|**nvarchar(60)**|Description of the allocation unit type:<br /><br /> **DROPPED**<br /><br /> **IN_ROW_DATA**<br /><br /> **LOB_DATA**<br /><br /> **ROW_OVERFLOW_DATA**|  
-|container_id|**bigint**|ID of the storage container associated with the allocation unit.<br /><br /> If type = 1 or 3, container_id = sys.partitions.hobt_id.<br /><br /> If type is 2, then container_id = sys.partitions.partition_id.<br /><br /> 0 = Allocation unit marked for deferred drop|  
+|container_id|**bigint**|ID of the storage container associated with the allocation unit.<br /><br /> If type = 1 or 3 in a rowstore index container_id = sys.partitions.hobt_id.<br /><br /> If type = 1 or 3 in a columnstore index, container_id = sys.column_store_row_groups.delta_store_hobt_id.<br /><br /> If type is 2, then container_id = sys.partitions.partition_id.<br /><br /> 0 = Allocation unit marked for deferred drop|  
 |data_space_id|**int**|ID of the filegroup in which this allocation unit resides.|  
 |total_pages|**bigint**|Total number of pages allocated or reserved by this allocation unit.|  
 |used_pages|**bigint**|Number of total pages actually in use.|  


### PR DESCRIPTION
In columnstore indexes container_id can point to a delta store, not a index partition.