### PR TITLE
Update Ubuntu installation instructions with lsb_release -rs

### DIFF
--- a/docs/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server.md
+++ b/docs/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server.md
@@ -159,20 +159,7 @@ sudo zypper install -y unixODBC-devel
 sudo su
 curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 
-#Download appropriate package for the OS version
-#Choose only ONE of the following, corresponding to your OS version
-
-#Ubuntu 16.04
-curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
-
-#Ubuntu 18.04
-curl https://packages.microsoft.com/config/ubuntu/18.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
-
-#Ubuntu 20.04
-curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
-
-#Ubuntu 21.04
-curl https://packages.microsoft.com/config/ubuntu/21.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
+curl https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list > /etc/apt/sources.list.d/mssql-release.list
 
 exit
 sudo apt-get update

--- a/docs/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server.md
+++ b/docs/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server.md
@@ -156,6 +156,13 @@ sudo zypper install -y unixODBC-devel
 ### <a id="ubuntu17"></a> Ubuntu
 
 ```bash
+
+if ! [[ "16.04 18.04 20.04 21.04" == *"$(lsb_release -rs)"* ]];
+then
+    echo "Ubuntu $(lsb_release -rs) is not currently supported.";
+    exit;
+fi
+
 sudo su
 curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 


### PR DESCRIPTION
Short PR: the installation instructions can be greatly simplified and automated by using $(lsb_release -rs) instead of manually selecting the version number.