### PR TITLE
Update "sys.openkeys"

### DIFF
--- a/docs/relational-databases/system-catalog-views/sys-openkeys-transact-sql.md
+++ b/docs/relational-databases/system-catalog-views/sys-openkeys-transact-sql.md
@@ -23,7 +23,7 @@ ms.author: randolphwest
 monikerRange: "=azuresqldb-current||>=sql-server-2016||>=sql-server-linux-2017||=azuresqldb-mi-current"
 ---
 # sys.openkeys (Transact-SQL)
-[!INCLUDE [SQL Server SQL Database](../../includes/applies-to-version/sql-asdb.md)]
+[!INCLUDE [SQL Server SQL Database](../../includes/applies-to-version/sql-asdb.md)] 
 
   This catalog view returns information about encryption keys that are open in the current session.  
   


### PR DESCRIPTION
Currently, "sys.openkeys" is marked as not supported for Azure Synapse Analytics Dedicated SQL Pools.
But, "OPEN SYMMETRIC KEY" is marked as supported for Azure Synapse Analytics and in "OPEN SYMMETRIC KEY", its mentioned as follows - 

"Information about open symmetric keys is visible in the sys.openkeys (Transact-SQL) catalog view." 

I have also verified that the "sys.openkeys" provide the opened key information in Azure Synapse Analytics Dedicated SQL pool and can you confirm and mark "sys.openkeys" document is supported for Azure Synapse Analytics ?