### PR TITLE
Update SQL Server versions to include 2022

### DIFF
--- a/docs/ssms/download-sql-server-management-studio-ssms-19.md
+++ b/docs/ssms/download-sql-server-management-studio-ssms-19.md
@@ -124,7 +124,7 @@ These components aren't uninstalled because they can be shared with other produc
 
 ## Supported SQL offerings
 
-- This version of SSMS works with all [supported versions of SQL Server 2008 - SQL Server 2019](../sql-server/end-of-support/sql-server-end-of-support-overview.md) and provides the greatest level of support for working with the latest cloud features in Azure SQL Database and Azure Synapse Analytics.
+- This version of SSMS works with all [supported versions of SQL Server 2008 - SQL Server 2022](../sql-server/end-of-support/sql-server-end-of-support-overview.md) and provides the greatest level of support for working with the latest cloud features in Azure SQL Database and Azure Synapse Analytics.
 - Additionally, SSMS 19 (Preview) can be installed side by side with SSMS 18.x, 17.x, SSMS 16.x, or SQL Server 2014 SSMS and earlier.
 - SQL Server Integration Services (SSIS) - SSMS version 17.x or later doesn't support connecting to the legacy SQL Server Integration Services service. To connect to an earlier version of the legacy Integration Services, use the version of SSMS aligned with the version of SQL Server. For example, use SSMS 16.x to connect to the legacy SQL Server 2016 Integration Services service. SSMS 17.x and SSMS 16.x can be installed side by side on the same computer. Since the release of SQL Server 2012, the SSIS Catalog database, SSISDB, is the recommended way to store, manage, run, and monitor Integration Services packages. For details, see [SSIS Catalog](../integration-services/catalog/ssis-catalog.md).
 


### PR DESCRIPTION
Updating documentation to let readers know that SSMS 19 can work with SQL Server 2022.