### PR TITLE
Added DATABASE MIRRORING to protocol_type

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-exec-connections-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-exec-connections-transact-sql.md
@@ -37,7 +37,7 @@ Returns information about the connections established to this instance of [!INCL
 |most_recent_session_id|**int**|Represents the session ID for the most recent request associated with this connection. (SOAP connections can be reused by another session.) Is nullable.|  
 |connect_time|**datetime**|Timestamp when connection was established. Is not nullable.|  
 |net_transport|**nvarchar(40)**|Always returns **Session** when a connection has multiple active result sets (MARS) enabled.<br /><br /> **Note:** Describes the physical transport protocol that is used by this connection. Is not nullable.|  
-|protocol_type|**nvarchar(40)**|Specifies the protocol type of the payload. It currently distinguishes between TDS (TSQL) and SOAP. Is nullable.|  
+|protocol_type|**nvarchar(40)**|Specifies the protocol type of the payload. It currently distinguishes between TDS (TSQL), SOAP, and DATABASE MIRRORING. Is nullable.|  
 |protocol_version|**int**|Version of the data access protocol associated with this connection. Is nullable.|  
 |endpoint_id|**int**|An identifier that describes what type of connection it is. This endpoint_id can be used to query the sys.endpoints view. Is nullable.|  
 |encrypt_option|**nvarchar(40)**|Boolean value to describe whether encryption is enabled for this connection. Is not nullable.|  

--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-exec-connections-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-exec-connections-transact-sql.md
@@ -37,7 +37,8 @@ Returns information about the connections established to this instance of [!INCL
 |most_recent_session_id|**int**|Represents the session ID for the most recent request associated with this connection. (SOAP connections can be reused by another session.) Is nullable.|  
 |connect_time|**datetime**|Timestamp when connection was established. Is not nullable.|  
 |net_transport|**nvarchar(40)**|Always returns **Session** when a connection has multiple active result sets (MARS) enabled.<br /><br /> **Note:** Describes the physical transport protocol that is used by this connection. Is not nullable.|  
-|protocol_type|**nvarchar(40)**|Specifies the protocol type of the payload. It currently distinguishes between TDS (TSQL), SOAP, and DATABASE MIRRORING. Is nullable.|  
+|protocol_type|**nvarchar(40)**|Specifies the protocol type of the payload. It currently distinguishes between TDS ("TSQL"), "SOAP", and "Database Mirroring". Is nullable.|  
+
 |protocol_version|**int**|Version of the data access protocol associated with this connection. Is nullable.|  
 |endpoint_id|**int**|An identifier that describes what type of connection it is. This endpoint_id can be used to query the sys.endpoints view. Is nullable.|  
 |encrypt_option|**nvarchar(40)**|Boolean value to describe whether encryption is enabled for this connection. Is not nullable.|  

--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-exec-connections-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-exec-connections-transact-sql.md
@@ -38,7 +38,6 @@ Returns information about the connections established to this instance of [!INCL
 |connect_time|**datetime**|Timestamp when connection was established. Is not nullable.|  
 |net_transport|**nvarchar(40)**|Always returns **Session** when a connection has multiple active result sets (MARS) enabled.<br /><br /> **Note:** Describes the physical transport protocol that is used by this connection. Is not nullable.|  
 |protocol_type|**nvarchar(40)**|Specifies the protocol type of the payload. It currently distinguishes between TDS ("TSQL"), "SOAP", and "Database Mirroring". Is nullable.|  
-
 |protocol_version|**int**|Version of the data access protocol associated with this connection. Is nullable.|  
 |endpoint_id|**int**|An identifier that describes what type of connection it is. This endpoint_id can be used to query the sys.endpoints view. Is nullable.|  
 |encrypt_option|**nvarchar(40)**|Boolean value to describe whether encryption is enabled for this connection. Is not nullable.|  


### PR DESCRIPTION
When querying sys.dm_exec_connections, the database mirroring endpoints (AG endpoint) shows up and lists DATABASE MIRRORING as the protocol type.