### PR TITLE
Add WHERE to table_index syntax in CREATE TABLE

### DIFF
--- a/docs/t-sql/statements/create-table-transact-sql.md
+++ b/docs/t-sql/statements/create-table-transact-sql.md
@@ -207,6 +207,7 @@ column_set_name XML COLUMN_SET FOR ALL_SPARSE_COLUMNS
     | INDEX index_name CLUSTERED COLUMNSTORE
     | INDEX index_name [ NONCLUSTERED ] COLUMNSTORE ( column_name [ ,... n ] )
     }
+    [ WHERE <filter_predicate> ]
     [ WITH ( <index_option> [ ,... n ] ) ]
     [ ON { partition_scheme_name ( column_name )
          | filegroup_name


### PR DESCRIPTION
A "filtered index" can also be created inside a `CREATE TABLE` statement, however, the `WHERE` is omitted in the `table_index` section. I have added this with the same syntax as shown in [CREATE INDEX (Transact-SQL)](https://docs.microsoft.com/en-us/sql/t-sql/statements/create-index-transact-sql?view=sql-server-ver16): `[ WHERE <filter_predicate> ]` prior to the `WITH` clause of the `INDEX`.