### PR TITLE
Correction to compatibility level remark.

### DIFF
--- a/docs/t-sql/functions/string-agg-transact-sql.md
+++ b/docs/t-sql/functions/string-agg-transact-sql.md
@@ -77,7 +77,7 @@ If the input expression is type `VARCHAR`, the separator cannot be type `NVARCHA
 
 Null values are ignored and the corresponding separator is not added. To return a place holder for null values, use the `ISNULL` function as demonstrated in example B.
 
-`STRING_AGG` is available in any compatibility level.
+`STRING_AGG` is available in any compatibility level.  However, <order_clause> is not available at compatibility level 100 (or below).
 
 ## Examples
 


### PR DESCRIPTION
Databases at compatibility level 100 throw a syntax error when string_agg() has the <order_clause>.  I tested on SQL Server 2017 Developer.  Confirmation from others here: https://stackoverflow.com/a/52871832/5982751