### PR TITLE
Fixed tiny error in path to cert

### DIFF
--- a/docs/t-sql/statements/create-certificate-transact-sql.md
+++ b/docs/t-sql/statements/create-certificate-transact-sql.md
@@ -228,7 +228,7 @@ GO
   
 ```sql  
 CREATE ASSEMBLY Shipping19   
-    FROM ' c:\Shipping\Certs\Shipping19.dll'   
+    FROM 'c:\Shipping\Certs\Shipping19.dll'   
     WITH PERMISSION_SET = SAFE;  
 GO  
 CREATE CERTIFICATE Shipping19 FROM ASSEMBLY Shipping19;  


### PR DESCRIPTION
I made this fix, but also, on line 217, there's a ref to Azure SQL DB not supporting a file for the cert, that's the case for Synapse, too, right? I didn't make an edit to this effect.