### PR TITLE
Example C doesnt really create a csv file

### DIFF
--- a/docs/t-sql/functions/concat-ws-transact-sql.md
+++ b/docs/t-sql/functions/concat-ws-transact-sql.md
@@ -92,7 +92,7 @@ Address
 1 Microsoft Way,Redmond,WA,98052
 ```
 
-### C.  Generating CSV file from table
+### C.  Generating CSV formated data from table
 This example uses a comma `,` as the separator value, and adds the carriage return character `char(13)` in the column separated values format of the result set.
 
 ```sql

--- a/docs/t-sql/functions/concat-ws-transact-sql.md
+++ b/docs/t-sql/functions/concat-ws-transact-sql.md
@@ -92,7 +92,7 @@ Address
 1 Microsoft Way,Redmond,WA,98052
 ```
 
-### C.  Generating CSV formated data from table
+### C.  Generating CSV-formatted data from table
 This example uses a comma `,` as the separator value, and adds the carriage return character `char(13)` in the column separated values format of the result set.
 
 ```sql


### PR DESCRIPTION
The result of the query has commas between values and a char(13) in each record but this isnt a character separated _file_ and using that word is misleading.