### PR TITLE
Add limitation for FCI

### DIFF
--- a/docs/database-engine/configure-windows/configure-windows-service-accounts-and-permissions.md
+++ b/docs/database-engine/configure-windows/configure-windows-service-accounts-and-permissions.md
@@ -67,7 +67,7 @@ Depending on the components that you decide to install, SQL Server setup install
 Startup accounts used to start and run SQL Server can be [domain user accounts](#Domain_User), [local user accounts](#Local_User), [managed service accounts](#MSA), [virtual accounts](#VA_Desc), or [built-in system accounts](#Local_Service). To start and run, each service in SQL Server must have a startup account configured during installation.
 
   > [!NOTE]
-  > For SQL Server Failover Cluster Instance (FCI), [domain user accounts](#Domain_User) or .[Group-Managed Service Accounts].(#GMSA) (SQL Server 2016 and later) can be used as Startup accounts for SQL Server.
+  > For SQL Server Failover Cluster Instance for SQL Server 2016 and later, [domain user accounts](#Domain_User) or [Group-Managed Service Accounts](#GMSA) can be used as startup accounts for SQL Server.
 
 This section describes the accounts that can be configured to start SQL Server services, the default values used by SQL Server Setup, the concept of per-service SID's, the startup options, and configuring the firewall.
 

--- a/docs/database-engine/configure-windows/configure-windows-service-accounts-and-permissions.md
+++ b/docs/database-engine/configure-windows/configure-windows-service-accounts-and-permissions.md
@@ -66,6 +66,9 @@ Depending on the components that you decide to install, SQL Server setup install
 
 Startup accounts used to start and run SQL Server can be [domain user accounts](#Domain_User), [local user accounts](#Local_User), [managed service accounts](#MSA), [virtual accounts](#VA_Desc), or [built-in system accounts](#Local_Service). To start and run, each service in SQL Server must have a startup account configured during installation.
 
+  > [!NOTE]
+  > For SQL Server Failover Cluster Instance (FCI), [domain user accounts](#Domain_User) or .[Group-Managed Service Accounts].(#GMSA) (SQL Server 2016 and later) can be used as Startup accounts for SQL Server.
+
 This section describes the accounts that can be configured to start SQL Server services, the default values used by SQL Server Setup, the concept of per-service SID's, the startup options, and configuring the firewall.
 
 - [Default Service Accounts](#Default_Accts)


### PR DESCRIPTION
For FCI, Startup accounts can only be domain account or gMSA.
I could see that limitation with setup GUI for FCI, but I could not find it in a Docs, so I added here as many customers see this document for choosing startup account.