### PR TITLE
use http for xmlns

### DIFF
--- a/docs/t-sql/statements/bulk-insert-transact-sql.md
+++ b/docs/t-sql/statements/bulk-insert-transact-sql.md
@@ -285,7 +285,7 @@ The following format file uses the `SQLFLT8` data type to map the second data fi
 
 ```xml
 <?xml version="1.0"?>
-<BCPFORMAT xmlns="https://schemas.microsoft.com/sqlserver/2004/bulkload/format" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<BCPFORMAT xmlns="http://schemas.microsoft.com/sqlserver/2004/bulkload/format" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 <RECORD>
 <FIELD ID="1" xsi:type="CharTerm" TERMINATOR="\t" MAX_LENGTH="30"/>
 <FIELD ID="2" xsi:type="CharTerm" TERMINATOR="\r\n" MAX_LENGTH="30"/> </RECORD> <ROW>


### PR DESCRIPTION
With https version, SQL throws an error:
Msg 4855, Level 16, State 1, Line 3
Line 2 in format file "C:\t_floatformat-c-xml.xml": unexpected element "BCPFORMAT".

Solution:
https://stackoverflow.com/questions/54373618/why-does-format-file-cause-error-during-sql-server-bulk-insert