### PR TITLE
Fix incorrect version, etc in "Collation and Unicode support"

### DIFF
--- a/docs/relational-databases/collations/collation-and-unicode-support.md
+++ b/docs/relational-databases/collations/collation-and-unicode-support.md
@@ -2,7 +2,7 @@
 description: "Collation and Unicode support"
 title: "Collation and Unicode support | Microsoft Docs"
 ms.custom: ""
-ms.date: 12/05/2019
+ms.date: 08/02/2021
 ms.prod: sql
 ms.reviewer: ""
 ms.technology: 
@@ -25,6 +25,7 @@ helpviewer_keywords:
   - "SQL Server collations"
   - "UTF-8"
   - "UTF-16"
+  - "UCS-2"
   - "UTF8"
   - "UTF16"
   - "UCS2"
@@ -372,7 +373,7 @@ After you've assigned a collation to the server, you can change it only by expor
 To query the server collation for an instance of [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)], use the `SERVERPROPERTY` function:
 
 ```sql
-SELECT CONVERT(varchar, SERVERPROPERTY('collation'));
+SELECT CONVERT(nvarchar(128), SERVERPROPERTY('collation'));
 ```
 
 To query the server for all available collations, use the following `fn_helpcollations()` built-in function:
@@ -403,7 +404,7 @@ ALTER DATABASE myDB COLLATE Greek_CS_AI;
 You can retrieve the current collation of a database by using a statement that's similar to the following:
 
 ```sql
-SELECT CONVERT (VARCHAR(50), DATABASEPROPERTYEX('database_name','collation'));
+SELECT CONVERT (nvarchar(128), DATABASEPROPERTYEX('database_name', 'collation'));
 ```
 
 #### <a name="Column-level-collations"></a> Column-level collations    
@@ -454,7 +455,7 @@ It would be difficult to select a code page for character data types that will s
 If you store character data that reflects multiple languages in [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] ([!INCLUDE[ssVersion2005](../../includes/ssversion2005-md.md)] and later), use Unicode data types (**nchar**, **nvarchar**, and **ntext**) instead of non-Unicode data types (**char**, **varchar**, and **text**). 
 
 > [!NOTE]
