### PR TITLE
Typo "&#40;Database Engine&#41;"→"\(Database Engine\)"

### DIFF
--- a/docs/t-sql/data-types/tostring-database-engine.md
+++ b/docs/t-sql/data-types/tostring-database-engine.md
@@ -24,7 +24,7 @@ ms.author: mikeray
 
 [!INCLUDE [SQL Server Azure SQL Database Azure SQL Managed Instance](../../includes/applies-to-version/sql-asdb-asdbmi.md)]
 
-Returns a string with the logical representation of *this*. ToString is called implicitly when a conversion from **hierarchyid** to a string type occurs. Acts as the opposite of [Parse &#40;Database Engine&#41;](../../t-sql/data-types/parse-database-engine.md).
+Returns a string with the logical representation of *this*. ToString is called implicitly when a conversion from **hierarchyid** to a string type occurs. Acts as the opposite of [Parse \(Database Engine\)](../../t-sql/data-types/parse-database-engine.md).
   
 ## Syntax  
 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/sql/t-sql/data-types/tostring-database-engine?view=sql-server-ver15
#PingMSFTDocs