### PR TITLE
Update rename-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/rename-transact-sql.md
+++ b/docs/t-sql/statements/rename-transact-sql.md
@@ -19,7 +19,7 @@ monikerRange: ">= aps-pdw-2016 || = azure-sqldw-latest"
 Renames a user-created table in [!INCLUDE[ssSDW](../../includes/sssdw-md.md)]. Renames a user-created table, a column in a user-created table or database in [!INCLUDE[ssPDW](../../includes/sspdw-md.md)].
 
 > [!NOTE]
-> To rename a database in [!INCLUDE[ssSDW](../../includes/sssdw-md.md)], use [ALTER DATABASE ([!INCLUDE[ssSDW](../../includes/sssdwfull-md.md)])](alter-database-transact-sql.md?view=azure-sqldw-latest&preserve-view=true). To rename a database in Azure SQL Database, use the [ALTER DATABASE (Azure SQL Database)](alter-database-transact-sql.md?view=azuresqldb-mi-current&preserve-view=true) statement. To rename a database in [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)], use the stored procedure [sp_renamedb](../../relational-databases/system-stored-procedures/sp-renamedb-transact-sql.md).
+> To rename a database in Azure SQL Database, use the [ALTER DATABASE (Azure SQL Database)](alter-database-transact-sql.md?view=azuresqldb-mi-current&preserve-view=true) statement. To rename a database in [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)], use the stored procedure [sp_renamedb](../../relational-databases/system-stored-procedures/sp-renamedb-transact-sql.md).
 
 
 > [!NOTE]


### PR DESCRIPTION
"ALTER DATABASE" cannot be used to rename databases in Azure Synapse Analytics. 
Currently, Serverless SQL pool does not supported for "ALTER DATABASE MODIFY NAME" and SQL Dedicated Pools cannot be renamed. 
Test scenario is attached
[Test Scenario - Rename SQL Pools.docx](https://github.com/MicrosoftDocs/sql-docs/files/8817665/Test.Scenario.-.Rename.SQL.Pools.docx)
.