### PR TITLE
Update create-function-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/create-function-transact-sql.md
+++ b/docs/t-sql/statements/create-function-transact-sql.md
@@ -745,11 +745,10 @@ WITH EMP_cte(EmployeeID, OrganizationNode, FirstName, LastName, JobTitle, Recurs
         -- Join recursive member to anchor
         SELECT e.BusinessEntityID, e.OrganizationNode, p.FirstName, p.LastName, e.JobTitle, RecursionLevel + 1
         FROM HumanResources.Employee e
-              INNER JOIN EMP_cte 
-              ON e.OrganizationNode.GetAncestor(1) = case when EMP_cte.OrganizationNode is NULL then CAST('/' AS hierarchyid)
-			                               						     else EMP_cte.OrganizationNode end
-              INNER JOIN Person.Person p
-              ON p.BusinessEntityID = e.BusinessEntityID
+          INNER JOIN EMP_cte
+          ON e.OrganizationNode.GetAncestor(1) = EMP_cte.OrganizationNode
+          INNER JOIN Person.Person p
+          ON p.BusinessEntityID = e.BusinessEntityID
         )
 -- copy the required columns to the result of the function
     INSERT @retFindReports

--- a/docs/t-sql/statements/create-function-transact-sql.md
+++ b/docs/t-sql/statements/create-function-transact-sql.md
@@ -735,7 +735,8 @@ BEGIN
 WITH EMP_cte(EmployeeID, OrganizationNode, FirstName, LastName, JobTitle, RecursionLevel) -- CTE name and columns
     AS (
         -- Get the initial list of Employees for Manager n
-        SELECT e.BusinessEntityID, e.OrganizationNode, p.FirstName, p.LastName, e.JobTitle, 0
+        SELECT e.BusinessEntityID, OrganizationNode = ISNULL(e.OrganizationNode, CAST('/' AS hierarchyid)) 
+        , p.FirstName, p.LastName, e.JobTitle, 0
         FROM HumanResources.Employee e
               INNER JOIN Person.Person p
               ON p.BusinessEntityID = e.BusinessEntityID

--- a/docs/t-sql/statements/create-function-transact-sql.md
+++ b/docs/t-sql/statements/create-function-transact-sql.md
@@ -737,17 +737,18 @@ WITH EMP_cte(EmployeeID, OrganizationNode, FirstName, LastName, JobTitle, Recurs
         -- Get the initial list of Employees for Manager n
         SELECT e.BusinessEntityID, e.OrganizationNode, p.FirstName, p.LastName, e.JobTitle, 0
         FROM HumanResources.Employee e
-INNER JOIN Person.Person p
-ON p.BusinessEntityID = e.BusinessEntityID
+              INNER JOIN Person.Person p
+              ON p.BusinessEntityID = e.BusinessEntityID
         WHERE e.BusinessEntityID = @InEmpID
         UNION ALL
         -- Join recursive member to anchor
         SELECT e.BusinessEntityID, e.OrganizationNode, p.FirstName, p.LastName, e.JobTitle, RecursionLevel + 1
         FROM HumanResources.Employee e
-            INNER JOIN EMP_cte
-            ON e.OrganizationNode.GetAncestor(1) = EMP_cte.OrganizationNode
-INNER JOIN Person.Person p
-ON p.BusinessEntityID = e.BusinessEntityID
+              INNER JOIN EMP_cte 
+              ON e.OrganizationNode.GetAncestor(1) = case when EMP_cte.OrganizationNode is NULL then CAST('/' AS hierarchyid)
+			                               						     else EMP_cte.OrganizationNode end
+              INNER JOIN Person.Person p
+              ON p.BusinessEntityID = e.BusinessEntityID
         )
 -- copy the required columns to the result of the function
     INSERT @retFindReports


### PR DESCRIPTION
Example C. Creating a multi-statement table-valued function is wrong when the root OrganizationNode is NULL for e.BusinessEntityID = 1, change to fix the problem by using case expression.

test on AdventureWorks2016CTP3
result before the change: (1 row affected)
after: (290 rows affected)