### PR TITLE
Update databasepropertyex-transact-sql.md

### DIFF
--- a/docs/t-sql/functions/databasepropertyex-transact-sql.md
+++ b/docs/t-sql/functions/databasepropertyex-transact-sql.md
@@ -144,7 +144,14 @@ Collation                     Edition        ServiceObjective  MaxSizeInBytes
 ----------------------------  -------------  ----------------  --------------  
 SQL_Latin1_General_CP1_CI_AS  DataWarehouse  DW1000            5368709120  
 ```  
+
+### C. Use DATABASEPROPERTYEX to know when a query is running on an Azure SQL Database replica  
+When using Azure SQL Database read scale out feature, you can verify whether you are connected to a read-only replica or not by running the following query in the context of your database. It will return READ_ONLY when you are connected to a read-only replica. This way you can also identify when a query is running on a read-only replica.
   
+```sql
+SELECT DATABASEPROPERTYEX(DB_NAME(), 'Updateability'); 
+```  
+
 ## See also
 [ALTER DATABASE &#40;Transact-SQL&#41;](../../t-sql/statements/alter-database-transact-sql.md)  
 [Database States](../../relational-databases/databases/database-states.md)  

--- a/docs/t-sql/functions/databasepropertyex-transact-sql.md
+++ b/docs/t-sql/functions/databasepropertyex-transact-sql.md
@@ -146,7 +146,7 @@ SQL_Latin1_General_CP1_CI_AS  DataWarehouse  DW1000            5368709120
 ```  
 
 ### C. Use DATABASEPROPERTYEX to know when a query is running on an Azure SQL Database replica  
-When using Azure SQL Database read scale out feature, you can verify whether you are connected to a read-only replica or not by running the following query in the context of your database. It will return READ_ONLY when you are connected to a read-only replica. This way you can also identify when a query is running on a read-only replica.
+When using Azure SQL Database read the scale-out feature, you can verify whether you are connected to a read-only replica or not by running the following query in the context of your database. It will return READ_ONLY when you're connected to a read-only replica. This way, you can also identify when a query is running on a read-only replica.
   
 ```sql
 SELECT DATABASEPROPERTYEX(DB_NAME(), 'Updateability'); 

--- a/docs/t-sql/functions/databasepropertyex-transact-sql.md
+++ b/docs/t-sql/functions/databasepropertyex-transact-sql.md
@@ -145,7 +145,7 @@ Collation                     Edition        ServiceObjective  MaxSizeInBytes
 SQL_Latin1_General_CP1_CI_AS  DataWarehouse  DW1000            5368709120  
 ```  
 
-### C. Use DATABASEPROPERTYEX to know when a query is running on an Azure SQL Database replica  
+### C. Use DATABASEPROPERTYEX to verify connection to replica  
 When using Azure SQL Database read the scale-out feature, you can verify whether you are connected to a read-only replica or not by running the following query in the context of your database. It will return READ_ONLY when you're connected to a read-only replica. This way, you can also identify when a query is running on a read-only replica.
   
 ```sql


### PR DESCRIPTION
I would like to show how useful is DATABASEPROPERTYEX to identify when a query is running on a read-only replica when using the read scale out feature on Azure SQL Database. At this time I only see on this page useful examples of this function for SQL Server on-premises only.