### PR TITLE
Update create-external-data-source-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/create-external-data-source-transact-sql.md
+++ b/docs/t-sql/statements/create-external-data-source-transact-sql.md
@@ -377,7 +377,7 @@ Specifies a database-scoped credential for authenticating to the external data s
 Additional notes and guidance when creating a credential:
 
 - `CREDENTIAL` is only required if the data has been secured. `CREDENTIAL` isn't required for data sets that allow anonymous access.
-- When the `TYPE` = `BLOB_STORAGE`, the credential must be created using `SHARED ACCESS SIGNATURE` as the identity. Furthermore, the SAS token should be configured as follows:
+- When the `TYPE` = `BLOB_STORAGE`, the credential may be created using `SHARED ACCESS SIGNATURE` or `Managed Identity` as the identity. Furthermore, if using `SHARED ACCESS SIGNATURE` the SAS token should be configured as follows:
   - Exclude the leading `?` when configured as the secret
   - Have at least read permission on the file that should be loaded (for example `srt=o&sp=r`)
   - Use a valid expiration period (all dates are in UTC time).


### PR DESCRIPTION
Currently the documentation states that when the external data source's TYPE = BLOB_STORAGE then a SHARED ACCESS SIGNATURE credential must be used, but after testing Managed Identity credential types work as well.