### PR TITLE
Quote default in examples

### DIFF
--- a/docs/t-sql/database-console-commands/dbcc-freesystemcache-transact-sql.md
+++ b/docs/t-sql/database-console-commands/dbcc-freesystemcache-transact-sql.md
@@ -82,7 +82,7 @@ The following example illustrates how to clean caches that are dedicated to a sp
   
 ```sql
 -- Clean all the caches with entries specific to the resource pool named "default".  
-DBCC FREESYSTEMCACHE ('ALL', default);  
+DBCC FREESYSTEMCACHE ('ALL', [default]);  
 ```  
   
 ### B. Releasing entries from their respective caches after they become unused  


### PR DESCRIPTION
The default has to be quoted otherwise this error shows up
The keyword DEFAULT is not allowed in DBCC commands.