### PR TITLE
Fix typo in description

### DIFF
--- a/docs/t-sql/functions/fetch-status-transact-sql.md
+++ b/docs/t-sql/functions/fetch-status-transact-sql.md
@@ -1,6 +1,6 @@
 ---
-description: "@@FETCH_STATUS (Transact-SQL)"
 title: FETCH_STATUS (Transact-SQL)
+description: "@@FETCH_STATUS (Transact-SQL)"
 ms.custom: ""
 ms.date: "09/18/2017"
 ms.prod: sql

--- a/docs/t-sql/functions/fetch-status-transact-sql.md
+++ b/docs/t-sql/functions/fetch-status-transact-sql.md
@@ -1,5 +1,5 @@
 ---
-description: "&#x40;&#x40;FETCH_STATUS (Transact-SQL)"
+description: "@@FETCH_STATUS (Transact-SQL)"
 title: FETCH_STATUS (Transact-SQL)
 ms.custom: ""
 ms.date: "09/18/2017"


### PR DESCRIPTION
Bad quoting. The result is that in `Recommended content` section referring to this page you cannot see the correct text