### PR TITLE
Add example error to docs about sp_refreshsqlmodule

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-refreshsqlmodule-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-refreshsqlmodule-transact-sql.md
@@ -31,7 +31,7 @@ monikerRange: "=azuresqldb-current||>=sql-server-2016||>=sql-server-linux-2017||
 # sp_refreshsqlmodule (Transact-SQL)
 [!INCLUDE [sql-asdb-asdbmi-asa-pdw](../../includes/applies-to-version/sql-asdb-asdbmi-asa.md)]
 
-  Updates the metadata for the specified non-schema-bound stored procedure, user-defined function, view, DML trigger, database-level DDL trigger, or server-level DDL trigger in the current database. Persistent metadata for these objects, such as data types of parameters, can become outdated because of changes to their underlying objects.
+  Updates the metadata for the specified non-schema-bound stored procedure, user-defined function, view, DML trigger, database-level DDL trigger, or server-level DDL trigger in the current database. Persistent metadata for these objects, such as data types of parameters, can become outdated because of changes to their underlying objects.  An example symptom of this issue is an error such as `The definition for user-defined data type 'typename' has changed`.  Refreshing the metadata for the module that uses the type specified in the error may resolve it.
   
  ![Topic link icon](../../database-engine/configure-windows/media/topic-link.gif "Topic link icon") [Transact-SQL Syntax Conventions](../../t-sql/language-elements/transact-sql-syntax-conventions-transact-sql.md)  
   

--- a/docs/relational-databases/system-stored-procedures/sp-refreshsqlmodule-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-refreshsqlmodule-transact-sql.md
@@ -31,7 +31,7 @@ monikerRange: "=azuresqldb-current||>=sql-server-2016||>=sql-server-linux-2017||
 # sp_refreshsqlmodule (Transact-SQL)
 [!INCLUDE [sql-asdb-asdbmi-asa-pdw](../../includes/applies-to-version/sql-asdb-asdbmi-asa.md)]
 
-  Updates the metadata for the specified non-schema-bound stored procedure, user-defined function, view, DML trigger, database-level DDL trigger, or server-level DDL trigger in the current database. Persistent metadata for these objects, such as data types of parameters, can become outdated because of changes to their underlying objects.  An example symptom of this issue is an error such as `The definition for user-defined data type 'typename' has changed`.  Refreshing the metadata for the module that uses the type specified in the error may resolve it.
+  Updates the metadata for the specified non-schema-bound stored procedure, user-defined function, view, DML trigger, database-level DDL trigger, or server-level DDL trigger in the current database. Persistent metadata for these objects, such as data types of parameters, can become outdated because of changes to their underlying objects.  An example symptom of this issue is an error such as `The definition for user-defined data type 'typename' has changed`.  Refreshing the metadata for the module that uses the type specified in the error may resolve the problem.
   
  ![Topic link icon](../../database-engine/configure-windows/media/topic-link.gif "Topic link icon") [Transact-SQL Syntax Conventions](../../t-sql/language-elements/transact-sql-syntax-conventions-transact-sql.md)  
   

--- a/docs/relational-databases/system-stored-procedures/sp-refreshsqlmodule-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-refreshsqlmodule-transact-sql.md
@@ -32,7 +32,7 @@ monikerRange: "=azuresqldb-current||>=sql-server-2016||>=sql-server-linux-2017||
 
 [!INCLUDE [sql-asdb-asdbmi-asa-pdw](../../includes/applies-to-version/sql-asdb-asdbmi-asa.md)]
 
-Updates the metadata for the specified non-schema-bound stored procedure, user-defined function, view, DML trigger, database-level DDL trigger, or server-level DDL trigger in the current database. Persistent metadata for these objects, such as data types of parameters, can become outdated because of changes to their underlying objects.  For example, you may see an error such as `The definition for user-defined data type 'typename' has changed`.  Refreshing the metadata for the module that uses the type specified in the error may resolve the problem.
+Updates the metadata for the specified non-schema-bound stored procedure, user-defined function, view, DML trigger, database-level DDL trigger, or server-level DDL trigger in the current database. Persistent metadata for these objects, such as data types of parameters, can become outdated because of changes to their underlying objects. For example, you might see an error like `The definition for user-defined data type 'typename' has changed`. Refreshing the metadata for the module that uses the type specified in the error might resolve the problem.
   
 ![Topic link icon](../../database-engine/configure-windows/media/topic-link.gif "Topic link icon") [Transact-SQL Syntax Conventions](../../t-sql/language-elements/transact-sql-syntax-conventions-transact-sql.md)  
   

--- a/docs/relational-databases/system-stored-procedures/sp-refreshsqlmodule-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-refreshsqlmodule-transact-sql.md
@@ -1,8 +1,6 @@
 ---
