### PR TITLE
Update sp-databases-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-databases-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-databases-transact-sql.md
@@ -45,7 +45,9 @@ sp_databases
 |**REMARKS**|**varchar(254)**|For the [!INCLUDE[ssDE](../../includes/ssde-md.md)], this field always returns NULL.|  
   
 ## Remarks  
- Database names that are returned can be used as parameters in the USE statement to change the current database context.  
+ Database names that are returned can be used as parameters in the USE statement to change the current database context.
+ 
+ DATABASE_SIZE will return NULL for databases larger than 2.15TB.
   
  **sp_databases** has no equivalent in Open Database Connectivity (ODBC).  
   

--- a/docs/relational-databases/system-stored-procedures/sp-databases-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-databases-transact-sql.md
@@ -47,7 +47,7 @@ sp_databases
 ## Remarks  
  Database names that are returned can be used as parameters in the USE statement to change the current database context.
  
- DATABASE_SIZE will return NULL for databases larger than 2.15TB.
+ DATABASE_SIZE returns a NULL value for databases larger than 2.15TB.
   
  **sp_databases** has no equivalent in Open Database Connectivity (ODBC).  
   

--- a/docs/relational-databases/system-stored-procedures/sp-databases-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-databases-transact-sql.md
@@ -47,7 +47,7 @@ sp_databases
 ## Remarks  
  Database names that are returned can be used as parameters in the USE statement to change the current database context.
  
- DATABASE_SIZE returns a NULL value for databases larger than 2.15TB.
+ DATABASE_SIZE returns a NULL value for databases larger than 2.15 TB.
   
  **sp_databases** has no equivalent in Open Database Connectivity (ODBC).  
   


### PR DESCRIPTION
Added remark that DATABASE_SIZE will return NULL for databases larger than 2.15TB.