### PR TITLE
Update alter-login-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/alter-login-transact-sql.md
+++ b/docs/t-sql/statements/alter-login-transact-sql.md
@@ -257,13 +257,6 @@ ALTER LOGIN [Mary5] WITH PASSWORD = '****' UNLOCK ;
 GO
 ```
 
-To unlock a login without changing the password, turn the check policy off and then on again.
-
-```sql
-ALTER LOGIN [Mary5] WITH CHECK_POLICY = OFF;
-ALTER LOGIN [Mary5] WITH CHECK_POLICY = ON;
-GO
-```
 
 ### G. Changing the password of a login using HASHED
 


### PR DESCRIPTION
Remove below part. Because CHECK_POLICY is not supported in synapse  "Msg 40517, Level 16, State 1, Line 6 Keyword or statement option 'check_policy' is not supported in this version of SQL Server."

To unlock a login without changing the password, turn the check policy off and then on again.

```sql
ALTER LOGIN [Mary5] WITH CHECK_POLICY = OFF;
ALTER LOGIN [Mary5] WITH CHECK_POLICY = ON;
GO
```