### PR TITLE
Typo : syntax errors with print() function without () (Python3)

### DIFF
--- a/docs/connect/python/pymssql/step-3-proof-of-concept-connecting-to-sql-using-pymssql.md
+++ b/docs/connect/python/pymssql/step-3-proof-of-concept-connecting-to-sql-using-pymssql.md
@@ -39,7 +39,7 @@ The [cursor.execute](https://pypi.org/project/pymssql/) function can be used to 
     cursor.execute('SELECT c.CustomerID, c.CompanyName,COUNT(soh.SalesOrderID) AS OrderCount FROM SalesLT.Customer AS c LEFT OUTER JOIN SalesLT.SalesOrderHeader AS soh ON c.CustomerID = soh.CustomerID GROUP BY c.CustomerID, c.CompanyName ORDER BY OrderCount DESC;')  
     row = cursor.fetchone()  
     while row:  
-        print str(row[0]) + " " + str(row[1]) + " " + str(row[2])     
+        print(str(row[0]) + " " + str(row[1]) + " " + str(row[2]))     
         row = cursor.fetchone()  
 ```  
   
@@ -55,7 +55,7 @@ In this example you will see how to execute an [INSERT](../../../t-sql/statement
     cursor.execute("INSERT SalesLT.Product (Name, ProductNumber, StandardCost, ListPrice, SellStartDate) OUTPUT INSERTED.ProductID VALUES ('SQL Server Express', 'SQLEXPRESS', 0, 0, CURRENT_TIMESTAMP)")  
     row = cursor.fetchone()  
     while row:  
-        print "Inserted Product ID : " +str(row[0])  
+        print("Inserted Product ID : " +str(row[0]))
         row = cursor.fetchone()  
     conn.commit()
     conn.close()


### PR DESCRIPTION
Not having parenthesis make a syntax error.