### PR TITLE
Update cast-and-convert-transact-sql.md

### DIFF
--- a/docs/t-sql/functions/cast-and-convert-transact-sql.md
+++ b/docs/t-sql/functions/cast-and-convert-transact-sql.md
@@ -276,6 +276,7 @@ When you convert data types that differ in decimal places, [!INCLUDE[ssNoVersion
 |**float**|**numeric**|Round<br /><br /> Conversion of **float** values that use scientific notation to **decimal** or **numeric** is restricted to values of precision 17 digits only. Any value with precision higher than 17 rounds to zero.|  
 |**float**|**datetime**|Round|  
 |**datetime**|**int**|Round|  
+|**datetime**|**time**|Round|
   
 For example, the values 10.6496 and -10.6496 may be truncated or rounded during conversion to **int** or **numeric** types:
   


### PR DESCRIPTION
added a section to the table to call out the rounding rules when casting a datetime to a time.. The rounding behavior seems to me to be undocumented or a bug. It definitely was unexpected see this post on SO for further discussion: https://stackoverflow.com/questions/69033081/t-sql-truncate-time-not-round-to-the-nearest-minute it's proably worth adding an example to the PR to demonstrate the behavior. If I can get confirmation that this behavior is by design and not a bug from the product team I will be glad to amend the PR.