### PR TITLE
Adding feature line for Lock Pages In Memory

### DIFF
--- a/docs/sql-server/editions-and-components-of-sql-server-version-15.md
+++ b/docs/sql-server/editions-and-components-of-sql-server-version-15.md
@@ -193,6 +193,7 @@ The Developer edition continues to support only 1 client for [[!INCLUDE[ssNoVers
 |In-Memory Database: hybrid buffer pool|Yes|Yes|No|No|No|
 |In-Memory Database: memory-optimized tempdb metadata|Yes|No|No|No|No|
 |In-Memory Database: persistent memory support|Yes|Yes|Yes|Yes|Yes|
+|Lock Pages In Memory|Yes|Yes|No|No|No|
 |Stretch database|Yes|Yes|Yes|Yes|Yes|
 |Multi-instance support|50|50|50|50|50|
 |Table and index partitioning|Yes|Yes|Yes|Yes|Yes|


### PR DESCRIPTION
It's documented on the feature page https://docs.microsoft.com/en-us/sql/database-engine/configure-windows/server-memory-server-configuration-options?view=sql-server-ver15#lock-pages-in-memory-lpim  But to follow the practice of consolidating edition feature differences on this page it should be here too.