### PR TITLE
Update sys-dm-os-spinlock-stats-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-os-spinlock-stats-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-os-spinlock-stats-transact-sql.md
@@ -38,7 +38,7 @@ Returns information about all spinlock waits organized by type.
 |spins|**bigint**|The number of times a thread executes a loop while attempting to acquire the spinlock.|  
 |spins_per_collision|**real**|Ratio of spins per collision.|  
 |sleep_time|**bigint**|The amount of time in milliseconds that threads spent sleeping in the event of a backoff.|  
-|backoffs|**int**|The number of times a thread that is "spinning" fails to acquire the spinlock and yields the scheduler.|  
+|backoffs|**bigint**|The number of times a thread that is "spinning" fails to acquire the spinlock and yields the scheduler.|  
 
 
 ## Permissions  


### PR DESCRIPTION
I ran into an issue, where data in the backoffs column was larger than the int data type.

name	collisions	spins	spins_per_collision	sleep_time	backoffs
LOCK_HASH	56569370607	6157696645368	108.8521	384823	7056017787

This was in SQL Server 2019.