### PR TITLE
Update open-a-template.md

### DIFF
--- a/docs/ssms/template/open-a-template.md
+++ b/docs/ssms/template/open-a-template.md
@@ -34,7 +34,7 @@ You can open templates from the Template Explorer.
   
     3.  Drag the template into a code editor window to add the template code to the contents of the editor window.  
   
-After the template is open, use the **Replace Template Parameters** dialog box to replace the template parameters with your values.  
+After the template is open, use the **Specify Values for Template Parameters** dialog box from the **Query** menu to replace the template parameters with your values.  
   
 If opening a template launches a new editor window, the window will open with the credentials of the current active connection. For example, if you are focused on an instance of the [!INCLUDE[ssDE](../../includes/ssde_md.md)] in Object Explorer when you open the CREATE DATABASE template, a new editor window will be opened using a connection to that instance. If there is no active connection, [!INCLUDE[ssManStudio](../../includes/ssmanstudio-md.md)] will present a login dialog.  
   


### PR DESCRIPTION
Document states that to use the 'Replace Template Parameters' dialog box instead of 'Specify Values for Template Parameters' dialog box.