### PR TITLE
CREATE EXTERNAL DATA SOURCE (Transact-SQL) Removing what seems to be an extra unintended slash

### DIFF
--- a/docs/t-sql/statements/create-database-scoped-credential-transact-sql.md
+++ b/docs/t-sql/statements/create-database-scoped-credential-transact-sql.md
@@ -133,7 +133,7 @@ CREATE MASTER KEY ENCRYPTION BY PASSWORD='<EnterStrongPasswordHere>';
 -- Create a database scoped credential.
 CREATE DATABASE SCOPED CREDENTIAL ADL_User
 WITH
-    IDENTITY = '<client_id>@\<OAuth_2.0_Token_EndPoint>',
+    IDENTITY = '<client_id>@<OAuth_2.0_Token_EndPoint>',
     SECRET = '<key>'
 ;
 ```


### PR DESCRIPTION
### C. Creating a database scoped credential for PolyBase Connectivity to Azure Data Lake Store.
In this section there was a slash that was preventing me from creating an external table because upon removing it 
my external table in my Azure SQL pool was able to be created with an ADLS Gen 2 as an external data source.