### PR TITLE
Update create-synonym-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/create-synonym-transact-sql.md
+++ b/docs/t-sql/statements/create-synonym-transact-sql.md
@@ -42,7 +42,7 @@ CREATE SYNONYM [ schema_name_1. ] synonym_name FOR <object>
   
 <object> :: =  
 {  
-    [ server_name.[ database_name ] . [ schema_name_2 ]. object_name   
+    [ server_name.[ database_name ] . [ schema_name_2 ].    
   | database_name . [ schema_name_2 ].| schema_name_2. ] object_name  
 }  
 ```  


### PR DESCRIPTION
Deleted "object_name" on line 45. The original syntax says that if you specify "server_name", you need to specify "object_name" twice.

Original syntax expanded to several rows:
[ 
  server_name.[ database_name ] . [ schema_name_2 ]. object_name   
  |
  database_name . [ schema_name_2 ].
  |
  schema_name_2. 
] object_name