### PR TITLE
Update start-sql-server-in-single-user-mode.md

### DIFF
--- a/docs/database-engine/configure-windows/start-sql-server-in-single-user-mode.md
+++ b/docs/database-engine/configure-windows/start-sql-server-in-single-user-mode.md
@@ -45,7 +45,7 @@ For example, **-m"SQLCMD"** limits connections to a single connection and that c
 The following example starts the SQL Server instance in single-user mode and only allows connection through the SQL Server Management Studio Query Editor.
 
 ```console
-net start "SQL Server (MSSQLSERVER)" -m"Microsoft SQL Server Management Studio - Query"
+net start "SQL Server (MSSQLSERVER)" /m"Microsoft SQL Server Management Studio - Query"
 ```
 
 ## Note for Clustered installations  


### PR DESCRIPTION
The code example used -m instead of /m. NET START will not accept -m.
See https://docs.microsoft.com/en-us/sql/database-engine/configure-windows/database-engine-service-startup-options?view=sql-server-ver15#using-startup-options-for-troubleshooting