### PR TITLE
Update columnstore-indexes-overview.md

### DIFF
--- a/docs/relational-databases/indexes/columnstore-indexes-overview.md
+++ b/docs/relational-databases/indexes/columnstore-indexes-overview.md
@@ -58,7 +58,7 @@ A rowgroup from where all data has been deleted transitions from COMPRESSED into
 > After merging smaller rowgroups, the index quality should be improved. 
 
 > [!NOTE]
-> <a name="bckmergetsk"></a> Starting with [!INCLUDE[sql-server-2019](../../includes/sssql19-md.md)], [!INCLUDE[ssSDSfull](../../includes/sssdsfull-md.md)],  [!INCLUDE[ssSDSMIfull](../../includes/sssdsmifull-md.md)], and Synapse Analytics, the tuple-mover is helped by a background merge task that automatically compresses smaller OPEN delta rowgroups that have existed for some time as determined by an internal threshold, or merges COMPRESSED rowgroups from where a large number of rows has been deleted. This improves the columnstore index quality over time.         
+> <a name="bckmergetsk"></a> Starting with [!INCLUDE[sql-server-2019](../../includes/sssql19-md.md)], [!INCLUDE[ssSDSfull](../../includes/sssdsfull-md.md)],  [!INCLUDE[ssSDSMIfull](../../includes/sssdsmifull-md.md)], and dedicated SQL pools in Azure Synapse Analytics, the tuple-mover is helped by a background merge task that automatically compresses smaller OPEN delta rowgroups that have existed for some time as determined by an internal threshold, or merges COMPRESSED rowgroups from where a large number of rows has been deleted. This improves the columnstore index quality over time.         
 
 #### Column segment
 A column segment is a column of data from within the rowgroup.  

--- a/docs/relational-databases/indexes/columnstore-indexes-overview.md
+++ b/docs/relational-databases/indexes/columnstore-indexes-overview.md
@@ -58,7 +58,7 @@ A rowgroup from where all data has been deleted transitions from COMPRESSED into
 > After merging smaller rowgroups, the index quality should be improved. 
 
 > [!NOTE]
-> <a name="bckmergetsk"></a> Starting with [!INCLUDE[sql-server-2019](../../includes/sssql19-md.md)], [!INCLUDE[ssSDSfull](../../includes/sssdsfull-md.md)], and [!INCLUDE[ssSDSMIfull](../../includes/sssdsmifull-md.md)], the tuple-mover is helped by a background merge task that automatically compresses smaller OPEN delta rowgroups that have existed for some time as determined by an internal threshold, or merges COMPRESSED rowgroups from where a large number of rows has been deleted. This improves the columnstore index quality over time.         
+> <a name="bckmergetsk"></a> Starting with [!INCLUDE[sql-server-2019](../../includes/sssql19-md.md)], [!INCLUDE[ssSDSfull](../../includes/sssdsfull-md.md)],  [!INCLUDE[ssSDSMIfull](../../includes/sssdsmifull-md.md)], and Synapse Analytics, the tuple-mover is helped by a background merge task that automatically compresses smaller OPEN delta rowgroups that have existed for some time as determined by an internal threshold, or merges COMPRESSED rowgroups from where a large number of rows has been deleted. This improves the columnstore index quality over time.         
 
 #### Column segment
 A column segment is a column of data from within the rowgroup.  


### PR DESCRIPTION
Synapse Analytics also has a tuple mover. Customers are confused. (Although the doc https://docs.microsoft.com/en-us/azure/synapse-analytics/sql-data-warehouse/sql-data-warehouse-tables-index explains "Closed groups are automatically converted to columnstore row groups by the background "tuple mover" process.")