### PR TITLE
Updated ms.prod_service

### DIFF
--- a/docs/connect/oledb/features/using-database-mirroring.md
+++ b/docs/connect/oledb/features/using-database-mirroring.md
@@ -19,7 +19,7 @@ author: David-Engel
 ms.author: v-daenge
 ---
 # Using Database Mirroring
-[!INCLUDE [SQL Server](../../../includes/applies-to-version/sql-asdb-asdbmi-asa-pdw.md)]
+[!INCLUDE [SQL Server](../../../includes/applies-to-version/sqlserver.md)]
 
 [!INCLUDE[Driver_OLEDB_Download](../../../includes/driver_oledb_download.md)]
 

--- a/docs/connect/oledb/features/using-database-mirroring.md
+++ b/docs/connect/oledb/features/using-database-mirroring.md
@@ -4,7 +4,7 @@ description: OLE DB Driver for SQL Server supports database mirroring. Developer
 ms.custom: ""
 ms.date: "06/12/2018"
 ms.prod: sql
-ms.prod_service: "database-engine, sql-database, synapse-analytics, pdw"
+ms.prod_service: "database-engine"
 ms.reviewer: ""
 ms.technology: connectivity
 ms.topic: "reference"


### PR DESCRIPTION
Removed sql-database, synapse-analytics, pdw from ms.prod_service as Azure SQL DB and SQL MI do not support Database Mirroring.