### PR TITLE
Removing a confusing sentence which doesn't help the customer

### DIFF
--- a/docs/t-sql/statements/create-external-language-transact-sql.md
+++ b/docs/t-sql/statements/create-external-language-transact-sql.md
@@ -100,7 +100,7 @@ This provides a possibility to give a set of environment variables to the extern
 
 **platform**
 
-This parameter is needed for hybrid OS scenarios. In a hybrid architecture, the language needs to be registered once per platform. Platform and language name will be the unique key per external language. If no platform is specified, the current OS is assumed.
+This parameter is needed for hybrid OS scenarios. In a hybrid architecture, the language needs to be registered once per platform. If no platform is specified, the current OS is assumed.
 
 ## Permissions
 


### PR DESCRIPTION
Each specific external language can have one or more external language file spec. For one external language, there cannot be multiple external language files from the same platform (e.g. we cannot have TWO ext lang files BOTH for WINDOWS for a specific ext lang). This was already mentioned under file_spec in this doc.

Removing the confusing sentence: Platform and language name will be the unique key per external language.