### PR TITLE
Added Domain Values For IO_PENDING Column

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-io-pending-io-requests-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-io-pending-io-requests-transact-sql.md
@@ -35,7 +35,7 @@ monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-s
 |**io_completion_request_address**|**varbinary(8)**|Memory address of the IO request. Is not nullable.|  
 |**io_type**|**nvarchar(60)**|Type of pending I/O request. Is not nullable.|  
 |**io_pending_ms_ticks**|**bigint**|Internal use only. Is not nullable.| 
-|**io_pending**|**int**|Indicates whether the I/O request is pending or has been completed by Windows. An I/O request can still be pending even when Windows has completed the request, but [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] has not yet performed a context switch in which it would process the I/O request and remove it from this list. Is not nullable.|  
+|**io_pending**|**int**|Indicates whether the I/O request is pending (1) or has been completed by Windows (0). An I/O request can still be pending even when Windows has completed the request, but [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] has not yet performed a context switch in which it would process the I/O request and remove it from this list. Is not nullable. <br /> **Value** <br /> 0 = Pending SQL Server <br /> 1 = Pending Windows <br />|  
 |**io_completion_routine_address**|**varbinary(8)**|Internal function to call when the I/O request is completed. Is nullable.|  
 |**io_user_data_address**|**varbinary(8)**|Internal use only. Is nullable.|  
 |**scheduler_address**|**varbinary(8)**|Scheduler on which this I/O request was issued. The I/O request will appear on the pending I/O list of the scheduler. For more information, see [sys.dm_os_schedulers &#40;Transact-SQL&#41;](../../relational-databases/system-dynamic-management-views/sys-dm-os-schedulers-transact-sql.md). Is not nullable.|  

--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-io-pending-io-requests-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-io-pending-io-requests-transact-sql.md
@@ -35,7 +35,8 @@ monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-s
 |**io_completion_request_address**|**varbinary(8)**|Memory address of the IO request. Is not nullable.|  
 |**io_type**|**nvarchar(60)**|Type of pending I/O request. Is not nullable.|  
 |**io_pending_ms_ticks**|**bigint**|Internal use only. Is not nullable.| 
-|**io_pending**|**int**|Indicates whether the I/O request is pending (1) or has been completed by Windows (0). An I/O request can still be pending even when Windows has completed the request, but [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] has not yet performed a context switch in which it would process the I/O request and remove it from this list. Is not nullable. <br /> **Value** <br /> 0 = Pending SQL Server <br /> 1 = Pending Windows <br />|  
+|**io_pending**|**int**|Indicates whether the I/O request is pending (1) or has been completed by the operating system (0). An I/O request can still be pending even when OS has completed the request, but [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] has not yet performed a context switch in which it would process the I/O request and remove it from this list. Is not nullable. <br /> **Value** <br /> 0 = Pending SQL Server <br /> 1 = Pending OS <br />|  
+
 |**io_completion_routine_address**|**varbinary(8)**|Internal function to call when the I/O request is completed. Is nullable.|  
 |**io_user_data_address**|**varbinary(8)**|Internal use only. Is nullable.|  
 |**scheduler_address**|**varbinary(8)**|Scheduler on which this I/O request was issued. The I/O request will appear on the pending I/O list of the scheduler. For more information, see [sys.dm_os_schedulers &#40;Transact-SQL&#41;](../../relational-databases/system-dynamic-management-views/sys-dm-os-schedulers-transact-sql.md). Is not nullable.|  


### PR DESCRIPTION
Added the domain values for the IO_PENDING column since it did not exist. This helps the reader understand if the IO is waiting on a completion in Windows or for SQL Server to process the IO completion from Windows.