### PR TITLE
Added note from SET XACT_ABORT

### DIFF
--- a/docs/t-sql/language-elements/throw-transact-sql.md
+++ b/docs/t-sql/language-elements/throw-transact-sql.md
@@ -65,6 +65,7 @@ THROW [ { error_number | @local_variable },
 |If a *msg_id* is passed to RAISERROR, the ID must be defined in sys.messages.|The *error_number* parameter does not have to be defined in sys.messages.|  
 |The *msg_str* parameter can contain **printf** formatting styles.|The *message* parameter does not accept **printf** style formatting.|  
 |The *severity* parameter specifies the severity of the exception.|There is no *severity* parameter. When THROW is used to initiate the exception, the severity is always set to 16. However, when THROW is used to re-throw an existing exception, the severity is set to that exception's severity level.|  
+| Does not honor [SET XACT_ABORT](https://docs.microsoft.com/en-us/sql/t-sql/statements/set-xact-abort-transact-sql) | Transactions _will_ be rolled back if [SET XACT_ABORT](https://docs.microsoft.com/en-us/sql/t-sql/statements/set-xact-abort-transact-sql) is ON |
   
 ## Examples  
   

--- a/docs/t-sql/language-elements/throw-transact-sql.md
+++ b/docs/t-sql/language-elements/throw-transact-sql.md
@@ -65,7 +65,8 @@ THROW [ { error_number | @local_variable },
 |If a *msg_id* is passed to RAISERROR, the ID must be defined in sys.messages.|The *error_number* parameter does not have to be defined in sys.messages.|  
 |The *msg_str* parameter can contain **printf** formatting styles.|The *message* parameter does not accept **printf** style formatting.|  
 |The *severity* parameter specifies the severity of the exception.|There is no *severity* parameter. When THROW is used to initiate the exception, the severity is always set to 16. However, when THROW is used to re-throw an existing exception, the severity is set to that exception's severity level.|  
-| Does not honor [SET XACT_ABORT](https://docs.microsoft.com/en-us/sql/t-sql/statements/set-xact-abort-transact-sql) | Transactions _will_ be rolled back if [SET XACT_ABORT](https://docs.microsoft.com/en-us/sql/t-sql/statements/set-xact-abort-transact-sql) is ON |
+| Does not honor [SET XACT_ABORT](https://docs.microsoft.com/sql/t-sql/statements/set-xact-abort-transact-sql) | Transactions _will_ be rolled back if [SET XACT_ABORT](https://docs.microsoft.com/sql/t-sql/statements/set-xact-abort-transact-sql) is ON |
+
   
 ## Examples  
   


### PR DESCRIPTION
Extra note from SET XACT_ABORT page  seems important as it is the best reason to prefer THROW over RAISERROR, and so far not mentioned

"The THROW statement honors SET XACT_ABORT. RAISERROR does not. New applications should use THROW instead of RAISERROR."