### PR TITLE
reverse rowversion and timestamp

### DIFF
--- a/docs/t-sql/data-types/data-type-synonyms-transact-sql.md
+++ b/docs/t-sql/data-types/data-type-synonyms-transact-sql.md
@@ -41,7 +41,7 @@ Data type synonyms are included in [!INCLUDE[ssNoVersion](../../includes/ssnover
 |**national character varying(**_n_**)**|**nvarchar(n)**|  
 |**national char varying(**_n_**)**|**nvarchar(n)**|  
 |**national text**|**ntext**|  
-|**timestamp**|rowversion|  
+|**rowversion**|timetamp|  
   
 Data type synonyms can be used instead of the corresponding base data type name in data definition language (DDL) statements. These statements include CREATE TABLE, CREATE PROCEDURE, and DECLARE *\@variable*. However, after the object is created, the synonyms have no visibility. When the object is created, the object is assigned the base data type that is associated with the synonym. There's no record that the synonym was specified in the statement that created the object.
   


### PR DESCRIPTION
Original documentation claims timestamp is the synonym, and rowversion is the base type. However, actual behaviour is the opposite.