### PR TITLE
distinct is not an operator

### DIFF
--- a/docs/mdx/operators-mdx-syntax.md
+++ b/docs/mdx/operators-mdx-syntax.md
@@ -50,8 +50,6 @@ author: minewiskan
   
 -   AS  
   
--   DISTINCT  
-  
 -   :  
   
 -   ^  

--- a/docs/mdx/operators-mdx-syntax.md
+++ b/docs/mdx/operators-mdx-syntax.md
@@ -1,7 +1,7 @@
 ---
 description: "Operators (MDX Syntax)"
 title: "Operators (MDX Syntax) | Microsoft Docs"
-ms.date: 06/04/2018
+ms.date: 11/08/2021
 ms.prod: sql
 ms.technology: analysis-services
 ms.custom: mdx
@@ -48,8 +48,6 @@ author: minewiskan
   
 -   IS  
   
--   AS  
-  
 -   :  
   
 -   ^  
@@ -57,8 +55,6 @@ author: minewiskan
 -   /, *  
   
 -   +, -  
-  
--   EXISTING  
   
 -   <>, >=, =, \<=, >, <  
   


### PR DESCRIPTION
Why is `distinct` list as an operator? It is a normal [function](https://docs.microsoft.com/en-us/sql/mdx/distinct-mdx?view=sql-server-ver15), or?