### PR TITLE
Don't recommend DATALENGTH as replacement for LEN

### DIFF
--- a/docs/t-sql/functions/len-transact-sql.md
+++ b/docs/t-sql/functions/len-transact-sql.md
@@ -50,16 +50,11 @@ LEN ( string_expression )
  If you are using SC collations, the returned integer value counts UTF-16 surrogate pairs as a single character. For more information, see [Collation and Unicode Support](../../relational-databases/collations/collation-and-unicode-support.md).  
   
 ## Remarks  
-LEN excludes trailing spaces. If that is a problem, consider using the [DATALENGTH &#40;Transact-SQL&#41;](../../t-sql/functions/datalength-transact-sql.md) function which does not trim the string. If processing a unicode string, DATALENGTH will return a number that may not be equal to the number of characters. The following example demonstrates LEN and DATALENGTH with a trailing space.  
+LEN excludes trailing spaces. If that is a problem, consider ensuring the string does not end with a space. The following example demonstrates LEN with a trailing space.  
   
-```sql  
-  DECLARE @v1 VARCHAR(40),  
-    @v2 NVARCHAR(40);  
-SELECT   
-@v1 = 'Test of 22 characters ',   
-@v2 = 'Test of 22 characters ';  
-SELECT LEN(@v1) AS [VARCHAR LEN] , DATALENGTH(@v1) AS [VARCHAR DATALENGTH];  
-SELECT LEN(@v2) AS [NVARCHAR LEN], DATALENGTH(@v2) AS [NVARCHAR DATALENGTH];  
+```sql
+DECLARE @v1 VARCHAR(40) = 'Test of 22 characters ';
+SELECT LEN(@v1) AS [LEN Without Trailing Space], LEN(@v2 + '_') - 1 AS [LEN With Trailing Space];
 ```  
 
 > [!NOTE]


### PR DESCRIPTION
`LEN` counts the number of characters, while `DATALENGTH` counts the number of bytes. At the least, this requires logic bound to the type of the string (e.g. `varchar` vs. `nvarchar`), but also doesn't account for surrogate pairs that are counted as one character but multiple "characters" worth of bytes. `DATALENGTH` cannot be used to get the correct number of characters in a string containing surrogate pairs.