### PR TITLE
Update sys-sql-modules-transact-sql.md - Unnecessary object_name invocation 

### DIFF
--- a/docs/relational-databases/system-catalog-views/sys-sql-modules-transact-sql.md
+++ b/docs/relational-databases/system-catalog-views/sys-sql-modules-transact-sql.md
@@ -1,8 +1,8 @@
 ---
 description: "sys.sql_modules (Transact-SQL)"
-title: "sys.sql_modules (Transact-SQL) | Microsoft Docs"
+title: "sys.sql_modules (Transact-SQL)"
 ms.custom: ""
-ms.date: 11/06/2018
+ms.date: 08/20/2021
 ms.prod: sql
 ms.prod_service: "database-engine, sql-database, synapse-analytics, pdw"
 ms.reviewer: ""
@@ -17,7 +17,6 @@ dev_langs:
   - "TSQL"
 helpviewer_keywords: 
   - "sys.sql_modules catalog view"
-ms.assetid: 23d3ccd2-f356-4d89-a2cd-bee381243f99
 author: WilliamDAssafMSFT
 ms.author: wiassaf
 monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-server-2016||>=sql-server-linux-2017||=azuresqldb-mi-current"
@@ -25,7 +24,7 @@ monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-s
 # sys.sql_modules (Transact-SQL)
 [!INCLUDE [sql-asdb-asdbmi-asa-pdw](../../includes/applies-to-version/sql-asdb-asdbmi-asa-pdw.md)]
 
-  Returns a row for each object that is an SQL language-defined module in [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)], including natively compiled scalar user-defined function. Objects of type P, RF, V, TR, FN, IF, TF, and R have an associated SQL module. Stand-alone defaults, objects of type D, also have an SQL module definition in this view. For a description of these types, see the **type** column in the [sys.objects](../../relational-databases/system-catalog-views/sys-objects-transact-sql.md) catalog view.  
+  Returns a row for each object that is an SQL language-defined module in [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)], including natively compiled scalar user-defined function. Objects of type P, RF, V, TR, FN, IF, TF, and R have an associated SQL module. Stand-alone defaults, objects of type D, also have an SQL module definition in this view. For a description of these types, see the `type` column in the [sys.objects](../../relational-databases/system-catalog-views/sys-objects-transact-sql.md) catalog view.  
   
  For more information, see [Scalar User-Defined Functions for In-Memory OLTP](../../relational-databases/in-memory-oltp/scalar-user-defined-functions-for-in-memory-oltp.md).  
   
@@ -38,11 +37,11 @@ monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-s
 |**is_schema_bound**|**bit**|Module was created with SCHEMABINDING option.<br /><br /> Always contains a value of 1 for natively compiled stored procedures.|  
 |**uses_database_collation**|**bit**|1 = Schema-bound module definition depends on the default-collation of the database for correct evaluation; otherwise, 0. Such a dependency prevents changing the database's default collation.|  
 |**is_recompiled**|**bit**|Procedure was created WITH RECOMPILE option.|  
-|**null_on_null_input**|**bit**|Module was declared to produce a NULL output on any NULL input.|  
-|**execute_as_principal_id**|**Int**|ID of the EXECUTE AS database principal.<br /><br /> NULL by default or if EXECUTE AS CALLER.<br /><br /> ID of the specified principal if EXECUTE AS SELF or EXECUTE AS \<principal>.<br /><br /> -2 = EXECUTE AS OWNER.|  
+|**null_on_null_input**|**bit**|Module was declared to produce a `NULL` output on any `NULL` input.|  
+|**execute_as_principal_id**|**Int**|ID of the EXECUTE AS database principal.<br /><br /> `NULL` by default or if EXECUTE AS CALLER.<br /><br /> ID of the specified principal if EXECUTE AS SELF or EXECUTE AS \<principal>.<br /><br /> -2 = EXECUTE AS OWNER.|  
 |**uses_native_compilation**|**bit**|**Applies to**: [!INCLUDE[ssSQL14](../../includes/sssql14-md.md)] through [!INCLUDE[ssSQL14](../../includes/sssql14-md.md)].<br /><br /> 0 = not natively compiled<br /><br /> 1 = is natively compiled<br /><br /> The default value is 0.|  
