### PR TITLE
Changed strings in the example to Unicode

### DIFF
--- a/docs/relational-databases/triggers/logon-triggers.md
+++ b/docs/relational-databases/triggers/logon-triggers.md
@@ -25,20 +25,20 @@ ms.author: "jroth"
 ```  
 USE master;  
 GO  
-CREATE LOGIN login_test WITH PASSWORD = '3KHJ6dhx(0xVYsdf' MUST_CHANGE,  
+CREATE LOGIN login_test WITH PASSWORD = N'3KHJ6dhx(0xVYsdf' MUST_CHANGE,  
     CHECK_EXPIRATION = ON;  
 GO  
 GRANT VIEW SERVER STATE TO login_test;  
 GO  
 CREATE TRIGGER connection_limit_trigger  
-ON ALL SERVER WITH EXECUTE AS 'login_test'  
+ON ALL SERVER WITH EXECUTE AS N'login_test'  
 FOR LOGON  
 AS  
 BEGIN  
-IF ORIGINAL_LOGIN()= 'login_test' AND  
+IF ORIGINAL_LOGIN()= N'login_test' AND  
     (SELECT COUNT(*) FROM sys.dm_exec_sessions  
             WHERE is_user_process = 1 AND  
-                original_login_name = 'login_test') > 3  
+                original_login_name = N'login_test') > 3  
     ROLLBACK;  
 END;  
 ```  


### PR DESCRIPTION
The data types (i.e. sysname) being compared here are Unicode, yet the strings in the examples aren't. Just updated the example to use Unicode strings.