### PR TITLE
Update create-table-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/create-table-transact-sql.md
+++ b/docs/t-sql/statements/create-table-transact-sql.md
@@ -113,7 +113,7 @@ column_name <data_type>
           ENCRYPTION_TYPE = { DETERMINISTIC | RANDOMIZED } ,
           ALGORITHM = 'AEAD_AES_256_CBC_HMAC_SHA_256'
         ) ]
-    [ <column_constraint> [, ...n ] ]
+    [ <column_constraint> [ ...n ] ]
     [ <column_index> ]
   
 <data_type> ::=


### PR DESCRIPTION
Removed the comma from the "[ ...n ]" on line 116.  SQL Server 2019 (15.0.4153.1) does not accept a comma between column constraints in a CREATE TABLE statement.
Sample Code that works:
use tempdb
;
drop table if exists WERT
;
create table WERT (
  asdf int
    constraint ck check (asdf between 1 and 100)
    constraint df default 22
, zxcv int
);
exec sp_help 'WERT'
;
If you put a comma in front of "constraint df default 22" you will get an error.