### PR TITLE
Nondeterminism of STRING_SPLIT

### DIFF
--- a/docs/t-sql/functions/string-functions-transact-sql.md
+++ b/docs/t-sql/functions/string-functions-transact-sql.md
@@ -145,7 +145,7 @@ The following scalar functions perform an operation on a string input value and 
 :::row-end:::
 
   
- All built-in string functions except `FORMAT` are deterministic. This means they return the same value any time they are called with a specific set of input values. For more information about function determinism, see [Deterministic and Nondeterministic Functions](../../relational-databases/user-defined-functions/deterministic-and-nondeterministic-functions.md).  
+ All built-in string functions except `FORMAT` and `STRING_SPLIT` are deterministic. This means they return the same value any time they are called with a specific set of input values. For more information about function determinism, see [Deterministic and Nondeterministic Functions](../../relational-databases/user-defined-functions/deterministic-and-nondeterministic-functions.md).  
   
  When string functions are passed arguments that are not string values, the input type is implicitly converted to a text data type. For more information, see [Data Type Conversion &#40;Database Engine&#41;](../../t-sql/data-types/data-type-conversion-database-engine.md).  
   


### PR DESCRIPTION
In [this commit](https://github.com/MicrosoftDocs/sql-docs/commit/f12ff508b69db557347846748ef7f92a62905ddc), the output of `STRING_SPLIT` was clarified to be nondeterministic:

> The output rows might be in any order.

However, `string-functions-transact-sql.md` has not been updated and currently suggests that `STRING_SPLIT` is deterministic:

> All built-in string functions except `FORMAT` are deterministic.

This change simply updates the statement to read instead

> All built-in string functions except `FORMAT` and `STRING_SPLIT` are deterministic.