### PR TITLE
Mistake with Randomized / Deterministic values

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-describe-parameter-encryption-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-describe-parameter-encryption-transact-sql.md
@@ -77,7 +77,7 @@ sp_describe_parameter_encryption
 |**parameter_ordinal**|**int**|Id of the row in the result set.|  
 |**parameter_name**|**sysname**|Name of one of the parameters specified in the *\@params* argument.|  
 |**column_encryption_algorithm**|**tinyint**|Code indicating the encryption algorithm configured for the column, the parameter corresponds to. The currently supported values are: 2 for **AEAD_AES_256_CBC_HMAC_SHA_256**.|  
-|**column_encryption_type**|**tinyint**|Code indicating the encryption type configured for the column, the parameter corresponds to. The supported values are:<br /><br /> 0 - plaintext (the column is not encrypted)<br /><br /> 1 - randomized encryption<br /><br /> 2 - deterministic encryption.|  
+|**column_encryption_type**|**tinyint**|Code indicating the encryption type configured for the column, the parameter corresponds to. The supported values are:<br /><br /> 0 - plaintext (the column is not encrypted)<br /><br /> 1 - deterministic encryption<br /><br /> 2 - randomized encryption.|  
 |**column_encryption_key_ordinal**|**int**|Code of the row in the first result set. The referenced row describes the column encryption key configured for the column, the parameter corresponds to.|  
 |**column_encryption_normalization_rule_version**|**tinyint**|Version number of the type normalization algorithm.|  
   


### PR DESCRIPTION
This typo led to a bug in SQL Server JDBC-driver 10.2.

Here is the proof of what SQL Server actually returns:
![image](https://user-images.githubusercontent.com/13791336/175398524-dc267a4c-1501-4e85-93f3-473afc6840ec.png)
