### PR TITLE
Correcting behavior of QUOTED_IDENTIFIER database setting.

### DIFF
--- a/docs/relational-databases/databases/database-properties-options-page.md
+++ b/docs/relational-databases/databases/database-properties-options-page.md
@@ -173,7 +173,8 @@ Enables this feature.
  When **SIMPLE**, queries are parameterized based on the default behavior of the database. When **FORCED**, [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] parameterizes all queries in the database.  
   
  **Quoted Identifiers Enabled**  
- Specifies a database default for the whether [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] double quote `"` is used to specify delimited identifiers (TRUE) or varchar literals (FALSE). Possible values are **True** and **False**. For more information, see [SET QUOTED_IDENTIFIER &#40;Transact-SQL&#41;](../../t-sql/statements/set-quoted-identifier-transact-sql.md).  This database will amost always can be overriden for a session, since most client drivers SET QUOTED_IDENTIFIER ON at connection time.
+ Specifies a database default for the whether [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] double quote `"` is used to specify delimited identifiers (_true_) or varchar literals (_false_). Possible values are _true_ and _false_. For more information, see [SET QUOTED_IDENTIFIER](../../t-sql/statements/set-quoted-identifier-transact-sql.md).  This database default setting can be overridden by a session's setting, and many client drivers SET QUOTED_IDENTIFIER ON at connection time.
+
   
  **Recursive Triggers Enabled**  
  Specify whether triggers can be fired by other triggers. Possible values are **True** and **False**. When set to **True**, this enables recursive firing of triggers. When set to **False**, only direct recursion is prevented. To disable indirect recursion, set the nested triggers server option to 0 using sp_configure. For more information, see [Create Nested Triggers](../../relational-databases/triggers/create-nested-triggers.md).  

--- a/docs/relational-databases/databases/database-properties-options-page.md
+++ b/docs/relational-databases/databases/database-properties-options-page.md
@@ -2,7 +2,7 @@
 title: "Database Properties (Options Page)"
 description: "Learn how to use the Options tab in the Database Properties dialog box to view or modify a database's collation, recovery model, and other settings."
 ms.custom: ""
-ms.date: "08/17/2021"
+ms.date: "12/21/2021"
 ms.prod: sql
 ms.prod_service: "database-engine"
 ms.reviewer: ""

--- a/docs/relational-databases/databases/database-properties-options-page.md
+++ b/docs/relational-databases/databases/database-properties-options-page.md
@@ -173,7 +173,7 @@ Enables this feature.
  When **SIMPLE**, queries are parameterized based on the default behavior of the database. When **FORCED**, [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] parameterizes all queries in the database.  
   
  **Quoted Identifiers Enabled**  
- Specify whether [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] keywords can be used as identifiers (an object or variable name) if enclosed in quotation marks. Possible values are **True** and **False**. For more information, see [SET QUOTED_IDENTIFIER &#40;Transact-SQL&#41;](../../t-sql/statements/set-quoted-identifier-transact-sql.md).  
+ Specifies a database default for the whether [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] double quote `"` is used to specify delimited identifiers (TRUE) or varchar literals (FALSE). Possible values are **True** and **False**. For more information, see [SET QUOTED_IDENTIFIER &#40;Transact-SQL&#41;](../../t-sql/statements/set-quoted-identifier-transact-sql.md).  This database will amost always can be overriden for a session, since most client drivers SET QUOTED_IDENTIFIER ON at connection time.
   
  **Recursive Triggers Enabled**  
  Specify whether triggers can be fired by other triggers. Possible values are **True** and **False**. When set to **True**, this enables recursive firing of triggers. When set to **False**, only direct recursion is prevented. To disable indirect recursion, set the nested triggers server option to 0 using sp_configure. For more information, see [Create Nested Triggers](../../relational-databases/triggers/create-nested-triggers.md).  


### PR DESCRIPTION
The doc in ALTER DATABASE is correct, and correcting this to be a correct summary of it. https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-database-transact-sql-set-options?view=sql-server-ver15#quoted_identifier--on--off-

This setting does not prohibit identifiers as object names as the current doc suggests.  eg this works:

```
alter database current set quoted_identifier off
go
set quoted_identifier on
create table "table"(id int)
drop table "table"
go
alter database current set quoted_identifier on
go
set quoted_identifier on
create table "table"(id int)
drop table "table"
```