### PR TITLE
Fix sql query

### DIFF
--- a/docs/integration-services/lesson-1-6-adding-and-configuring-the-lookup-transformations.md
+++ b/docs/integration-services/lesson-1-6-adding-and-configuring-the-lookup-transformations.md
@@ -53,8 +53,8 @@ In both cases, the Lookup transformation uses the OLE DB connection manager you 
     2.  Select **Use results of an SQL query**, and then enter or paste the following SQL statement:  
   
         ```sql
-        SELECT * FROM [Sales].[Currency]
-        WHERE [CurrencyCode]
+        SELECT * FROM [dbo].[DimCurrency]
+        WHERE [CurrencyAlternateKey]
         IN ('ARS', 'AUD', 'BRL', 'CAD', 'CNY',
             'DEM', 'EUR', 'FRF', 'GBP', 'JPY',
 	        'MXN', 'SAR', 'USD', 'VEB')


### PR DESCRIPTION
AdventureWorksDW2012 has not [Sales] schema and [Currency] table, those are possible to find in regular AdventureWorks2012 database.
In my opinion query should refer to [dbo].[DimCurrency] and [CurrencyAlternateKey] column.