### PR TITLE
Update rs-exe-utility-ssrs.md

### DIFF
--- a/docs/reporting-services/tools/rs-exe-utility-ssrs.md
+++ b/docs/reporting-services/tools/rs-exe-utility-ssrs.md
@@ -31,7 +31,7 @@ ms.author: maggies
 ```  
   
 rs {-?}  
-{-i input_file=}  
+{-i input_file}  
 {-s serverURL}  
 {-u username}  
 {-p password}  


### PR DESCRIPTION
Unlike the "-v globalvars=..." parameter, the "input_file" parameter does not use the syntax with "="