### PR TITLE
Clean up examples - SARGability & clause positions

### DIFF
--- a/docs/relational-databases/views/create-indexed-views.md
+++ b/docs/relational-databases/views/create-indexed-views.md
@@ -2,7 +2,7 @@
 description: "Create Indexed Views"
 title: "Create Indexed Views | Microsoft Docs"
 ms.custom: ""
-ms.date: "11/19/2018"
+ms.date: "07/23/2021"
 ms.prod: sql
 ms.prod_service: "database-engine, sql-database, synapse-analytics, pdw"
 ms.reviewer: ""

--- a/docs/relational-databases/views/create-indexed-views.md
+++ b/docs/relational-databases/views/create-indexed-views.md
@@ -192,8 +192,8 @@ SELECT SUM(UnitPrice*OrderQty*(1.00-UnitPriceDiscount)) AS Rev,
 FROM Sales.SalesOrderDetail AS od
 JOIN Sales.SalesOrderHeader AS o
    ON od.SalesOrderID=o.SalesOrderID
-      AND ProductID BETWEEN 700 and 800
-      AND OrderDate >= CONVERT(datetime,'05/01/2002',101)
+      AND o.OrderDate >= CONVERT(datetime,'05/01/2012',101)
+WHERE od.ProductID BETWEEN 700 and 800
    GROUP BY OrderDate, ProductID
    ORDER BY Rev DESC;
 GO
@@ -202,8 +202,8 @@ SELECT OrderDate, SUM(UnitPrice*OrderQty*(1.00-UnitPriceDiscount)) AS Rev
 FROM Sales.SalesOrderDetail AS od
 JOIN Sales.SalesOrderHeader AS o
    ON od.SalesOrderID=o.SalesOrderID
-      AND DATEPART(mm,OrderDate)= 3
-      AND DATEPART(yy,OrderDate) = 2002
+      AND o.OrderDate >= CONVERT(datetime,'03/01/2012',101)
+      AND o.OrderDate < CONVERT(datetime,'04/01/2012',101)
     GROUP BY OrderDate
     ORDER BY OrderDate ASC;
 ```


### PR DESCRIPTION
Update the example to use proper date boundaries, `>=` and `<` logic, in the final example. This changes the query to use a seek on the example index, rather than a scan of it; which would be much more performant as the query is SARGable. 

Also changed the date ranges in both example queries, as proposed in the related [issue](https://github.com/MicrosoftDocs/sql-docs/issues/6634) so that it's relevant for more recent versions of the Adventure Works database. Though I prefer, personally, to use unambiguous date formats (`yyyyMMdd`, I have used `CONVERT` in the second query with an explicit style to be consistent with the prior query.

Finally, I move the clause `ProductID BETWEEN 700 and 800` to the `WHERE`. `ProductID` is in the table `SalesOrderDetail` so it doesn't make much sense being in the `ON` clause for the `JOIN` to the table `SalesOrderHeader`. Technically the date boundaries in the `ON` clause in the second example could be moved to the `WHERE` (not if it were a `LEFT JOIN`) but it's not as unintuitive in its current position.