### PR TITLE
Update sql-agent-extension-automatic-registration-all-vms.md

### DIFF
--- a/azure-sql/virtual-machines/windows/sql-agent-extension-automatic-registration-all-vms.md
+++ b/azure-sql/virtual-machines/windows/sql-agent-extension-automatic-registration-all-vms.md
@@ -27,7 +27,7 @@ This article teaches you to enable the automatic registration feature. Alternati
 
 Registering your SQL Server VM with the [SQL IaaS Agent extension](sql-server-iaas-agent-extension-automate-management.md) to unlock a full feature set of benefits. 
 
-When automatic registration is enabled, a job runs daily to detect whether or not SQL Server is installed on all the unregistered VMs in the subscription. This is done by copying the SQL IaaS agent extension binaries to the VM, then running a one-time utility that checks for the SQL Server registry hive. If the SQL Server hive is detected, the virtual machine is registered with the  extension in lightweight mode. If no SQL Server hive exists in the registry, the binaries are removed. Automatic registration can take up to 4 days to detect newly created SQL Server VMs.
+When automatic registration is enabled, a job runs monthly to detect whether or not SQL Server is installed on all the unregistered VMs in the subscription. This is done by copying the SQL IaaS agent extension binaries to the VM, then running a one-time utility that checks for the SQL Server registry hive. If the SQL Server hive is detected, the virtual machine is registered with the  extension in lightweight mode. If no SQL Server hive exists in the registry, the binaries are removed. 
 
 > [!CAUTION]
 > If the SQL Server hive is not present in the registry, removing the binaries might be impacted if there are [resource locks](/azure/governance/blueprints/concepts/resource-locking#locking-modes-and-states) in place. 


### PR DESCRIPTION
Discussing with Abdullah Mamun on this subject - the job doesn't run daily. It runs monthly. 

With that in mind, the documentation should reflect this, and the line below:

Automatic registration can take up to 4 days to detect newly created SQL Server VMs.

I doubt we can say that it will only take 4 days to pick up a VM with SQL Server installed. The process could take up to 30 depending on when SQL is installed, and when the job runs. 

Currently working a case now where this is the focus of the customer's issue, and again - if the job doesn't run daily, we can't have this out in the ether.