### PR TITLE
where clause is optional

### DIFF
--- a/docs/mdx/mdx-data-manipulation-select.md
+++ b/docs/mdx/mdx-data-manipulation-select.md
@@ -59,8 +59,8 @@ FROM
            <SELECT query axis clause>,...n ] )   
          ]   
             FROM   
-         <SELECT subcube clause>   
-         <SELECT slicer axis clause> )  
+           <SELECT subcube clause>   
+         [ <SELECT slicer axis clause> ] )  
   
 <SELECT slicer axis clause> ::=   
       WHERE Tuple_Expression  


### PR DESCRIPTION
I guess something like `SELECT * FROM ( SELECT * FROM myCube )` is allowed, or?