### PR TITLE
Fix bug in Example D

### DIFF
--- a/docs/t-sql/functions/patindex-transact-sql.md
+++ b/docs/t-sql/functions/patindex-transact-sql.md
@@ -124,7 +124,7 @@ position
 The following example uses the `[^]` [string operator](../../t-sql/language-elements/wildcard-character-s-not-to-match-transact-sql.md) to find the position of a character that is not a number, letter, or space.
 
 ```sql
-SELECT position = PATINDEX('%[^ 0-9A-z]%', 'Please ensure the door is locked!'); 
+SELECT position = PATINDEX('%[^ 0-9A-Za-z]%', 'Please ensure the door is locked!'); 
 ```
 [!INCLUDE[ssResult](../../includes/ssresult-md.md)]  
 


### PR DESCRIPTION
The example pattern '%[^ 0-9A-z]%' did not match characters in the range 91-96, even though they are not numbers, letters, or spaces.
For example:
SELECT position = PATINDEX('%[^ 0-9A-Za-z]%', 'Please^ensure the door is locked!');
returns 33, but it should return 7.
With the proposed update, it works correctly.