### PR TITLE
Change >= to >

### DIFF
--- a/docs/relational-databases/statistics/statistics.md
+++ b/docs/relational-databases/statistics/statistics.md
@@ -123,7 +123,7 @@ ORDER BY s.name;
   |Temporary|*n* < 6|6|
   |Temporary|6 <= *n* <= 500|500|
   |Permanent|*n* <= 500|500|
-  |Temporary or permanent|*n* >= 500|MIN ( 500 + (0.20 * *n*), SQRT(1,000 * *n*) ) |
+  |Temporary or permanent|*n* > 500|MIN ( 500 + (0.20 * *n*), SQRT(1,000 * *n*) ) |
 
   For example if your table contains 2 million rows, then the calculation is the minimum of `500 + (0.20 * 2,000,000) = 400,500` and `SQRT(1,000 * 2,000,000) = 44,721`. This means the statistics will be updated every 44,721 modifications.
 


### PR DESCRIPTION
Otherwise, the boundary value 500 would qualify for two rows of the table.
Changed it to match the pre compatibility level 130 table.