### PR TITLE
Update the default FILEGROWTH value to 16 MB

### DIFF
--- a/docs/t-sql/statements/alter-database-transact-sql-file-and-filegroup-options.md
+++ b/docs/t-sql/statements/alter-database-transact-sql-file-and-filegroup-options.md
@@ -3,7 +3,7 @@ title: "ALTER DATABASE File and Filegroups"
 description: Update a database's files and filegroups using Transact-SQL.
 titleSuffix: SQL Server (Transact-SQL)
 ms.custom: "seo-lt-2019"
-ms.date: "02/21/2019"
+ms.date: "09/15/2021"
 ms.prod: sql
 ms.prod_service: "sql-database"
 ms.reviewer: ""

--- a/docs/t-sql/statements/alter-database-transact-sql-file-and-filegroup-options.md
+++ b/docs/t-sql/statements/alter-database-transact-sql-file-and-filegroup-options.md
@@ -841,8 +841,8 @@ A value of 0 indicates that automatic growth is set to off and no additional spa
 
 If FILEGROWTH is not specified, the default values are:
 
-- Data 64 MB
-- Log files 64 MB
+- Data 16 MB
+- Log files 16 MB
 
 **\<add_or_modify_filegroups>::=**
 


### PR DESCRIPTION
The default FILEGROWTH value is 64 MB as shown in the document, However, when I actually create a new database in SQL MI, the default FILEGROWTH is 16 MB. 
The document needs to be corrected with correct value