### PR TITLE
Update dbo-sysjobhistory-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-tables/dbo-sysjobhistory-transact-sql.md
+++ b/docs/relational-databases/system-tables/dbo-sysjobhistory-transact-sql.md
@@ -60,7 +60,13 @@ This table is stored in the **msdb** database.
 		sh.run_date,
 		sh.step_name,
 		STUFF(STUFF(RIGHT(REPLICATE('0', 6) +  CAST(sh.run_time as varchar(6)), 6), 3, 0, ':'), 6, 0, ':') 'run_time',
-		STUFF(STUFF(STUFF(RIGHT(REPLICATE('0', 8) + CAST(sh.run_duration as varchar(8)), 8), 3, 0, ':'), 6, 0, ':'), 9, 0, ':') 'run_duration (DD:HH:MM:SS)  '
+		CASE WHEN sh.run_duration > 235959 THEN
+		   CAST((CAST(LEFT(CAST(sh.run_duration AS VARCHAR), LEN(CAST(sh.run_duration AS VARCHAR)) - 4) AS INT) / 24) AS VARCHAR)
+		   + '.' + RIGHT('00' + CAST(CAST(LEFT(CAST(sh.run_duration AS VARCHAR), LEN(CAST(sh.run_duration AS VARCHAR)) - 4) AS INT) % 24 AS VARCHAR), 2)
+		   + ':' + STUFF(CAST(RIGHT(CAST(sh.run_duration AS VARCHAR), 4) AS VARCHAR(6)), 3, 0, ':')
+		ELSE
+		   STUFF(STUFF(RIGHT(REPLICATE('0', 6) + CAST(sh.run_duration AS VARCHAR(6)), 6), 3, 0, ':'), 6, 0, ':')
+		END 'LastRunDuration (DD.HH:MM:SS) '
 FROM msdb.dbo.sysjobs sj
 JOIN msdb.dbo.sysjobhistory sh
 ON sj.job_id = sh.job_id


### PR DESCRIPTION
The field [run_duration] (table msdb.dbo.sysjobhistory) has no the format DDHHMMSS and can have more than 6 digits:
- Example 1: job duration --> 28hh 15mm 35ss is stored as 281535 (so the calculate for 'run_duration (DD:HH:MM:SS)  ' will give a wrong value = 00:28:15:35) and should be 01.04:15:35
- Example 2: job duration --> 5dd 3hh 15mm 35ss is stored as 1231535 (so the calculate for 'run_duration (DD:HH:MM:SS)  ' will give a wrong value = 01:23:15:35) and should be 05.03:15:35