### PR TITLE
Update rename-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/rename-transact-sql.md
+++ b/docs/t-sql/statements/rename-transact-sql.md
@@ -17,7 +17,7 @@ monikerRange: ">= aps-pdw-2016 || = azure-sqldw-latest"
 Renames a user-created table in [!INCLUDE[ssSDW](../../includes/sssdw-md.md)]. Renames a user-created table, a column in a user-created table or database in [!INCLUDE[ssPDW](../../includes/sspdw-md.md)].
 
 > [!NOTE]
-> Renaming SQL Pools is not supported currently.
+> Renaming Dedicated SQL Pools is not supported currently in V2.
 > To rename a database in [!INCLUDE[ssSDW](../../includes/sssdw-md.md)], use [ALTER DATABASE ([!INCLUDE[ssSDW](../../includes/sssdwfull-md.md)])](alter-database-transact-sql.md?view=aps-pdw-2016-au7&preserve-view=true). To rename a database in Azure SQL Database, use the [ALTER DATABASE (Azure SQL Database)](alter-database-transact-sql.md?view=azuresqldb-mi-current&preserve-view=true) statement. To rename a database in [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)], use the stored procedure [sp_renamedb](../../relational-databases/system-stored-procedures/sp-renamedb-transact-sql.md).
 
 ## Syntax

--- a/docs/t-sql/statements/rename-transact-sql.md
+++ b/docs/t-sql/statements/rename-transact-sql.md
@@ -17,6 +17,7 @@ monikerRange: ">= aps-pdw-2016 || = azure-sqldw-latest"
 Renames a user-created table in [!INCLUDE[ssSDW](../../includes/sssdw-md.md)]. Renames a user-created table, a column in a user-created table or database in [!INCLUDE[ssPDW](../../includes/sspdw-md.md)].
 
 > [!NOTE]
+> Renaming SQL Pools is not supported currently.
 > To rename a database in [!INCLUDE[ssSDW](../../includes/sssdw-md.md)], use [ALTER DATABASE ([!INCLUDE[ssSDW](../../includes/sssdwfull-md.md)])](alter-database-transact-sql.md?view=aps-pdw-2016-au7&preserve-view=true). To rename a database in Azure SQL Database, use the [ALTER DATABASE (Azure SQL Database)](alter-database-transact-sql.md?view=azuresqldb-mi-current&preserve-view=true) statement. To rename a database in [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)], use the stored procedure [sp_renamedb](../../relational-databases/system-stored-procedures/sp-renamedb-transact-sql.md).
 
 ## Syntax


### PR DESCRIPTION
Adding a note to let users know that renaming of SQL Pools is not supported at the moment.