### PR TITLE
Update create-database-scoped-credential-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/create-database-scoped-credential-transact-sql.md
+++ b/docs/t-sql/statements/create-database-scoped-credential-transact-sql.md
@@ -114,7 +114,7 @@ The following example creates a database scoped credential that can be used to c
 CREATE MASTER KEY ENCRYPTION BY PASSWORD='<EnterStrongPasswordHere>';
 
 -- Create a database scoped credential.
-CREATE DATABASE SCOPED CREDENTIAL MyCredentials
+CREATE DATABASE SCOPED CREDENTIAL [https://MyStorageAccount.blob.core.windows.net/MyStorageContainerSqlEvents]
 WITH IDENTITY = 'SHARED ACCESS SIGNATURE',
 SECRET = 'QLYMgmSXMklt%2FI1U6DcVrQixnlU5Sgbtk1qDRakUBGs%3D';
 ```


### PR DESCRIPTION
Hi If you are using a database scoped credential (or possibly more than 1) the name of the credential needs to be the path to the blob storage
If you just use a random identifier it will not work - took me way to long to find out what was wrong - so updating the example as proposed in BoL would be very helpful

[https://MyStorageAccount.blob.core.windows.net/MyStorageContainerSqlEvents]