### PR TITLE
Update reference-azdata-bdc-hdfs.md

### DIFF
--- a/docs/azdata/reference/reference-azdata-bdc-hdfs.md
+++ b/docs/azdata/reference/reference-azdata-bdc-hdfs.md
@@ -336,7 +336,7 @@ azdata bdc hdfs cp --from-path -f
 ### Examples
 Copy file or directory between the local machine and HDFS.
 ```bash
-azdata bdc hdfs cp --from_path "tmp/test.txt" --to-path "hdfs:/user/me/test.txt"
+azdata bdc hdfs cp --from-path "tmp/test.txt" --to-path "hdfs:/user/me/test.txt"
 ```
 ### Required Parameters
 #### `--from-path -f`


### PR DESCRIPTION
copy command example syntax issue.

Before: azdata bdc hdfs cp --from_path "tmp/test.txt" --to-path "hdfs:/user/me/test.txt"
After: azdata bdc hdfs cp --from-path "tmp/test.txt" --to-path "hdfs:/user/me/test.txt"