-|**is_inlineable**|**bit**|**Applies to**: [!INCLUDE[sssql19-md](../../includes/sssql19-md.md)] and later.<br/><br />Indicates whether the module is inlineable or not. Inlineability is based on the conditions specified [here](../user-defined-functions/scalar-udf-inlining.md#inlineable-scalar-udfs-requirements).<br /><br /> 0 = not inlineable<br /><br /> 1 = is inlineable. <br /><br /> For scalar UDFs, the value will be 1 if the UDF is inlineable, and 0 otherwise. It always contains a value of 1 for inline TVFs, and 0 for all other module types.<br />|  
-|**inline_type**|**bit**|**Applies to**: [!INCLUDE[sssql19-md](../../includes/sssql19-md.md)] and later.<br /><br />Indicates whether inlining is turned on for the module currently. <br /><br />0 = inlining is turned off<br /><br /> 1 = inlining is turned on.<br /><br /> For scalar UDFs, the value will be 1 if inlining is turned on (explicitly or implicitly). The value will always be 1 for inline TVFs, and 0 for other module types.<br />|  
+|**is_inlineable**|**bit**|**Applies to**: [!INCLUDE[sssql19-md](../../includes/sssql19-md.md)] and later.<br/><br />Indicates whether the module is inlineable or not. Inlineability is based on the conditions specified [here](../user-defined-functions/scalar-udf-inlining.md#inlineable-scalar-udfs-requirements).<br /><br /> 0 = not inlineable<br /><br /> 1 = is inlineable. <br /><br /> For scalar user-defined functions (UDFs), the value will be 1 if the UDF is inlineable, and 0 otherwise. It always contains a value of 1 for inline table-valued functions (TVFs), and 0 for all other module types.<br />|  
+|**inline_type**|**bit**|**Applies to**: [!INCLUDE[sssql19-md](../../includes/sssql19-md.md)] and later.<br /><br />Indicates whether inlining is turned on for the module currently. <br /><br />0 = inlining is turned off<br /><br /> 1 = inlining is turned on.<br /><br /> For scalar user-defined functions (UDFs), the value will be 1 if inlining is turned on (explicitly or implicitly). The value will always be 1 for inline table-valued functions (TVFs), and 0 for other module types.<br />|  
 
   
 ## Remarks  
@@ -54,9 +53,9 @@ monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-s
  [!INCLUDE[ssCatViewPerm](../../includes/sscatviewperm-md.md)] For more information, see [Metadata Visibility Configuration](../../relational-databases/security/metadata-visibility-configuration.md).  
   
 ## Examples  
- The following example returns the name, type, and definition of each module in the current database.  
+ The following example returns the object_id, schema name, object name, object type, and definition of each module in the current database.  
   
-```  
+```sql  
 SELECT 
           sm.object_id
         , ss.[name] as [schema]
@@ -64,22 +63,15 @@ SELECT
         , o.[type]
         , o.[type_desc]
         , sm.[definition]  
-
-FROM sys.sql_modules AS sm  
-    
+FROM sys.sql_modules AS sm     
 JOIN sys.objects AS o 
-
     ON sm.object_id = o.object_id  
-
 JOIN sys.schemas AS ss
-
     ON o.schema_id = ss.schema_id  
-
 ORDER BY 
       o.[type]
     , ss.[name]
-    , o.[name]
-;  
+    , o.[name];  
 ```  
   
 ## See Also  
@@ -87,5 +79,3 @@ ORDER BY
  [Object Catalog Views &#40;Transact-SQL&#41;](../../relational-databases/system-catalog-views/object-catalog-views-transact-sql.md)   
  [Querying the SQL Server System Catalog FAQ](../../relational-databases/system-catalog-views/querying-the-sql-server-system-catalog-faq.yml)   
  [In-Memory OLTP &#40;In-Memory Optimization&#41;](../../relational-databases/in-memory-oltp/in-memory-oltp-in-memory-optimization.md)  
-  
-  

--- a/docs/relational-databases/system-catalog-views/sys-sql-modules-transact-sql.md
+++ b/docs/relational-databases/system-catalog-views/sys-sql-modules-transact-sql.md
@@ -57,11 +57,29 @@ monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-s
  The following example returns the name, type, and definition of each module in the current database.  
   
 ```  
-SELECT sm.object_id, OBJECT_NAME(sm.object_id) AS object_name, o.type, o.type_desc, sm.definition  
+SELECT 
+          sm.object_id
+        , ss.[name] as [schema]
+        , o.[name] as object_name
+        , o.[type]
+        , o.[type_desc]
+        , sm.[definition]  
+
 FROM sys.sql_modules AS sm  
-JOIN sys.objects AS o ON sm.object_id = o.object_id  
-ORDER BY o.type;  
-GO  
+    
+JOIN sys.objects AS o 
+
+    ON sm.object_id = o.object_id  
+
+JOIN sys.schemas AS ss
+
+    ON o.schema_id = ss.schema_id  
+
+ORDER BY 
+      o.[type]
+    , ss.[name]
+    , o.[name]
+;  
 ```  
   
 ## See Also  


### PR DESCRIPTION
Peers:-

It is preferable to directly use the object name from sys.objects rather than to invoke object_name function.

The reasons include:-

1) Metadata locks during object creation
2) The existence of sys.objects in the query, as is

Also, added sys.schemas so that we can include the schema name, as well.