### PR TITLE
Update string-split-transact-sql.md

### DIFF
--- a/docs/t-sql/functions/string-split-transact-sql.md
+++ b/docs/t-sql/functions/string-split-transact-sql.md
@@ -95,7 +95,6 @@ In a practice run, the preceding SELECT returned following result table:
 |dolor|  
 |sit|  
 |amet.|  
-| &nbsp; |
 
 The following example enables the `ordinal` column by passing 1 for the optional third argument:  
 
@@ -112,7 +111,6 @@ This statement then returns the following result table:
 |dolor|3|  
 |sit|4|  
 |amet.|5|  
-| &nbsp; ||
 
 ## Examples  
   


### PR DESCRIPTION
Removed the extra blank line in the example results within 'Remarks' section. The extra blank line is not returned in the results so shouldn't be shown in the example.