### PR TITLE
TCP/IP is not default for all Edition

### DIFF
--- a/docs/ssms/scripting/sqlcmd-connect-to-the-database-engine.md
+++ b/docs/ssms/scripting/sqlcmd-connect-to-the-database-engine.md
@@ -22,7 +22,8 @@ monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-s
 ---
 # sqlcmd - Connect to the Database Engine
 [!INCLUDE[SQL Server Azure SQL Database Synapse Analytics PDW](../../includes/applies-to-version/sql-asdb-asdbmi-asa-pdw.md)]
-  [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] supports client communication with the TCP/IP network protocol (the default), and the named pipes protocol. The shared memory protocol is also available if the client is connecting to an instance of the [!INCLUDE[ssDE](../../includes/ssde-md.md)] on the same computer. There are three common methods of selecting the protocol. The protocol used by the **sqlcmd** utility is determined in the following order:  
+  [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] supports client communication with the TCP/IP network protocol, and the named pipes protocol. The shared memory protocol is also available if the client is connecting to an instance of the [!INCLUDE[ssDE](../../includes/ssde-md.md)] on the same computer. For default SQL Server network protocol, please see [here](../../database-engine/configure-windows/default-sql-server-network-protocol-configuration.md). 
+  There are three common methods of selecting the protocol. The protocol used by the **sqlcmd** utility is determined in the following order:  
   
 -   **sqlcmd** uses the protocol specified as part of the connection string as described below.  
   


### PR DESCRIPTION
For SQL Server Express and Developer Edition, TCP/IP is disabled by default, so it should remove TCP/IP as default here, instead it should link to following page for default configuration.

https://docs.microsoft.com/en-us/sql/database-engine/configure-windows/default-sql-server-network-protocol-configuration?view=sql-server-ver15