### PR TITLE
Update sys-fn-pagerescracker-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-functions/sys-fn-pagerescracker-transact-sql.md
+++ b/docs/relational-databases/system-functions/sys-fn-pagerescracker-transact-sql.md
@@ -66,7 +66,7 @@ The `sys.fn_PageResCracker` function can be used in conjunction with [sys.dm_db_
 SELECT page_info.* 
 FROM sys.dm_exec_requests AS d  
 CROSS APPLY sys.fn_PageResCracker (d.page_resource) AS r  
-CROSS APPLY sys.dm_db_page_info(r.db_id, r.file_id, r.page_id, 1) AS page_info
+CROSS APPLY sys.dm_db_page_info(r.db_id, r.file_id, r.page_id, 'DETAILED') AS page_info
 ```  
   
 ## See Also  


### PR DESCRIPTION
The fourth parameter of function sys.dm_db_page_info can be default,'LIMITED' or 'DETAILED', it does not have the value 1.
Following query is not correct, I replace the 1 with 'DETAILED'
SELECT page_info.* 
FROM sys.dm_exec_requests AS d  
CROSS APPLY sys.fn_PageResCracker (d.page_resource) AS r  
CROSS APPLY sys.dm_db_page_info(r.db_id, r.file_id, r.page_id, 1) AS page_info