-> For Unicode data types, the [!INCLUDE[ssde_md](../../includes/ssde_md.md)] can represent up to 65,535 characters using UCS-2, or the full Unicode range (‭1,114,111‬ characters) if supplementary characters are used. For more information about enabling supplementary characters, see [Supplementary Characters](#Supplementary_Characters).
+> For Unicode data types, the [!INCLUDE[ssde_md](../../includes/ssde_md.md)] can represent up to 65,536 characters using UCS-2, or the full Unicode range (‭1,114,112‬ characters) if supplementary characters are used. For more information about enabling supplementary characters, see [Supplementary Characters](#Supplementary_Characters).
 
 Alternatively, starting with [!INCLUDE[sql-server-2019](../../includes/sssql19-md.md)], if a UTF-8 enabled collation (\_UTF8) is used, previously non-Unicode data types (**char** and **varchar**) become Unicode data types using UTF-8 encoding. [!INCLUDE[sql-server-2019](../../includes/sssql19-md.md)] doesn't change the behavior of previously existing Unicode data types (**nchar**, **nvarchar**, and **ntext**), which continue to use UCS-2 or UTF-16 encoding. For more information, see [Storage differences between UTF-8 and UTF-16](#storage_differences).
 
@@ -499,7 +500,7 @@ The following table provides information about using multilingual data with vari
 |Non-Unicode|Non-Unicode|This is a very limiting scenario for multilingual data. You can use only a single code page.|    
     
 ##  <a name="Supplementary_Characters"></a> Supplementary characters    
-The Unicode Consortium allocates to each character a unique code point, which is a value in the range 000000–10FFFF. The most frequently used characters have code point values in the range 000000–00FFFF (65,535 characters) which fit into an 8-bit or 16-bit word in memory and on-disk. This range is usually designated as the Basic Multilingual Plane (BMP). 
+The Unicode Consortium allocates to each character a unique code point, which is a value in the range 000000–10FFFF. The most frequently used characters have code point values in the range 000000–00FFFF (65,536 characters) which fit into an 8-bit or 16-bit word in memory and on-disk. This range is usually designated as the Basic Multilingual Plane (BMP). 
 
 But the Unicode Consortium has established 16 additional "planes" of characters, each the same size as the BMP. This definition allows Unicode the potential to represent 1,114,112 characters (that is, 2<sup>16</sup> * 17 characters) within the code point range 000000–10FFFF. Characters with code point values larger than 00FFFF require two to four consecutive 8-bit words (UTF-8), or two consecutive 16-bit words (UTF-16). These characters located beyond the BMP are called *supplementary characters*, and the additional consecutive 8-bit or 16-bit words are called *surrogate pairs*. For more information about supplementary characters, surrogates, and surrogate pairs, refer to [the Unicode Standard](http://www.unicode.org/standard/standard.html).    
 
@@ -510,7 +511,7 @@ But the Unicode Consortium has established 16 additional "planes" of characters,
 [!INCLUDE[sql-server-2019](../../includes/sssql19-md.md)] extends supplementary character support to the **char** and **varchar** data types with the new UTF-8 enabled collations ([\_UTF8](#utf8)). These data types are also capable of representing the full Unicode character range.   
 
 > [!NOTE]
-> Starting with [!INCLUDE[ssSQL14](../../includes/sssql14-md.md)], all new \_140 collations automatically support supplementary characters.
+> Starting with [!INCLUDE[sssql17-md](../../includes/sssql17-md.md)], all new collations automatically support supplementary characters.
 
 If you use supplementary characters:    
     
@@ -540,7 +541,7 @@ The following table compares the behavior of some string functions and string op
 ## <a name="GB18030"></a> GB18030 support    
 GB18030 is a separate standard that's used in the People's Republic of China for encoding Chinese characters. In GB18030, characters can be 1, 2, or 4 bytes in length. [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] provides support for GB18030-encoded characters by recognizing them when they enter the server from a client-side application and converting and storing them natively as Unicode characters. After they're stored in the server, they're treated as Unicode characters in any subsequent operations. 
 
-You can use any Chinese collation, preferably the latest 100 version. All \_100 level collations support linguistic sorting with GB18030 characters. If the data includes supplementary characters (surrogate pairs), you can use the SC collations that are available in [!INCLUDE[ssnoversion](../../includes/ssnoversion-md.md)] to improve searching and sorting.    
+You can use any Chinese collation, preferably the latest 100 version. All version 100 collations support linguistic sorting with GB18030 characters. If the data includes supplementary characters (surrogate pairs), you can use the SC collations that are available in [!INCLUDE[ssnoversion](../../includes/ssnoversion-md.md)] to improve searching and sorting.    
 
 > [!NOTE]
 > Ensure that your client tools, such as [!INCLUDE[ssManStudioFull](../../includes/ssmanstudiofull-md.md)], use the Dengxian font to correctly display strings that contain GB18030-encoded characters.
@@ -556,16 +557,17 @@ Database applications that interact with [!INCLUDE[ssNoVersion](../../includes/s
 
 ## <a name="Japanese_Collations"></a> Japanese collations added in  [!INCLUDE [sssql17-md](../../includes/sssql17-md.md)]
  
-Starting with [!INCLUDE [sssql17-md](../../includes/sssql17-md.md)], new Japanese collation families are supported, with the permutations of various options (\_CS, \_AS, \_KS, \_WS, and \_VSS). 
+Starting with [!INCLUDE [sssql17-md](../../includes/sssql17-md.md)], new Japanese collation families are supported, with the permutations of various options (\_CS, \_AS, \_KS, \_WS, and \_VSS), as well as \_BIN and \_BIN2. 
 
 To list these collations, you can query the [!INCLUDE[ssDEnoversion](../../includes/ssdenoversion-md.md)]:      
 
 ```sql 
-SELECT Name, Description FROM fn_helpcollations()  
-WHERE Name LIKE 'Japanese_Bushu_Kakusu_140%' OR Name LIKE 'Japanese_XJIS_140%'
+SELECT name, description
+FROM   sys.fn_helpcollations()  
+WHERE  COLLATIONPROPERTY(name, 'Version') = 3;
 ``` 
 
-All the new collations have built-in support for supplementary characters, so none of the new **\_140** collations has (or needs) the SC flag.
+All the new collations have built-in support for supplementary characters, so none of the new **140** collations has (or needs) the SC flag.
 
 These collations are supported in [!INCLUDE[ssde_md](../../includes/ssde_md.md)] indexes, memory-optimized tables, columnstore indexes, and natively compiled modules.
 


### PR DESCRIPTION
This fixes #6618 

1. Main purpose of this update is to correct the note stating: "Starting with SQL Server 2014 (12.x), all new _140 collations automatically support supplementary characters.". I accidentally introduced that error back in https://github.com/MicrosoftDocs/sql-docs/commit/a5dd5b5837766d4b0522d8dd1986e1b53fdd3b44#diff-bd26ae1d32f0764b643c46bbd2af1259a58e375debebe0d71b2cdb1583dfd754R153 on 2017-10-24, due to inconsistent naming conventions (at least at that time) for the include files. That was supposed to have been "SQL Server 2017 (14.x)".

    Some of the include files had version numbers in their names referring to the internal version number (e.g. 11 = version 11.x / 110 &mdash; this is SQL Server 2012), while other include files had version numbers in their names referring to the common version number / product name (e.g. 14 = SQL Server 2014; this is version 12.x / 120).

2. Fixed data type used for `CONVERT` in server collation query. It was `varchar`, which has two problems: 1) the base datatype is `nvarchar`, and even though only standard ASCII characters are used, it's still best to match the base data type, and 2) it's a bad practice to not specify a max size for variable length types as the default is situation-dependent. Here the default is 30 (instead of 1) which is still a problem given that as of SQL Server 2019, 1476 out of 5508 (27%) collation names are over 30 characters long and are thus silently truncated by using `varchar`.

    Please see "Arguments" list in documentation for [SERVERPROPERTY](https://docs.microsoft.com/en-us/sql/t-sql/functions/serverproperty-transact-sql#arguments).
    ```sql
    SELECT [name], LEN([name]) AS [NameLength]
    FROM   sys.fn_helpcollations()
    WHERE  LEN([name]) > 30
    ORDER BY 2, 1;
    -- 1476
    ```

3. Fixed data type used for `CONVERT` in database collation query. It was `varchar(50)`, which, while better than just `varchar`, still has two problems: 1) the base datatype is `nvarchar`, and even though only standard ASCII characters are used, it's still best to match the base data type, and 2) while 50 is better than the default 30, this is still a problem given that as of SQL Server 2019, 48 collation names are over 50 characters long and are thus silently truncated by using `varchar(50)`.

    Please see "Arguments" list in documentation for [DATABASEPROPERTYEX](https://docs.microsoft.com/en-us/sql/t-sql/functions/databasepropertyex-transact-sql#arguments).
    ```sql
    SELECT [name], LEN([name]) AS [NameLength]
    FROM   sys.fn_helpcollations()
    WHERE  LEN([name]) > 50
    ORDER BY 2, 1;
    -- 48
    ```

4. Fixed the max number of code points for BMP and all of Unicode to be 65,536 and 1,114,112, respectively. Both were 1 less than that (in a few places), most likely using the max addressable code point value in each case, and not accounting for U+0000 (i.e. range vs quantity).

5. Removed "_140" from note regarding new collations automatically supporting supplementary characters. The starting SQL Server version is already mentioned, and making this version specific means one more place to update if/when a new series of collations is introduced (one more place that can be overlooked, leaving misleading documentation).

6. For consistency, removed "_" prefix from two remaining collation version number references that had them. The vast majority of collation version number references do not use that prefix, so now none of them do.

7. Under "GB18030 support", changed "100 level" to be "version 100" for consistency.

8. Under "Japanese collations ...", added "BIN and BIN2" for accuracy.

9. Under "Japanese collations ...", updated query to list new collations: 1) actual column names are not capitalized in the DB, and 2) since the Japanese collations were the only collations added in SQL Server 2017, using `COLLATIONPROPERTY(name, 'Version')` is a more deterministic method of filtering as it doesn't rely on string parsing yet is logically equivalent.

    If not using `COLLATIONPROPERTY`, then the following is preferred:
    ```sql
    SELECT name, description
    FROM   sys.fn_helpcollations()
    WHERE  name LIKE N'%[_]140[_]%';
    ```   

10.  Added "UCS-2" to keywords (meta data) as it was the only one missing from those combinations.

Take care,
Solomon...
https://SqlQuantumLift.com/
https://SqlQuantumLeap.com/
https://SQLsharp.com/
