### PR TITLE
Update string-agg-transact-sql.md

### DIFF
--- a/docs/t-sql/functions/string-agg-transact-sql.md
+++ b/docs/t-sql/functions/string-agg-transact-sql.md
@@ -77,7 +77,7 @@ If the input expression is type `VARCHAR`, the separator cannot be type `NVARCHA
 
 Null values are ignored and the corresponding separator is not added. To return a place holder for null values, use the `ISNULL` function as demonstrated in example B.
 
-`STRING_AGG` is available in any compatibility level.
+`STRING_AGG` is available in any compatibility level. However, the WITHIN GROUP clause is only available in compatibility level 110 or higher.
 
 ## Examples
 


### PR DESCRIPTION
Added a note that WITHIN GROUP is only available in compat level 110 or later. You can verify this with the script below. The first SELECT fails, the second succeeds.

SELECT o.name, string_agg(c.name, ',') WITHIN GROUP (ORDER BY c.name)
FROM   sys.objects o
JOIN   sys.columns c ON o.object_id = c.object_id
GROUP BY o.name
go
ALTER DATABASE CURRENT SET COMPATIBILITY_LEVEL = 110
go
SELECT o.name, string_agg(c.name, ',') WITHIN GROUP (ORDER BY c.name)
FROM   sys.objects o
JOIN   sys.columns c ON o.object_id = c.object_id
GROUP BY o.name
go