### PR TITLE
Update sys-geo-replication-links-azure-sql-database.md

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-geo-replication-links-azure-sql-database.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-geo-replication-links-azure-sql-database.md
@@ -39,7 +39,8 @@ monikerRange: "= azuresqldb-current"
 |role_desc|**nvarchar(256)**|PRIMARY<br /><br /> SECONDARY|  
 |secondary_allow_connections|**tinyint**|The secondary type, one of:<br /><br /> 0 = No. The secondary database is not accessible until failover.<br /><br /> 1 = ReadOnly. The secondary database is accessible only to client connections with ApplicationIntent=ReadOnly.<br /><br /> 2 = All. The secondary database is accessible to any client connection.|  
 |secondary_allow_connections _desc|**nvarchar(256)**|No<br /><br /> All<br /><br /> Read-Only|  
-  
+|percent_copied|**int**|0 to 100|
+
 ## Permissions
 
 This view is only available in the **master** database to the server-level principal login.  

--- a/docs/relational-databases/system-dynamic-management-views/sys-geo-replication-links-azure-sql-database.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-geo-replication-links-azure-sql-database.md
@@ -39,7 +39,7 @@ monikerRange: "= azuresqldb-current"
 |role_desc|**nvarchar(256)**|PRIMARY<br /><br /> SECONDARY|  
 |secondary_allow_connections|**tinyint**|The secondary type, one of:<br /><br /> 0 = No. The secondary database is not accessible until failover.<br /><br /> 1 = ReadOnly. The secondary database is accessible only to client connections with ApplicationIntent=ReadOnly.<br /><br /> 2 = All. The secondary database is accessible to any client connection.|  
 |secondary_allow_connections _desc|**nvarchar(256)**|No<br /><br /> All<br /><br /> Read-Only|  
-|percent_copied|**int**|0 to 100|
+|percent_copied|**int**|Seeding progress in percent|
 
 ## Permissions
 


### PR DESCRIPTION
'percent_copied' column is missing in the documentation. I tested it and it gives the seeding percentage. In my test, I only saw zero and a hundred. Noting in between. I informed @dimitri-furman  about this. His comment below:
Thanks for catching the missing column in the documentation. If you’d like to create a doc PR, please feel free, or we can fix it here (you can see view metadata by running exec sp_help 'sys.geo_replication_links'; in master).