### PR TITLE
Added callout to a limitation in Azure Synapse Analytics

### DIFF
--- a/docs/t-sql/statements/create-view-transact-sql.md
+++ b/docs/t-sql/statements/create-view-transact-sql.md
@@ -84,7 +84,10 @@ AS <select_statement>
     [ WITH <common_table_expression> [ ,...n ] ]  
     SELECT <select_criteria>  
 ```  
-  
+> [!Note] 
+> Please note that currently views in Azure Synapse Analytics do not support schema binding. For more information, see [Limitations](/azure/synapse-analytics/sql/develop-views#limitations).
+
+
 [!INCLUDE[sql-server-tsql-previous-offline-documentation](../../includes/sql-server-tsql-previous-offline-documentation.md)]
 
 ## Arguments


### PR DESCRIPTION
Schema binding is currently not supported by views in Synapse SQL Pools. I think this should be called out explicitly and linked to avoid confusion.