### PR TITLE
Add ntext and image to max_length description

### DIFF
--- a/docs/relational-databases/system-catalog-views/sys-columns-transact-sql.md
+++ b/docs/relational-databases/system-catalog-views/sys-columns-transact-sql.md
@@ -47,7 +47,7 @@ monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-s
 |column_id|**int**|ID of the column. Is unique within the object.<br /><br /> Column IDs might not be sequential.|  
 |system_type_id|**tinyint**|ID of the system type of the column.|  
 |user_type_id|**int**|ID of the type of the column as defined by the user.<br /><br /> To return the name of the type, join to the [sys.types](../../relational-databases/system-catalog-views/sys-types-transact-sql.md) catalog view on this column.|  
-|max_length|**smallint**|Maximum length (in bytes) of the column.<br /><br /> -1 = Column data type is **varchar(max)**, **nvarchar(max)**, **varbinary(max)**, or **xml**.<br /><br /> For **text** columns, the max_length value will be 16 or the value set by sp_tableoption 'text in row'.|  
+|max_length|**smallint**|Maximum length (in bytes) of the column.<br /><br /> -1 = Column data type is **varchar(max)**, **nvarchar(max)**, **varbinary(max)**, or **xml**.<br /><br /> For **text**, **ntext**, and **image** columns, the max_length value will be 16 (representing the 16-byte pointer only) or the value set by sp_tableoption 'text in row'.|  
 |precision|**tinyint**|Precision of the column if numeric-based; otherwise, 0.|  
 |scale|**tinyint**|Scale of column if numeric-based; otherwise, 0.|  
 |collation_name|**sysname**|Name of the collation of the column if character-based; otherwise `NULL`.|  


### PR DESCRIPTION
While deprecated, these types are still in use, and people ask from time to time what 16 means.