### PR TITLE
Fix Syntax error - copy in Elasticpool

### DIFF
--- a/azure-sql/database/database-copy.md
+++ b/azure-sql/database/database-copy.md
@@ -9,7 +9,7 @@ ms.topic: how-to
 author: rothja
 ms.author: jroth
 ms.reviewer: mathoma
-ms.date: 1/19/2022
+ms.date: 6/14/2022
 ---
 # Copy a transactionally consistent copy of a database in Azure SQL Database
 

--- a/azure-sql/database/database-copy.md
+++ b/azure-sql/database/database-copy.md
@@ -113,7 +113,7 @@ Database1 can be a single or pooled database. Copying between different tier poo
    -- Execute on the master database to start copying
    CREATE DATABASE Database2
    AS COPY OF Database1
-   (SERVICE_OBJECTIVE = ELASTIC_POOL( name = 'pool1' ) );
+   (SERVICE_OBJECTIVE = ELASTIC_POOL( name = pool1 ));
    ```
 
 ### Copy to a different server
@@ -134,7 +134,7 @@ Similarly, the below command copies Database1 on server1 to a new database named
 
 ```sql
 -- Execute on the master database of the target server (server2) to start copying from Server1 to Server2
-CREATE DATABASE Database2 AS COPY OF server1.Database1 (SERVICE_OBJECTIVE = ELASTIC_POOL( name = 'pool2' ) );
+CREATE DATABASE Database2 AS COPY OF server1.Database1 (SERVICE_OBJECTIVE = ELASTIC_POOL( name = pool2 ) );
 ```
 
 ### Copy to a different subscription


### PR DESCRIPTION
Fix syntax error. 
When copying to elastic pool the pool name should be as identifier and not as string 
therefore, I removed the ' from the pool name.