### PR TITLE
Update sys-dm-db-task-space-usage-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-db-task-space-usage-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-db-task-space-usage-transact-sql.md
@@ -87,9 +87,7 @@ On SQL Database **Basic**, **S0**, and **S1** service objectives, and for databa
   
 ## Relationship Cardinalities  
   
-|From|To|Relationship|  
-|----------|--------|------------------|  
-|dm_db_task_space_usage.request_id|dm_exec_requests.request_id|One-to-one|  
+![Capture](https://user-images.githubusercontent.com/73323764/132151558-1440cc03-4a35-42f4-9fb1-9d8e399af4d3.PNG)
 |dm_db_task_space_usage.session_id|dm_exec_requests.session_id|One-to-one|  
   
 ## See Also  


### PR DESCRIPTION
|From|To|Relationship|  
|----------|--------|------------------|  
|dm_db_task_space_usage.request_id|dm_exec_requests.request_id|Many-to-one|  

The combination of session_id + request_id in sys.dm_db_task_space_usage might not always be unique in the scenario when parallel thread is spun using the same request_id as per the attached screenshot. In this situation, you would need to filter the sys.dm_db_task_space_usage DMV with exec_context_id = 0 to show only the active row.