### PR TITLE
Fix typo in database truncation overview script

### DIFF
--- a/docs/relational-databases/logs/troubleshoot-a-full-transaction-log-sql-server-error-9002.md
+++ b/docs/relational-databases/logs/troubleshoot-a-full-transaction-log-sql-server-error-9002.md
@@ -166,7 +166,7 @@ SELECT * FROM #CannotTruncateLog_Db
 
 
 DECLARE no_truncate_db CURSOR FOR
-    SELECT log_reuse_wait, log_reuse_wait_desc, dbname, database_id, recovery_model_desc FROM #CannotTruncateLog_Db;
+    SELECT log_reuse_wait, log_reuse_wait_desc, @dbname, database_id, recovery_model_desc FROM #CannotTruncateLog_Db;
 
 
 OPEN no_truncate_db


### PR DESCRIPTION
Missing `@` in `@dbname` preventing execution in line 91