### PR TITLE
Mention column names in the query.

### DIFF
--- a/docs/relational-databases/json/json-data-sql-server.md
+++ b/docs/relational-databases/json/json-data-sql-server.md
@@ -160,7 +160,7 @@ SET @json = N'[
   {"id": 5, "info": {"name": "Jane", "surname": "Smith", "skills": ["SQL", "C#", "Azure"]}, "dob": "2005-11-04T12:00:00"}  
 ]';
 
-SELECT *  
+SELECT id, firstName, lastName, age, dateOfBirth, skill  
 FROM OPENJSON(@json)  
   WITH (
     id INT 'strict $.id',


### PR DESCRIPTION
The column names needs to be mentioned in the query to match the result set below. 

![image](https://user-images.githubusercontent.com/3396447/136768268-e251d261-75e3-48e3-bb2a-69483f6fb99f.png)

If we use `*` then `skills` also shows in the result set.

![image](https://user-images.githubusercontent.com/3396447/136768343-b614588f-1ff2-4750-ad11-f4aafbe7c365.png)

Fixes #6921