### PR TITLE
output-clause-transact-sql.md: example highligting

### DIFF
--- a/docs/t-sql/queries/output-clause-transact-sql.md
+++ b/docs/t-sql/queries/output-clause-transact-sql.md
@@ -263,17 +263,17 @@ DECLARE @MyTableVar TABLE
     employee VARCHAR(32)  
 );  
   
-PRINT 'table1, before delete'   
+PRINT 'table1, before delete';  
 SELECT * FROM dbo.table1;  
   
 DELETE FROM dbo.table1  
 OUTPUT DELETED.* INTO @MyTableVar  
 WHERE id = 4 OR id = 2;  
   
-PRINT 'table1, after delete'  
+PRINT 'table1, after delete';  
 SELECT * FROM dbo.table1;  
   
-PRINT '@MyTableVar, after delete'  
+PRINT '@MyTableVar, after delete';  
 SELECT * FROM @MyTableVar;  
   
 DROP TABLE dbo.table1;  


### PR DESCRIPTION
This code example has incorrect highlighting. I figure either the semicolons or the trailing space might fix this

![image](https://user-images.githubusercontent.com/2458645/124201006-d0f2d900-daa4-11eb-9fe0-e5c29a4ba200.png)
