### PR TITLE
Update dma-consolidatereports.md

### DIFF
--- a/docs/dma/dma-consolidatereports.md
+++ b/docs/dma/dma-consolidatereports.md
@@ -42,7 +42,7 @@ Saving the PowerShell modules into the PowerShell modules directory enables you 
 
 To load the modules, perform the following steps:
 
-1. Navigate to C:\Program Files\WindowsPowerShell\Modules, and then create a folder named **DataMigrationAssistant**.
+1. Navigate to C:\Program Files\WindowsPowerShell\Modules, and then create a folder named **dmaProcessor**.
 2. Open the [PowerShell-Modules](https://techcommunity.microsoft.com/gxcuf89792/attachments/gxcuf89792/MicrosoftDataMigration/161/1/PowerShell-Modules2.zip), and then save them into the folder you created.
 
       ![PowerShell Modules](../dma/media//dma-consolidatereports/dma-powershell-modules.png)


### PR DESCRIPTION
JoLamber discovered in context of support case that DataMigrationAssistant as folder name won't work.  Worked with TrevorB to discover the "C:\Program Files\WindowsPowerShell\Modules\DataMigrationAssistant\dmaProcessor\dmaProcessor.psm1" path does not work with the Import-Module Cmdlet but the "C:\Program Files\WindowsPowerShell\Modules\dmaProcessor\dmaProcessor.psm1" path does