### PR TITLE
Update sql-server-linux-availability-group-cluster-ubuntu.md

### DIFF
--- a/docs/linux/sql-server-linux-availability-group-cluster-ubuntu.md
+++ b/docs/linux/sql-server-linux-availability-group-cluster-ubuntu.md
@@ -211,7 +211,7 @@ Use constraints to configure the decisions of the cluster. Constraints have a sc
 To ensure that primary replica and the virtual ip resource are on the same host, define a colocation constraint with a score of INFINITY. To add the colocation constraint, run the following command on one node. 
 
 ```bash
-sudo pcs constraint colocation add master virtualip with master ag_cluster-clone INFINITY
+sudo pcs constraint colocation add virtualip with master ag_cluster-clone INFINITY
 ```
 
 ## Add ordering constraint


### PR DESCRIPTION
pcs constraint colocation add master virtualip with master ag_cluster-clone INFINITY --- this does not work. It causes virtual ip resource to stay on one node all the time. 

correct command is:
pcs constraint colocation add virtualip with master ag_cluster-clone INFINITY   --- This will add rsc-role started by default. 

Redhat 8 documentation has following command (which works)
pcs constraint colocation add virtualip with master ag_cluster-clone INFINITY with-rsc-role=Master