### PR TITLE
Update hadr-cluster-best-practices.md

### DIFF
--- a/azure-sql/virtual-machines/windows/hadr-cluster-best-practices.md
+++ b/azure-sql/virtual-machines/windows/hadr-cluster-best-practices.md
@@ -262,7 +262,7 @@ Use Transact-SQL (T-SQL) to modify the **session timeout** for an availability g
 
 ```sql
 ALTER AVAILABILITY GROUP AG1
-MODIFY REPLICA ON 'INSTANCE01' WITH (SESSION_TIMEOUT = 15);
+MODIFY REPLICA ON 'INSTANCE01' WITH (SESSION_TIMEOUT = 20);
 ```
 
 **Max failures in specified period**


### PR DESCRIPTION
Customer brought this to my attention that we call out 20 seconds (20000 ms) for our relaxed monitoring, but then give T-SQL for 15 seconds.

My gut take on this is that common sense would win out here and you'd update the value based on what you feel is best, but that didn't happen on at least a case I've had. My opinion following this case is that this T-SQL example would be better if the value we provide is set to match the value we provide for relaxed monitoring so there's no confusion at all.