### PR TITLE
Update configure-the-max-worker-threads-server-configuration-option.md

### DIFF
--- a/docs/database-engine/configure-windows/configure-the-max-worker-threads-server-configuration-option.md
+++ b/docs/database-engine/configure-windows/configure-the-max-worker-threads-server-configuration-option.md
@@ -63,7 +63,7 @@ The default value for **max worker threads** is 0. This enables [!INCLUDE[ssNoVe
   
 -   The following table shows the automatically configured number of max worker threads (when value is set to 0) based on various combinations of CPUs, computer architecture, and versions of [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)], using the formula: ***Default Max Workers* + ((*logical CPUs* - 4) * *Workers per CPU*)**.  
   
-    |Number of CPUs|32-bit computer (up to [!INCLUDE[ssSQL14](../../includes/sssql14-md.md)])|64-bit computer (up to [!INCLUDE[sssql16-md](../../includes/sssql16-md.md)] SP1)|64-bit computer (starting with [!INCLUDE[sssql16-md](../../includes/sssql16-md.md)] SP2 and [!INCLUDE[ssSQL17](../../includes/sssql17-md.md)])|   
+    |Number of logical CPUs|32-bit computer (up to [!INCLUDE[ssSQL14](../../includes/sssql14-md.md)])|64-bit computer (up to [!INCLUDE[sssql16-md](../../includes/sssql16-md.md)] SP1)|64-bit computer (starting with [!INCLUDE[sssql16-md](../../includes/sssql16-md.md)] SP2 and [!INCLUDE[ssSQL17](../../includes/sssql17-md.md)])|   
     |------------|------------|------------|------------|  
     |\<= 4|256|512|512|   
     |8|288|576|576|   
@@ -75,14 +75,14 @@ The default value for **max worker threads** is 0. This enables [!INCLUDE[ssNoVe
     
     Up to [!INCLUDE[sssql16-md](../../includes/sssql16-md.md)] SP1, the *Workers per CPU* only depend on the architecture (32-bit or 64-bit):
     
-    |Number of CPUs|32-bit computer <sup>Note 1</sup>|64-bit computer|   
+    |Number of logical CPUs|32-bit computer <sup>Note 1</sup>|64-bit computer|   
     |------------|------------|------------|   
     |\<= 4|256|512|   
     |\> 4|256 + ((logical CPU's - 4) * 8)|512 <sup>Note 2</sup> + ((logical CPU's - 4) * 16)|   
     
     Starting with [!INCLUDE[sssql16-md](../../includes/sssql16-md.md)] SP2 and [!INCLUDE[ssSQL17](../../includes/sssql17-md.md)], the *Workers per CPU* depend on the architecture and number of processors (between 4 and 64, or greater than 64):
     
-    |Number of CPUs|32-bit computer <sup>Note 1</sup>|64-bit computer|   
+    |Number of logical CPUs|32-bit computer <sup>Note 1</sup>|64-bit computer|   
     |------------|------------|------------|   
     |\<= 4|256|512|   
     |\> 4 and \<= 64|256 + ((logical CPU's - 4) * 8)|512 <sup>Note 2</sup> + ((logical CPU's - 4) * 16)|   


### PR DESCRIPTION
The document refered to CPU's for some of the calculations while in reality logical cpu's (cores + hyper threads) are used for the calculations. This makes a huge difference in todays high core CPU's 