### PR TITLE
add set-null example, fix malformed output sample

### DIFF
--- a/docs/t-sql/functions/json-modify-transact-sql.md
+++ b/docs/t-sql/functions/json-modify-transact-sql.md
@@ -109,6 +109,12 @@ SET @info=JSON_MODIFY(@info,'$.surname','Smith')
 
 PRINT @info
 
+-- Set name NULL 
+
+SET @info=JSON_MODIFY(@info,'strict $.name',NULL)
+
+PRINT @info
+
 -- Delete name  
 
 SET @info=JSON_MODIFY(@info,'$.name',NULL)
@@ -264,7 +270,7 @@ PRINT @info
     "skills": ["C#", "SQL"]
 } {
     "name": "John",
-    "skills": "["C#","T-SQL","Azure"]"
+    "skills": "[\"C#\",\"T-SQL\",\"Azure\"]"
 }
 ```  
   

--- a/docs/t-sql/functions/json-modify-transact-sql.md
+++ b/docs/t-sql/functions/json-modify-transact-sql.md
@@ -270,7 +270,7 @@ PRINT @info
     "skills": ["C#", "SQL"]
 } {
     "name": "John",
-    "skills": "[\"C#\",\"T-SQL\",\"Azure\"]"
+    "skills": ["C#", "T-SQL", "Azure"]
 }
 ```  
   


### PR DESCRIPTION
- add "Set name `NULL`" example to **Basic Operations** section
- fix malformed output in overwrite-array-with-text example in **Modify a JSON object** section