### PR TITLE
 SQL Server Browser and default instances note

### DIFF
--- a/docs/database-engine/configure-windows/sql-server-browser-service-database-engine-and-ssas.md
+++ b/docs/database-engine/configure-windows/sql-server-browser-service-database-engine-and-ssas.md
@@ -47,7 +47,7 @@ ms.author: maghan
   
  Upon startup, [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] Browser starts and claims UDP port 1434. [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] Browser reads the registry, identifies all instances of [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] on the computer, and notes the ports and named pipes that they use. When a server has two or more network cards, [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] Browser returns the first enabled port it encounters for [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)]. [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] Browser support ipv6 and ipv4.  
   
- When [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] clients request [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] resources, the client network library sends a UDP message to the server using port 1434. [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] Browser responds with the TCP/IP port or named pipe of the requested instance. The network library on the client application then completes the connection by sending a request to the server using the port or named pipe of the desired instance. 
+ When [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] clients request [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] resources, the client network library sends a UDP message to the server using port 1434. [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] Browser responds with the TCP/IP port or named pipe of the requested instance. The network library on the client application then completes the connection by sending a request to the server using the port or named pipe of the desired instance. SQL Server Browser Service does not provide port resolution for default instances.
   
  For information about starting and stopping the [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] Browser service, see [Start, Stop, Pause, Resume, Restart the Database Engine, SQL Server Agent, or SQL Server Browser Service](../../database-engine/configure-windows/start-stop-pause-resume-restart-sql-server-services.md).  
   
@@ -78,10 +78,7 @@ ms.author: maghan
  [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] Browser is not a clustered resource and does not support failover from one cluster node to the other. Therefore, in the case of a cluster, [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] Browser should be installed and turned on for each node of the cluster. On clusters, [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] Browser listens on IP_ANY.  
   
 > [!NOTE]  
->  When listening on IP_ANY, when you enable listening on specific IPs, the user must configure the same TCP port on each IP, because [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] Browser returns the first IP/port pair that it encounters.  
-
-> [!NOTE]  
->  When you use a default SQL Server instance and try to connect without inform the port, it automatically's will try the default SQL Server port 1433. [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] Which means that for a default instance you always need to inform the port in case of this one is different from the default 1433, otherwise the connection will fail.  
+>  When listening on IP_ANY, when you enable listening on specific IPs, the user must configure the same TCP port on each IP, because [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] Browser returns the first IP/port pair that it encounters.   
   
 ## Installing, Uninstalling, and Running from the Command Line  
  By default, the [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] Browser program is installed at C:\Program Files (x86)\Microsoft SQL Server\90\Shared\sqlbrowser.exe.  

--- a/docs/database-engine/configure-windows/sql-server-browser-service-database-engine-and-ssas.md
+++ b/docs/database-engine/configure-windows/sql-server-browser-service-database-engine-and-ssas.md
@@ -79,6 +79,9 @@ ms.author: maghan
   
 > [!NOTE]  
 >  When listening on IP_ANY, when you enable listening on specific IPs, the user must configure the same TCP port on each IP, because [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] Browser returns the first IP/port pair that it encounters.  
+
+> [!NOTE]  
+>  When you use a default SQL Server instance and try to connect without inform the port, it automatically's will try the default SQL Server port 1433. [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] Which means that for a default instance you always need to inform the port in case of this one is different from the default 1433, otherwise the connection will fail.  
   
 ## Installing, Uninstalling, and Running from the Command Line  
  By default, the [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] Browser program is installed at C:\Program Files (x86)\Microsoft SQL Server\90\Shared\sqlbrowser.exe.  


### PR DESCRIPTION
Hello team! I believe we need to add a quick note on this documentation about the SQL Server Browser and default instances, I mean, for default instances SQL Server Browser will always try to discover the instance using the port 1433 if no port is informed in the client connection string. I had more than two customer's with a misunderstanding on this, they were thinking that SQL Server Browser also perform port resolution for default instances when no port was informed on the connection string.