### PR TITLE
sys.external_languages to sys.external_language_files

### DIFF
--- a/docs/relational-databases/system-catalog-views/sys-external-language-files-transact-sql.md
+++ b/docs/relational-databases/system-catalog-views/sys-external-language-files-transact-sql.md
@@ -29,7 +29,7 @@ This catalog view provides a list of the external language extension files in th
 
 When an external language is created from a file_spec, the extension itself and its properties are listed in this view. This view will contain one entry per language, per OS.
 
-## sys.external_languages
+## sys.external_language_files
 
 The catalog view sys.external_language_files lists a row for each external language extension in the database. Parameters
 


### PR DESCRIPTION
that seems a typo.