### PR TITLE
Correct TrustServerCertificate keyword

### DIFF
--- a/docs/connect/ado-net/sqlclient-troubleshooting-guide.md
+++ b/docs/connect/ado-net/sqlclient-troubleshooting-guide.md
@@ -158,7 +158,7 @@ at Microsoft.Data.SqlClient.SqlInternalConnection.OnError(SqlException exception
   **Recommended Solution:** There are two available options to fix this issue:
 
     1. Install the target SQL Server's TLS/SSL certificate in the client environment. It will be validated if encryption is needed.
-    2. Set the "Trust Server Certificate = true" property in the connection string.
+    2. Set the "TrustServerCertificate=true" property in the connection string.
 
   **Insecure solution:** Disable the "Force Encryption" setting on SQL Server.
 


### PR DESCRIPTION
Corrects the connection string keyword from "Trust Server Certificate" to "TrustServerCertificate" as per
https://docs.microsoft.com/en-us/dotnet/framework/data/adonet/connection-string-syntax#using-trustservercertificate.