### PR TITLE
Added warning about requirements

### DIFF
--- a/docs/relational-databases/backup-restore/restore-the-master-database-transact-sql.md
+++ b/docs/relational-databases/backup-restore/restore-the-master-database-transact-sql.md
@@ -20,7 +20,7 @@ ms.author: chadam
   This topic explains how to restore the **master** database from a full database backup.
 
 > [!WARNING]
-> In the event of disaster recovery, the instance where the master database is being restored to should be as close to an exact match to the original as possible.  At minimum, this recovery instance should be the same version, edition, and patch level, as well as have the same selection of features, and the same external configuration (hostname, cluster membership, etc) as the original instance. Doing otherwise may result in undefined SQL Server instance behavior with inconsistent feature support, and is not guaranteed to be viable. 
+> In the event of disaster recovery, the instance where the master database is being restored to should be as close to an exact match to the original as possible. At a minimum, this recovery instance should be the same version, edition, and patch level, and it should have the same selection of features and the same external configuration (hostname, cluster membership, and so on) as the original instance. Doing otherwise might result in undefined SQL Server instance behavior, with inconsistent feature support, and is not guaranteed to be viable. 
   
 ### To restore the master database  
   

--- a/docs/relational-databases/backup-restore/restore-the-master-database-transact-sql.md
+++ b/docs/relational-databases/backup-restore/restore-the-master-database-transact-sql.md
@@ -17,7 +17,10 @@ ms.author: chadam
 # Restore the master Database (Transact-SQL)
  [!INCLUDE [SQL Server](../../includes/applies-to-version/sqlserver.md)]
 
-  This topic explains how to restore the **master** database from a full database backup.  
+  This topic explains how to restore the **master** database from a full database backup.
+
+> [!WARNING]
+> In the event of disaster recovery, the instance to which the Master database is being restored should be as close to an exact match to the original as possible.  At minimum, the instance Master is being restored to should be the same version, edition, and patch levels of SQL Server, the same selection of features installed, and the same external configuration (hostname, cluster membership, etc). Doing otherwise may result in an undefined SQL Server Instance behavior with inconsistent feature support, and is not guaranteed to be viable. 
   
 ### To restore the master database  
   

--- a/docs/relational-databases/backup-restore/restore-the-master-database-transact-sql.md
+++ b/docs/relational-databases/backup-restore/restore-the-master-database-transact-sql.md
@@ -20,7 +20,7 @@ ms.author: chadam
   This topic explains how to restore the **master** database from a full database backup.
 
 > [!WARNING]
-> In the event of disaster recovery, the instance to which the Master database is being restored should be as close to an exact match to the original as possible.  At minimum, the instance Master is being restored to should be the same version, edition, and patch levels of SQL Server, the same selection of features installed, and the same external configuration (hostname, cluster membership, etc). Doing otherwise may result in an undefined SQL Server Instance behavior with inconsistent feature support, and is not guaranteed to be viable. 
+> In the event of disaster recovery, the instance where the master database is being restored to should be as close to an exact match to the original as possible.  At minimum, this recovery instance should be the same version, edition, and patch level, as well as have the same selection of features, and the same external configuration (hostname, cluster membership, etc) as the original instance. Doing otherwise may result in undefined SQL Server instance behavior with inconsistent feature support, and is not guaranteed to be viable. 
   
 ### To restore the master database  
   


### PR DESCRIPTION
Added a warning about some basic requirements or items to watch out for when restoring master, either to another different server or as part of a disaster recovery exercise. The warning is about supportability when the master database is restored to an instance that may or may not have all the same features and functionality of the original.