### PR TITLE
Polices are missing from the default location

### DIFF
--- a/docs/relational-databases/policy-based-management/policy-based-management-storage.md
+++ b/docs/relational-databases/policy-based-management/policy-based-management-storage.md
@@ -19,10 +19,10 @@ ms.author: vanto
   Policies are stored in the msdb database. After a policy or condition is changed, msdb should be backed up. For more information, see [Back Up and Restore of System Databases &#40;SQL Server&#41;](../../relational-databases/backup-restore/back-up-and-restore-of-system-databases-sql-server.md).  
   
 ## Storing Policies  
- [!INCLUDE[ssnoversion](../../includes/ssnoversion-md.md)] includes policies that can be used to monitor an instance of [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)]. By default, these policies are not installed on the [!INCLUDE[ssDE](../../includes/ssde-md.md)]; however, they can be imported from the default installation location of C:\Program Files (x86)\Microsoft SQL Server\140\Tools\Policies\DatabaseEngine\1033.  
+ [!INCLUDE[ssnoversion](../../includes/ssnoversion-md.md)] includes policies that can be used to monitor an instance of [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)]. By default, these policies are not installed on the [!INCLUDE[ssDE](../../includes/ssde-md.md)]; however, they can be imported from the default installation location of C:\Program Files (x86)\Microsoft SQL Server\140\Tools\Policies\DatabaseEngine\1033.  There is no folder under tools directory. 
   
  You can directly create policies by using the **File/New** menu, and then saving them to a file. This enables you to create policies when you are not connected to an instance of the [!INCLUDE[ssDE](../../includes/ssde-md.md)].  
   
  Policy history for policies evaluated in the current instance of the [!INCLUDE[ssDE](../../includes/ssde-md.md)] is maintained in msdb system tables. Policy history for policies applied to other instances of the [!INCLUDE[ssDE](../../includes/ssde-md.md)] or applied to [!INCLUDE[ssRSnoversion](../../includes/ssrsnoversion-md.md)] or [!INCLUDE[ssASnoversion](../../includes/ssasnoversion-md.md)] is not retained.  
   
-  
+


### PR DESCRIPTION
Microsoft Best Practice policies are missing on the default installation location. There is no Polices folder under C:\Program Files (x86)\Microsoft SQL Server\140\Tools\.  Please let us know if I can download the polices from any other location.