### PR TITLE
Revert "Update lesson-1-6-adding-and-configuring-the-lookup-transformations.md"

### DIFF
--- a/docs/integration-services/lesson-1-6-adding-and-configuring-the-lookup-transformations.md
+++ b/docs/integration-services/lesson-1-6-adding-and-configuring-the-lookup-transformations.md
@@ -53,8 +53,8 @@ In both cases, the Lookup transformation uses the OLE DB connection manager you 
     2.  Select **Use results of an SQL query**, and then enter or paste the following SQL statement:  
   
         ```sql
-        SELECT * FROM [Sales].[Currency]
-        WHERE [CurrencyCode]
+        SELECT * FROM [dbo].[DimCurrency]
+        WHERE [CurrencyAlternateKey]
         IN ('ARS', 'AUD', 'BRL', 'CAD', 'CNY',
             'DEM', 'EUR', 'FRF', 'GBP', 'JPY',
 	        'MXN', 'SAR', 'USD', 'VEB')


### PR DESCRIPTION
The [commit ](https://github.com/MicrosoftDocs/sql-docs/commit/190d1cd7bb8e04ef3f2e6370e45a1b49c2bc1e20) says that the tables do not exist in AdventureWorks database from 2014-2019, which is correct, but they do exist in AdventureWorksDW2012, which is the [prerequisite ](https://docs.microsoft.com/en-us/sql/integration-services/ssis-how-to-create-an-etl-package?view=sql-server-ver15#prerequisites) to this tutorial.
Therefor a revert is required here.