### PR TITLE
 Wrong example C

### DIFF
--- a/docs/t-sql/language-elements/nullif-transact-sql.md
+++ b/docs/t-sql/language-elements/nullif-transact-sql.md
@@ -108,7 +108,29 @@ WHERE ProductID < 10;
 GO  
 ```  
 
+### C: Returning budget amounts that contain no data
+The following example creates a `budgets` table, loads data, and uses `NULLIF` to return a null if `current_year` is null or contains the same data as `previous_year`.
+
+```SQL
+
+Copy
+CREATE TABLE budgets (  
+   dept           TINYINT,  
+   current_year   DECIMAL(10,2),  
+   previous_year  DECIMAL(10,2)  
+);  
   
+INSERT INTO budgets VALUES(1, 100000, 150000);  
+INSERT INTO budgets VALUES(2, NULL, 300000);  
+INSERT INTO budgets VALUES(3, 0, 100000);  
+INSERT INTO budgets VALUES(4, NULL, 150000);  
+INSERT INTO budgets VALUES(5, 300000, 300000);  
+  
+SELECT dept, NULLIF(current_year,  
+   previous_year) AS LastBudget  
+FROM budgets;  
+```
+
  [!INCLUDE[ssResult](../../includes/ssresult-md.md)]  
   
  ```

--- a/docs/t-sql/language-elements/nullif-transact-sql.md
+++ b/docs/t-sql/language-elements/nullif-transact-sql.md
@@ -108,26 +108,6 @@ WHERE ProductID < 10;
 GO  
 ```  
 
-### C: Returning budget amounts that contain no data  
- The following example creates a `budgets` table, loads data, and uses `NULLIF` to return a null if neither `current_year` nor `previous_year` contains data.  
-  
-```sql  
-CREATE TABLE budgets (  
-   dept           TINYINT,  
-   current_year   DECIMAL(10,2),  
-   previous_year  DECIMAL(10,2)  
-);  
-  
-INSERT INTO budgets VALUES(1, 100000, 150000);  
-INSERT INTO budgets VALUES(2, NULL, 300000);  
-INSERT INTO budgets VALUES(3, 0, 100000);  
-INSERT INTO budgets VALUES(4, NULL, 150000);  
-INSERT INTO budgets VALUES(5, 300000, 300000);  
-  
-SELECT dept, NULLIF(current_year,  
-   previous_year) AS LastBudget  
-FROM budgets;  
-```  
   
  [!INCLUDE[ssResult](../../includes/ssresult-md.md)]  
   


### PR DESCRIPTION
### C: Returning budget amounts that contain no data  
 The following example creates a `budgets` table, loads data, and uses `NULLIF` to return a null if neither `current_year` nor `previous_year` contains data.  
  
```sql  
CREATE TABLE budgets (  
   dept           TINYINT,  
   current_year   DECIMAL(10,2),  
   previous_year  DECIMAL(10,2)  
);  
  
INSERT INTO budgets VALUES(1, 100000, 150000);  
INSERT INTO budgets VALUES(2, NULL, 300000);  
INSERT INTO budgets VALUES(3, 0, 100000);  
INSERT INTO budgets VALUES(4, NULL, 150000);  
INSERT INTO budgets VALUES(5, 300000, 300000);  
  
SELECT dept, NULLIF(current_year,  
   previous_year) AS LastBudget  
FROM budgets;  
```  


This example C is totally wrong, base on the question, "neither `current_year` nor `previous_year` contains data" means that both cols contain NULL, then the function used should be "Coalesce()",
so the right code is:

SELECT dept, COALESCE(current_year,  
   previous_year) AS LastBudget  
FROM budgets;