### PR TITLE
Update alter-database-scoped-configuration-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/alter-database-scoped-configuration-transact-sql.md
+++ b/docs/t-sql/statements/alter-database-scoped-configuration-transact-sql.md
@@ -27,7 +27,7 @@ monikerRange: "= azuresqldb-current || = azuresqldb-mi-current || >= sql-server-
 ---
 # ALTER DATABASE SCOPED CONFIGURATION (Transact-SQL)
 
-[!INCLUDE[tsql-appliesto-ss2016-asdb-asdw-xxx-md.md](../../includes/tsql-appliesto-ss2016-asdb-asdw-xxx-md.md)]
+[!INCLUDE[sqlserver2016-asdb-asdbmi-asa.md](../../includes/applies-to-version/sqlserver2016-asdb-asdbmi-asa.md)]
 
 This command enables several database configuration settings at the **individual database** level. 
 


### PR DESCRIPTION
Add to the documentation that this feature is also supported by SQL MI and removed the indication that it was not supported by PDW.
The information I've is that if it's not supported then it should be visible, we should not use the cross to tell that it's not supported.