### PR TITLE
Fix for escaped JSON output example

### DIFF
--- a/docs/t-sql/functions/json-modify-transact-sql.md
+++ b/docs/t-sql/functions/json-modify-transact-sql.md
@@ -271,7 +271,7 @@ PRINT @info
     "skills": ["C#", "SQL"]
 } {
     "name": "John",
-    "skills": ["C#", "T-SQL", "Azure"]
+    "skills": "[\"C#\",\"T-SQL\",\"Azure\"]"
 }
 ```  
   


### PR DESCRIPTION
The JSON output example for 'Modify a JSON object' did not show the double quotes and the special characters were not escaped.