### PR TITLE
generate-series-transact-sql - Fix example description

### DIFF
--- a/docs/t-sql/functions/generate-series-transact-sql.md
+++ b/docs/t-sql/functions/generate-series-transact-sql.md
@@ -71,7 +71,7 @@ No permissions are required for `GENERATE_SERIES`; however, the user needs `EXEC
 
 The following examples demonstrate the syntax for calling `GENERATE_SERIES`.
 
-### A. Generate a series of integer values between 1 and 100 in increments of 1 (default)
+### A. Generate a series of integer values between 1 and 10 in increments of 1 (default)
 
 ```sql
 SELECT value


### PR DESCRIPTION
Example shows 10 but description 100. Fixed to 10.