### PR TITLE
Added link to feature matrix for unsupported features

### DIFF
--- a/docs/connect/driver-feature-matrix.md
+++ b/docs/connect/driver-feature-matrix.md
@@ -1,6 +1,6 @@
 ---
 title: Driver feature support matrix
-description: Learn which popular features are supported in drivers for SQL Server and where to find information about them.
+description: Learn which SQL Server features are supported in the drivers .Net, ODBC, OLEDB, JDBC, Node.js, JavaScript and Python.
 ms.custom: ""
 ms.date: 05/06/2021
 ms.prod: sql

--- a/docs/connect/driver-feature-matrix.md
+++ b/docs/connect/driver-feature-matrix.md
@@ -1,6 +1,6 @@
 ---
 title: Driver feature support matrix
-description: Learn which SQL Server features are supported in the drivers .Net, ODBC, OLEDB, JDBC, Node.js, JavaScript and Python.
+description: Learn which SQL Server features are supported in the drivers for .NET, ODBC, OLE DB, JDBC, Node.js, JavaScript, and Python.
 ms.custom: ""
 ms.date: 05/06/2021
 ms.prod: sql

--- a/docs/connect/oledb/features/oledb-driver-for-sql-server-features.md
+++ b/docs/connect/oledb/features/oledb-driver-for-sql-server-features.md
@@ -20,6 +20,8 @@ ms.author: v-daenge
 
 [!INCLUDE[Driver_OLEDB_Download](../../../includes/driver_oledb_download.md)]
 
+For a complete list of features supported and unsupported by different OLEDB versions see the [Driver feature matrix](../../driver-feature-matrix.md#table2)
+
   In addition to exposing features of the Windows (formerly Microsoft) Data Access Components (WDAC), OLE DB Driver for SQL Server also implements many other features to expose [!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)] functionality.  
   
 ## In This Section    

--- a/docs/connect/oledb/features/oledb-driver-for-sql-server-features.md
+++ b/docs/connect/oledb/features/oledb-driver-for-sql-server-features.md
@@ -20,7 +20,7 @@ ms.author: v-daenge
 
 [!INCLUDE[Driver_OLEDB_Download](../../../includes/driver_oledb_download.md)]
 
-For a complete list of features supported and unsupported by different OLEDB versions see the [Driver feature matrix](../../driver-feature-matrix.md#table2)
+For a complete list of features that are supported and not supported in different OLE DB versions, see the [Driver feature matrix](../../driver-feature-matrix.md#table2).
 
   In addition to exposing features of the Windows (formerly Microsoft) Data Access Components (WDAC), OLE DB Driver for SQL Server also implements many other features to expose [!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)] functionality.  
   


### PR DESCRIPTION
Finding unsupported features is not obvious the matrix doesn't come up in search results