### PR TITLE
Update sql-server-linux-encrypted-connections.md

### DIFF
--- a/docs/linux/sql-server-linux-encrypted-connections.md
+++ b/docs/linux/sql-server-linux-encrypted-connections.md
@@ -148,3 +148,17 @@ systemctl restart mssql-server
 |The target principal name is incorrect.  |Make sure that Common Name field on SQL Server's certificate matches the server name specified in the client's connection string. |  
 |An existing connection was forcibly closed by the remote host. |This error can occur when the client doesn't support the TLS protocol version required by SQL Server. For example, if [!INCLUDE[ssNoVersion](../includes/ssnoversion-md.md)] is configured to require TLS 1.2, make sure your clients also support the TLS 1.2 protocol. |
 | | |   
+
+## Note for Ubuntu 20.04 and other recent Linux distribution releases
+
+**Symptom**
+
+When a [!INCLUDE[ssNoVersion](../includes/ssnoversion-md.md)] on Linux instance loads a certificate that was created with a signature algorithm using less than 112 bits of security (examples: MD5, SHA-1), you may observe connection failure errors such as the following:
+
+"A connection was successfully established with the server, but then an error occurred during the login process. (provider: SSL Provider, error: 0 - An existing connection was forcibly closed by the remote host.) (Microsoft SQL Server, Error: 10054)"
+
+This is due to OpenSSL security level 2 being enabled by default on Ubuntu 20.04 and newer. Security level 2 prohibits TLS connections with less than 112 bits of security from being established.
+
+**Solution**
+
+Install a certificate with a signature algorithm using at least 112 bits of security. Signature algorithms that satisfy this requirement include SHA-224, SHA-256, SHA-384, and SHA-512.

--- a/docs/linux/sql-server-linux-encrypted-connections.md
+++ b/docs/linux/sql-server-linux-encrypted-connections.md
@@ -149,15 +149,15 @@ systemctl restart mssql-server
 |An existing connection was forcibly closed by the remote host. |This error can occur when the client doesn't support the TLS protocol version required by SQL Server. For example, if [!INCLUDE[ssNoVersion](../includes/ssnoversion-md.md)] is configured to require TLS 1.2, make sure your clients also support the TLS 1.2 protocol. |
 | | |   
 
-## Note for Ubuntu 20.04 and other recent Linux distribution releases
+### Ubuntu 20.04 and other recent Linux distribution releases
 
 **Symptom**
 
-When a [!INCLUDE[ssNoVersion](../includes/ssnoversion-md.md)] on Linux instance loads a certificate that was created with a signature algorithm using less than 112 bits of security (examples: MD5, SHA-1), you may observe connection failure errors such as the following:
+When a [!INCLUDE[ssNoVersion](../includes/ssnoversion-md.md)] on Linux instance loads a certificate that was created with a signature algorithm using less than 112 bits of security (examples: MD5, SHA-1), you might observe a connection failure error, like this example:
 
-"A connection was successfully established with the server, but then an error occurred during the login process. (provider: SSL Provider, error: 0 - An existing connection was forcibly closed by the remote host.) (Microsoft SQL Server, Error: 10054)"
+`A connection was successfully established with the server, but then an error occurred during the login process. (provider: SSL Provider, error: 0 - An existing connection was forcibly closed by the remote host.) (Microsoft SQL Server, Error: 10054)`
 
-This is due to OpenSSL security level 2 being enabled by default on Ubuntu 20.04 and newer. Security level 2 prohibits TLS connections with less than 112 bits of security from being established.
+The error is due to OpenSSL security level 2 being enabled by default on Ubuntu 20.04 and later. Security level 2 prohibits TLS connections that have less than 112 bits of security from being established.
 
 **Solution**
 


### PR DESCRIPTION
Add documentation related to recent Linux distribution behavior with regards to OpenSSL certificates.

Users may encounter this issue out-of-the box if they are using their own custom certificates. This makes this issue searchable and documents the solution.

Mentioning @tejasaks / @amvin87 for review.