### PR TITLE
sample for using a delimited identifier is wrong

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-help-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-help-transact-sql.md
@@ -37,7 +37,7 @@ sp_help [ [ @objname = ] 'name' ]
   
 ## Arguments  
 `[ @objname = ] 'name'`
- Is the name of any object, in **sysobjects** or any user-defined data type in the **systypes** table. *name* is **nvarchar(**776**)**, with a default of NULL. Database names are not acceptable.  Two or three part names must be delimited, such as 'Person.AddressType' or [Person.AddressType].   
+ Is the name of any object, in **sysobjects** or any user-defined data type in the **systypes** table. *name* is **nvarchar(**776**)**, with a default of NULL. Database names are not acceptable.  Two or three part names may be delimited, such as 'Person.AddressType' or '[Person].[AddressType]'.   
    
   
 ## Return Code Values  


### PR DESCRIPTION
passing `[person.address]' would look for an object called dbo.[person.address], not an object called 'address' in the 'person' schema.