### PR TITLE
Fix typo in object name: sys.pdw_nodes_dm_exec_sql_text

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-pdw-nodes-exec-sql-text-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-pdw-nodes-exec-sql-text-transact-sql.md
@@ -15,7 +15,7 @@ ms.author: xiaoyul
 monikerRange: "=azure-sqldw-latest"
 ---
 
-# sys.pdw_nodes_dm_exec_sql_text (Transact-SQL)
+# sys.dm_pdw_nodes_exec_sql_text (Transact-SQL)
 [!INCLUDE [asa](../../includes/applies-to-version/asa.md)]
 
 Returns the text of the SQL batch that is identified by the specified *sql_handle*. This table-valued function replaces the system function **fn_get_sql**.


### PR DESCRIPTION
Replaced the reference `sys.pdw_nodes_dm_exec_sql_text` with `sys.dm_pdw_nodes_exec_sql_text`.

I don't know why it's doing anything on line 47. Never touched it. 