### PR TITLE
Update oracle-connection-type-ssrs.md

### DIFF
--- a/docs/reporting-services/report-data/oracle-connection-type-ssrs.md
+++ b/docs/reporting-services/report-data/oracle-connection-type-ssrs.md
@@ -137,7 +137,7 @@ Power BI Desktop uses **Unmanaged ODP.NET** for authoring Power BI reports. You 
 Contact your database administrator for connection information and for the credentials to use to connect to the data source. The following connection string example specifies an Oracle database on the server named "Oracle18" using Unicode. The server name must match what is defined in the Tnsnames.ora configuration file as the Oracle server instance name.  
   
 ```  
-Data Source="Oracle"; Unicode="True"  
+Data Source="Oracle18"; Unicode="True"  
 ```  
   
 For more connection string examples, see [Create data connection strings - Report Builder & SSRS](../../reporting-services/report-data/data-connections-data-sources-and-connection-strings-report-builder-and-ssrs.md).  


### PR DESCRIPTION
In line 140, you set the Data Source to **"Oracle"** at "Data Source="Oracle"; Unicode="True".However, you mentioned the server name is **"Oracle18"** at Line 137 **"The following connection string example specifies an Oracle database on the server named "Oracle18" using Unicode."**

So in the correct connection string, the data source value should match the server name to avoid any kind of confusion for the reader!

```  
Data Source="Oracle18"; Unicode="True"  
```