### PR TITLE
Fix shown result of Replace example

### DIFF
--- a/docs/t-sql/functions/replace-transact-sql.md
+++ b/docs/t-sql/functions/replace-transact-sql.md
@@ -110,7 +110,7 @@ GO
   
 ```  
 ------------  
-Number of spaces in the sentence: 8  
+Number of spaces in the sentence: 7  
 
 (1 row(s) affected)  
 ```  


### PR DESCRIPTION
Running the example gives another result than is shown. It's actually 7, not 8.