### PR TITLE
Fix grammar in understanding-isolation-levels.md

### DIFF
--- a/docs/connect/jdbc/understanding-isolation-levels.md
+++ b/docs/connect/jdbc/understanding-isolation-levels.md
@@ -24,7 +24,7 @@ Transaction isolation levels control the following effects:
 
 - How long the read locks are held.
 
-- Whether a read operation referencing rows modified by another transaction:
+- Whether read operations referencing rows modified by another transaction:
 
   - Block until the exclusive lock on the row is freed.
 


### PR DESCRIPTION
The following sentence:

> Whether **a read operation** referencing rows modified by another transaction:

Should read:

> Whether **read operations** referencing rows modified by another transaction:

...due to the way the sentences in the list below that line are formed (e.g. without this fix, the sentences would read "Whether a read operation...block until" which is incorrect. With the fix that now reads as "Whether read operations...block until").