### PR TITLE
Document procedure for Debian 11 (Bullseye)

### DIFF
--- a/docs/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server.md
+++ b/docs/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server.md
@@ -77,6 +77,9 @@ curl https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources
 #Debian 10
 curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list
 
+#Debian 11
+curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list
+
 exit
 sudo apt-get update
 sudo ACCEPT_EULA=Y apt-get install -y msodbcsql17


### PR DESCRIPTION
Small update - Debian 11 is live and there's provision on the actual site as well; this should probably be reflected on documentation.