### PR TITLE
Sample policy location

### DIFF
--- a/docs/relational-databases/policy-based-management/policy-based-management-storage.md
+++ b/docs/relational-databases/policy-based-management/policy-based-management-storage.md
@@ -19,7 +19,7 @@ ms.author: vanto
   Policies are stored in the msdb database. After a policy or condition is changed, msdb should be backed up. For more information, see [Back Up and Restore of System Databases &#40;SQL Server&#41;](../../relational-databases/backup-restore/back-up-and-restore-of-system-databases-sql-server.md).  
   
 ## Storing Policies  
- [!INCLUDE[ssnoversion](../../includes/ssnoversion-md.md)] includes policies that can be used to monitor an instance of [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)]. By default, these policies are not installed on the [!INCLUDE[ssDE](../../includes/ssde-md.md)]; however, they can be imported from the default installation location of C:\Program Files (x86)\Microsoft SQL Server\140\Tools\Policies\DatabaseEngine\1033.  
+ [!INCLUDE[ssnoversion](../../includes/ssnoversion-md.md)] includes policies that can be used to monitor an instance of [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)]. By default, these policies are not installed on the [!INCLUDE[ssDE](../../includes/ssde-md.md)]; Sample polices can be import from location https://github.com/microsoft/sql-server-samples/tree/master/samples/features/epm-framework/sample-policies. 
   
  You can directly create policies by using the **File/New** menu, and then saving them to a file. This enables you to create policies when you are not connected to an instance of the [!INCLUDE[ssDE](../../includes/ssde-md.md)].  
   


### PR DESCRIPTION
Microsoft Best Practice policies are missing on the default installation location. There is no Polices folder under C:\Program Files (x86)\Microsoft SQL Server\140\Tools.