### PR TITLE
Update walkthrough-author-custom-static-code-analysis-rule-assembly.md

### DIFF
--- a/docs/ssdt/walkthrough-author-custom-static-code-analysis-rule-assembly.md
+++ b/docs/ssdt/walkthrough-author-custom-static-code-analysis-rule-assembly.md
@@ -98,7 +98,7 @@ The first class that you must define is the WaitForDelayVisitor class, derived f
   
     ```  
     public WaitForDelayVisitor() {  
-       WaitForDelayStatments = new List<WaitForStatement>();  
+       WaitForDelayStatements = new List<WaitForStatement>();  
     }  
     ```  
   
@@ -108,7 +108,7 @@ The first class that you must define is the WaitForDelayVisitor class, derived f
     public override void ExplicitVisit(WaitForStatement node) {  
        // We are only interested in WAITFOR DELAY occurrences  
        if (node.WaitForOption == WaitForOption.Delay)  
-          WaitForDelayStatments.Add(node);  
+          WaitForDelayStatements.Add(node);  
     }  
     ```  
   


### PR DESCRIPTION
Typo in word `WaitForDelayStatements` was fixed.