### PR TITLE
Update monitoring-performance-by-using-the-query-store.md

### DIFF
--- a/docs/relational-databases/performance/monitoring-performance-by-using-the-query-store.md
+++ b/docs/relational-databases/performance/monitoring-performance-by-using-the-query-store.md
@@ -17,7 +17,7 @@ monikerRange: "=azuresqldb-current||>=sql-server-2016||>=sql-server-linux-2017||
 ---
 # Monitoring performance by using the Query Store
 
-[!INCLUDE [SQL Server ASDB, ASDBMI, ASDW ](../../includes/applies-to-version/sqlserver2016-asdb-asdbmi-asa.md)]
+[!INCLUDE [SQL Server ASDB, ASDBMI, ASA Dedicated Only](../../includes/applies-to-version/sqlserver2016-asdb-asdbmi-asa-dedicated-pool-only.md)]
 
 The [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] Query Store feature provides you with insight on query plan choice and performance. It simplifies performance troubleshooting by helping you quickly find performance differences caused by query plan changes. Query Store automatically captures a history of queries, plans, and runtime statistics, and retains these for your review. It separates data by time windows so you can see database usage patterns and understand when query plan changes happened on the server. You can configure query store using the [ALTER DATABASE SET](../../t-sql/statements/alter-database-transact-sql-set-options.md) option.
 
@@ -64,9 +64,6 @@ For more syntax options related to the Query Store, see [ALTER DATABASE SET Opti
 
 > [!IMPORTANT]
 > For information on enabling Query Store and keeping it adjusted to your workload, refer to [Best Practice with the Query Store](../../relational-databases/performance/best-practice-with-the-query-store.md#Configure).
-
-> [!NOTE]
-> Query Store cannot be enabled for the Azure Synapse Analytics Serverless SQL Pool.
 
 ## <a name="About"></a> Information in the Query Store
 

--- a/docs/relational-databases/performance/monitoring-performance-by-using-the-query-store.md
+++ b/docs/relational-databases/performance/monitoring-performance-by-using-the-query-store.md
@@ -65,6 +65,9 @@ For more syntax options related to the Query Store, see [ALTER DATABASE SET Opti
 > [!IMPORTANT]
 > For information on enabling Query Store and keeping it adjusted to your workload, refer to [Best Practice with the Query Store](../../relational-databases/performance/best-practice-with-the-query-store.md#Configure).
 
+> [!NOTE]
+> Query Store cannot be enabled for the Azure Synapse Analytics Serverless SQL Pool.
+
 ## <a name="About"></a> Information in the Query Store
 
 Execution plans for any specific query in [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] typically evolve over time due to a number of different reasons such as statistics changes, schema changes, creation/deletion of indexes, etc. The procedure cache (where cached query plans are stored) only stores the latest execution plan. Plans also get evicted from the plan cache due to memory pressure. As a result, query performance regressions caused by execution plan changes can be non-trivial and time consuming to resolve.


### PR DESCRIPTION
The document indicates its supported for "Azure Synapse Analytics", but it doesn't indicate which components.
Currently, the query store only available for Dedicated SQL Pool, but not to Serverless SQL Pool.
Since that making a confusion, I suggest to update this document that indicates this is not available for Serverless SQL Pool.