### PR TITLE
Fix the F1 keywords

### DIFF
--- a/docs/relational-databases/system-catalog-views/sys-database-query-store-internal-state-transact-sql.md
+++ b/docs/relational-databases/system-catalog-views/sys-database-query-store-internal-state-transact-sql.md
@@ -10,10 +10,10 @@ ms.technology: system-objects
 ms.topic: "reference"
 ms.custom: event-tier1-build-2022
 f1_keywords:
-  - "QUERY_STORE_QUERY"
-  - "SYS.QUERY_STORE_QUERY_TSQL"
-  - "SYS.QUERY_STORE_QUERY"
-  - "QUERY_STORE_QUERY_TSQL"
+  - "QUERY_STORE_INTERNAL_STATE"
+  - "SYS.QUERY_STORE_INTERNAL_STATE_TSQL"
+  - "SYS.QUERY_STORE_INTERNAL_STATE"
+  - "QUERY_STORE_INTERNAL_STATE_TSQL"
 helpviewer_keywords:
   - "query_store_query catalog view"
   - "sys.query_store_query catalog view"


### PR DESCRIPTION
Currently, F1 from sys.query_store_query DMV leads to this page instead of the correct one.