+title: sp_refreshsqlmodule (Transact-SQL)
 description: "sp_refreshsqlmodule (Transact-SQL)"
-title: "sp_refreshsqlmodule (Transact-SQL) | Microsoft Docs"
-ms.custom: ""
-ms.date: "07/25/2018"
 ms.prod: sql
 ms.prod_service: "database-engine, sql-database"
 ms.reviewer: ""
@@ -23,17 +21,20 @@ helpviewer_keywords:
   - "metadata [SQL Server], functions"
   - "stored procedures [SQL Server], refreshing metadata"
   - "user-defined functions [SQL Server], refreshing metadata"
-ms.assetid: f0022a05-50dd-4620-961d-361b1681d375
 author: markingmyname
 ms.author: maghan
+ms.custom: ""
+ms.date: "07/25/2018"
 monikerRange: "=azuresqldb-current||>=sql-server-2016||>=sql-server-linux-2017||=azuresqldb-mi-current"
 ---
+
 # sp_refreshsqlmodule (Transact-SQL)
+
 [!INCLUDE [sql-asdb-asdbmi-asa-pdw](../../includes/applies-to-version/sql-asdb-asdbmi-asa.md)]
 
-  Updates the metadata for the specified non-schema-bound stored procedure, user-defined function, view, DML trigger, database-level DDL trigger, or server-level DDL trigger in the current database. Persistent metadata for these objects, such as data types of parameters, can become outdated because of changes to their underlying objects.  An example symptom of this issue is an error such as `The definition for user-defined data type 'typename' has changed`.  Refreshing the metadata for the module that uses the type specified in the error may resolve the problem.
+Updates the metadata for the specified non-schema-bound stored procedure, user-defined function, view, DML trigger, database-level DDL trigger, or server-level DDL trigger in the current database. Persistent metadata for these objects, such as data types of parameters, can become outdated because of changes to their underlying objects.  For example, you may see an error such as `The definition for user-defined data type 'typename' has changed`.  Refreshing the metadata for the module that uses the type specified in the error may resolve the problem.
   
- ![Topic link icon](../../database-engine/configure-windows/media/topic-link.gif "Topic link icon") [Transact-SQL Syntax Conventions](../../t-sql/language-elements/transact-sql-syntax-conventions-transact-sql.md)  
+![Topic link icon](../../database-engine/configure-windows/media/topic-link.gif "Topic link icon") [Transact-SQL Syntax Conventions](../../t-sql/language-elements/transact-sql-syntax-conventions-transact-sql.md)  
   
 ## Syntax  
   


### PR DESCRIPTION
This morning we had an issue with a scalar function that was causing SqlExceptions to come back from ADO.NET when queried.  Running `EXEC sys.sp_refreshsqlmodule 'dbo.MyFunctionName';` fixed the problem.  The exact error that prompted us to need to run this command would be useful to be in the article.  I'm not sure it belongs right in the header, but I do think it should be in here somewhere.

Example stack trace (we were using Dapper with ADO.NET/.NET Core 3.1 if it's relevant but I don't think it is):
```
System.Data.SqlClient.SqlException: The definition for user-defined data type 'decimal' has changed.
   at System.Data.SqlClient.SqlConnection.OnError(SqlException exception, bool breakConnection, Action<T> wrapCloseInAction)
   at System.Data.SqlClient.SqlInternalConnection.OnError(SqlException exception, bool breakConnection, Action<T> wrapCloseInAction)
   at System.Data.SqlClient.TdsParser.ThrowExceptionAndWarning(TdsParserStateObject stateObj, bool callerHasConnectionLock, bool asyncClose)
   at System.Data.SqlClient.TdsParser.TryRun(RunBehavior runBehavior, SqlCommand cmdHandler, SqlDataReader dataStream, BulkCopySimpleResultSet bulkCopyHandler, TdsParserStateObject stateObj, out bool dataReady)
   at System.Data.SqlClient.SqlDataReader.TryHasMoreRows(out bool moreRows)
   at System.Data.SqlClient.SqlDataReader.TryReadInternal(bool setTimeout, out bool more)
   at System.Data.SqlClient.SqlDataReader+<>c__DisplayClass190_0.<ReadAsync>b__1(Task t)
   at System.Data.SqlClient.SqlDataReader.InvokeRetryable<T>(Func<T, TResult> moreFunc, TaskCompletionSource<TResult> source, IDisposable objectToDispose)
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable<TResult>+ConfiguredTaskAwaiter.GetResult()
   at Dapper.SqlMapper+<ExecuteScalarImplAsync>d__69<T>.MoveNext() in /_/Dapper/SqlMapper.Async.cs:line 1247
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter<TResult>.GetResult()
   at DotNetHelpers.Db.DatabaseReader+<>c__DisplayClass4_0<T>+<<GetScalar>b__0>d.MoveNext()
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter<TResult>.GetResult()
```