### PR TITLE
Update alter-role-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/alter-role-transact-sql.md
+++ b/docs/t-sql/statements/alter-role-transact-sql.md
@@ -50,7 +50,7 @@ ALTER ROLE  role_name
   
  
 ```syntaxsql
--- Syntax for SQL Server 2008, Azure Synapse Analytics and Parallel Data Warehouse
+-- Syntax for SQL Server 2008, Azure Synapse Analytics Serverless SQL Pool and Parallel Data Warehouse
   
 -- Change the name of a user-defined database role  
 ALTER ROLE role_name   


### PR DESCRIPTION
ALTER ROLE only supported for Azure Synapse Analytics Serverless SQL Pool.
This is not mentioned in Syntax. (Since customers copy / paste the syntax from the public documents, this needs to be specified under syntax comments.