### PR TITLE
Update restore-database-options-page.md

### DIFF
--- a/docs/relational-databases/backup-restore/restore-database-options-page.md
+++ b/docs/relational-databases/backup-restore/restore-database-options-page.md
@@ -39,11 +39,16 @@ ms.author: kendralittle
 >  Use this option only after careful consideration. For more information, see [RESTORE Arguments &#40;Transact-SQL&#41;](../../t-sql/statements/restore-statements-arguments-transact-sql.md).  
   
  **Preserve the replication settings [WITH KEEP_REPLICATION]**  
- Preserves the replication settings when restoring a published database to a server other than the server where the database was created. This option is relevant only if the database was replicated when the backup was created.  
+ Preserves the replication settings when doing a restore using a backup file of a published database to a server other than the server where the database was created. This option is relevant only if the database was replicated when the backup was created.  
   
  This option is available only with the **Leave the database ready for use by rolling back the uncommitted transactions** option (described later in this table), which is equivalent to restoring a backup with the RECOVERY option.  
   
  Selecting this option is equivalent to using the KEEP_REPLICATION option in a [RESTORE](../../t-sql/statements/restore-statements-transact-sql.md) statement.  
+ 
+ When doing a restore using backup file of a published database to the same server where the database was created and with same database name, keep_replication is not needed.
+
+When running “restore with recovery” and not restoring from a backup file, add keep_replication switch to preserve replication settings.
+
   
  For more information, see [Back Up and Restore Replicated Databases](../../relational-databases/replication/administration/back-up-and-restore-replicated-databases.md).  
   

--- a/docs/relational-databases/backup-restore/restore-database-options-page.md
+++ b/docs/relational-databases/backup-restore/restore-database-options-page.md
@@ -45,7 +45,8 @@ ms.author: kendralittle
   
  Selecting this option is equivalent to using the KEEP_REPLICATION option in a [RESTORE](../../t-sql/statements/restore-statements-transact-sql.md) statement.  
  
- When doing a restore using backup file of a published database to the same server where the database was created and with same database name, keep_replication is not needed.
+ When doing a restore using a backup file of a published database to the same server where the database was created and with same database name, KEEP_REPLICATION is not needed.
+
 
 When running RESTORE WITH RECOVERY and not restoring from a backup file, add the KEEP_REPLICATION option to preserve replication settings.
 

--- a/docs/relational-databases/backup-restore/restore-database-options-page.md
+++ b/docs/relational-databases/backup-restore/restore-database-options-page.md
@@ -47,7 +47,8 @@ ms.author: kendralittle
  
  When doing a restore using backup file of a published database to the same server where the database was created and with same database name, keep_replication is not needed.
 
-When running “restore with recovery” and not restoring from a backup file, add keep_replication switch to preserve replication settings.
+When running RESTORE WITH RECOVERY and not restoring from a backup file, add the KEEP_REPLICATION option to preserve replication settings.
+
 
   
  For more information, see [Back Up and Restore Replicated Databases](../../relational-databases/replication/administration/back-up-and-restore-replicated-databases.md).  


### PR DESCRIPTION
Based on RFC 14743166 
request to change the following:

From:
Preserves the replication settings when restoring a published database to a server other than the server where the database was created. This option is relevant only if the database was replicated when the backup was created.
This option is available only with the Leave the database ready for use by rolling back the uncommitted transactions option (described later in this table), which is equivalent to restoring a backup with the RECOVERY option.
Selecting this option is equivalent to using the KEEP_REPLICATION option in a RESTORE statement.

To
Preserves the replication settings when doing a restore using a backup file of a published database to a server other than the server where the database was created. This option is relevant only if the database was replicated when the backup was created. This option is available only with the Leave the database ready for use by rolling back the uncommitted transactions option (described later in this table), which is equivalent to restoring a backup with the RECOVERY option.
Selecting this option is equivalent to using the KEEP_REPLICATION option in a RESTORE statement.

When doing a restore using backup file of a published database to the same server where the database was created and with same database name, keep_replication is not needed.

When running “restore with recovery” and not restoring from a backup file, add keep_replication switch to preserve replication settings.