### PR TITLE
Fix some numbers and Add some internal configurations

### DIFF
--- a/docs/database-engine/configure-windows/server-configuration-options-sql-server.md
+++ b/docs/database-engine/configure-windows/server-configuration-options-sql-server.md
@@ -70,16 +70,17 @@ The following table lists all available configuration options, the range of poss
 
 | Configuration option | Minimum value | Maximum value | Default |
 |--|--|--|--|
-| [access check cache bucket count](../../database-engine/configure-windows/access-check-cache-server-configuration-options.md) (A) | 0 | 16384 | 0 |
+| [access check cache bucket count](../../database-engine/configure-windows/access-check-cache-server-configuration-options.md) (A) | 0 | 65536 | 0 |
 | [access check cache quota](../../database-engine/configure-windows/access-check-cache-server-configuration-options.md) (A) | 0 | 2147483647 | 0 |
 | [ad hoc distributed queries](../../database-engine/configure-windows/ad-hoc-distributed-queries-server-configuration-option.md) (A) | 0 | 1 | 0 |
 | [ADR cleaner retry timeout (min)](../../database-engine/configure-windows/adr-cleaner-retry-timeout-configuration-option.md)<br><br> Introduced in SQL Server 2019 | 0 | 32767 | 15 |
-| [ADR Preallocation Factor](../../database-engine/configure-windows/adr-preallocation-factor-server-configuration-option.md)<br><br> Introduced in SQL Server 2019 | 0 | 32767 | 4 |
+| [ADR Preallocation Factor](../../database-engine/configure-windows/adr-preallocation-factor-server-configuration-option.md)<br><br> Introduced in SQL Server 2019 | 0 | 32767 | 0<br /><br /> (When 0 is set, 4 is used as a default.) |
 | [affinity I/O mask](../../database-engine/configure-windows/affinity-input-output-mask-server-configuration-option.md) (A, RR) | -2147483648 | 2147483647 | 0 |
 | [affinity mask](../../database-engine/configure-windows/affinity-mask-server-configuration-option.md) (A) | -2147483648 | 2147483647 | 0 |
 | [affinity64 I/O mask](../../database-engine/configure-windows/affinity64-input-output-mask-server-configuration-option.md) (A, only available on 64-bit version of SQL Server) | -2147483648 | 2147483647 | 0 |
 | [affinity64 mask](../../database-engine/configure-windows/affinity64-mask-server-configuration-option.md) (A, RR), only available on 64-bit version of SQL Server | -2147483648 | 2147483647 | 0 |
 | [Agent XPs](../../database-engine/configure-windows/agent-xps-server-configuration-option.md) (A) | 0 | 1 | 0<br /><br /> (Changes to 1 when SQL Server Agent is started. Default value is 0 if SQL Server Agent is set to automatic start during Setup.) |
+| allow filesystem enumeration (Internal Use Only) | 0 | 1 | 1 |
 | [allow polybase export](../../database-engine/configure-windows/allow-polybase-export.md)<br/><br/> [!INCLUDE [sqlserver2016](../../includes/applies-to-version/sqlserver2016.md)].| 0 | 1 | 0 |
 | [allow updates](../../database-engine/configure-windows/allow-updates-server-configuration-option.md) (Obsolete. Don't use. Will cause an error during reconfigure.) | 0 | 1 | 0 |
 | [automatic soft-NUMA disabled](soft-numa-sql-server.md) | 0 | 1 | 0 |
@@ -89,7 +90,7 @@ The following table lists all available configuration options, the range of poss
 | [c2 audit mode](../../database-engine/configure-windows/c2-audit-mode-server-configuration-option.md) (A, RR) | 0 | 1 | 0 |
 | [clr enabled](../../database-engine/configure-windows/clr-enabled-server-configuration-option.md) | 0 | 1 | 0 |
 | [clr strict security](../../database-engine/configure-windows/clr-strict-security.md) (A) <br /> [!INCLUDE [sqlserver2017](../../includes/applies-to-version/sqlserver2017.md)]. | 0 | 1 | 0 |
-| [column encryption enclave type ](../../database-engine/configure-windows/configure-column-encryption-enclave-type.md) (A, RR) | 0 | 1 | 0 |
+| [column encryption enclave type ](../../database-engine/configure-windows/configure-column-encryption-enclave-type.md) (A, RR) | 0 | 1<br/><br/>(2 as Internal Use Only) | 0 |
 | [common criteria compliance enabled](../../database-engine/configure-windows/common-criteria-compliance-enabled-server-configuration-option.md) (A, RR) | 0 | 1 | 0 |
 | [contained database authentication](../../database-engine/configure-windows/contained-database-authentication-server-configuration-option.md) | 0 | 1 | 0 |
 | [cost threshold for parallelism](../../database-engine/configure-windows/configure-the-cost-threshold-for-parallelism-server-configuration-option.md) (A) | 0 | 32767 | 5 |
@@ -152,6 +153,8 @@ The following table lists all available configuration options, the range of poss
 | [two digit year cutoff](../../database-engine/configure-windows/configure-the-two-digit-year-cutoff-server-configuration-option.md) (A) | 1753 | 9999 | 2049 |
 | [user connections](../../database-engine/configure-windows/configure-the-user-connections-server-configuration-option.md) (A, RR, SC) | 0 | 32767 | 0 |
 | [user options](../../database-engine/configure-windows/configure-the-user-options-server-configuration-option.md) | 0 | 32767 | 0 |
+| version high part of SQL Server (Internal Use Only) | -2147483648 | 2147483647 | 0 |
+| version low part of SQL Server (Internal Use Only) | -2147483648 | 2147483647 | 0 |
 | [xp_cmdshell](../../database-engine/configure-windows/xp-cmdshell-server-configuration-option.md) (A) | 0 | 1 | 0 |
 
 ## See also


### PR DESCRIPTION
Here are my research result for each configuration that is different from SQL Server 2019.

- access check cache bucket count
From the code, it use 16384 for x86 and 65536 for x64, but as all supported versions are x64 only now, I change it to 65536.

- ADR cleaner retry timeout (min)
Actual default values is 0 when first started after clean setup, but I'm still investigating if 0 is ok or not.

- ADR Preallocation Factor
Actual default values is 0 when first started after clean setup, but when 0 is set, it will use 4 from the code.

- allow filesystem enumeration
I think it is internal, but customers can see from sp_configure or sys.configurations, we should document this, so some customers happen to changed, they can change back to default.

- column encryption enclave type
Max values is 2 from sp_configure or sys.configurations, but 1 is supported value as VSM.
I guess 2 is used for Azure SQL Database with SGX.

- min server memory (MB)
Run_value will use 16 MB if Configure_values is lower, so I added a comment.

- version high part of SQL Server / version low part of SQL Server
It is also internal, and used for replicated master, but the same as "allow filesystem enumeration", customers can see it, so it is better to have default values on here.