### PR TITLE
Update alter-database-transact-sql-set-options.md

### DIFF
--- a/docs/t-sql/statements/alter-database-transact-sql-set-options.md
+++ b/docs/t-sql/statements/alter-database-transact-sql-set-options.md
@@ -178,7 +178,7 @@ SET
     { READ_ONLY | READ_WRITE }
 
 <db_user_access_option> ::=
-    { SINGLE_USER | RESTRICTED_USER | MULTI_USER }
+    { SINGLE_USER | RESTRICTED_USER | MULTI_USER } ---SINGLE_USER and RESTRICTED_USER not supported in SQL MI
 
 <delayed_durability_option> ::=
     DELAYED_DURABILITY = { DISABLED | ALLOWED | FORCED }
@@ -1578,7 +1578,7 @@ SET
   { READ_ONLY | READ_WRITE }
 
 <db_user_access_option> ::=
-  { RESTRICTED_USER | MULTI_USER }
+  { RESTRICTED_USER | MULTI_USER } --cannot set restricted_user for SQL MI nor Read_only
 
 <delayed_durability_option> ::= DELAYED_DURABILITY = { DISABLED | ALLOWED | FORCED }
 
@@ -2232,7 +2232,7 @@ Not all database options use the WITH \<termination> clause or can be specified 
 ## Examples
 
 ### A. Setting the database to READ_ONLY
-Changing the state of a database or file group to READ_ONLY or READ_WRITE requires exclusive access to the database. The following example sets the database to `RESTRICTED_USER` mode to limit access. The example then sets the state of the [!INCLUDE[ssSampleDBobject](../../includes/sssampledbobject-md.md)] database to `READ_ONLY` and returns access to the database to all users.
+Changing the state of a database or file group to READ_ONLY or READ_WRITE requires exclusive access to the database. The following example sets the database to `RESTRICTED_USER` mode to limit access. The example then sets the state of the [!INCLUDE[ssSampleDBobject](../../includes/sssampledbobject-md.md)] database to `READ_ONLY` and returns access to the database to all users. --We cannot set the database in READ_ONLY or RESTRICTED_USER mode in SQL MI
 
 ```sql
 USE master;


### PR DESCRIPTION
Note there are many options that are not supported in SQL MI per this link:  https://docs.microsoft.com/en-us/azure/azure-sql/managed-instance/transact-sql-tsql-differences-sql-server#alter-database-statement  including RESTRICTED_USER and READ_ONLY.  There are several others so this document should be updated to accurately reflect those options we do not support.  Please consider reviewing the full list of what is not supported and including that here to reduce confusion for our customers.