### PR TITLE
Add syntax highlighting for VBA codes

### DIFF
--- a/docs/ado/guide/data/hellodata-code.md
+++ b/docs/ado/guide/data/hellodata-code.md
@@ -15,7 +15,7 @@ author: rothja
 ms.author: jroth
 ---
 # HelloData Code
-```  
+```  VBA
 'BeginHelloData  
 Option Explicit  
   

--- a/docs/ado/guide/data/hellodata-code.md
+++ b/docs/ado/guide/data/hellodata-code.md
@@ -15,7 +15,7 @@ author: rothja
 ms.author: jroth
 ---
 # HelloData Code
-```  VBA
+```vb
 'BeginHelloData  
 Option Explicit  
   


### PR DESCRIPTION
Currently, the markdown engine cannot auto-detect VBA codes needs to assign the language type manually.