### PR TITLE
Add information that we need forced failover on AG side after Forced …

### DIFF
--- a/docs/sql-server/failover-clusters/windows/wsfc-disaster-recovery-through-forced-quorum-sql-server.md
+++ b/docs/sql-server/failover-clusters/windows/wsfc-disaster-recovery-through-forced-quorum-sql-server.md
@@ -86,7 +86,7 @@ ms.author: mathoma
      You can minimize potential data loss and recovery time for the availability group replicas by bringing them back online in this sequence:  primary replica, synchronous secondary replicas, asynchronous secondary replicas.  
      
    >[!NOTE]
-   >After using forced quorum it is necessary to perform a forced failover with possible data loss to bring the availability group back online. For more information, review [Perform a forced manual failover of an availability group &#40;SQL Server&#41;](../../../database-engine/availability-groups/windows/perform-a-forced-manual-failover-of-an-availability-group-sql-server.md).
+   > After using forced quorum it is necessary to perform a forced failover with possible data loss to bring the availability group back online. For more information, review [Perform a forced manual failover of an availability group &#40;SQL Server&#41;](../../../database-engine/availability-groups/windows/perform-a-forced-manual-failover-of-an-availability-group-sql-server.md).
   
 6.  **Repair or replace failed components and re-validate cluster.** Now that you have recovered from the initial disaster and quorum failure, you should repair or replace the failed nodes and adjust related WSFC and Always On configurations accordingly.  This can include dropping availability group replicas, evicting nodes from the cluster, or flattening and re-installing software on a node.  
   

--- a/docs/sql-server/failover-clusters/windows/wsfc-disaster-recovery-through-forced-quorum-sql-server.md
+++ b/docs/sql-server/failover-clusters/windows/wsfc-disaster-recovery-through-forced-quorum-sql-server.md
@@ -84,6 +84,8 @@ ms.author: mathoma
 5.  **Recover availability group database replicas as needed.** Non-availability group databases should recover and come back online on their own as part of the regular SQL Server startup process.  
   
      You can minimize potential data loss and recovery time for the availability group replicas by bringing them back online in this sequence:  primary replica, synchronous secondary replicas, asynchronous secondary replicas.  
+     
+     Note that after using Forced Quorum it is necessary to perform a Forced Failover with possible data loss to bring the Availability Group back online. For more information, see [Perform a Forced Manual Failover of an Availability Group &#40;SQL Server&#41;](../../../database-engine/availability-groups/windows/perform-a-forced-manual-failover-of-an-availability-group-sql-server.md) 
   
 6.  **Repair or replace failed components and re-validate cluster.** Now that you have recovered from the initial disaster and quorum failure, you should repair or replace the failed nodes and adjust related WSFC and Always On configurations accordingly.  This can include dropping availability group replicas, evicting nodes from the cluster, or flattening and re-installing software on a node.  
   

--- a/docs/sql-server/failover-clusters/windows/wsfc-disaster-recovery-through-forced-quorum-sql-server.md
+++ b/docs/sql-server/failover-clusters/windows/wsfc-disaster-recovery-through-forced-quorum-sql-server.md
@@ -85,7 +85,8 @@ ms.author: mathoma
   
      You can minimize potential data loss and recovery time for the availability group replicas by bringing them back online in this sequence:  primary replica, synchronous secondary replicas, asynchronous secondary replicas.  
      
-     Note that after using Forced Quorum it is necessary to perform a Forced Failover with possible data loss to bring the Availability Group back online. For more information, see [Perform a Forced Manual Failover of an Availability Group &#40;SQL Server&#41;](../../../database-engine/availability-groups/windows/perform-a-forced-manual-failover-of-an-availability-group-sql-server.md) 
+>[!NOTE]
+>After using forced quorum it is necessary to perform a forced failover with possible data loss to bring the availability group back online. For more information, review [Perform a forced manual failover of an availability group &#40;SQL Server&#41;](../../../database-engine/availability-groups/windows/perform-a-forced-manual-failover-of-an-availability-group-sql-server.md).
   
 6.  **Repair or replace failed components and re-validate cluster.** Now that you have recovered from the initial disaster and quorum failure, you should repair or replace the failed nodes and adjust related WSFC and Always On configurations accordingly.  This can include dropping availability group replicas, evicting nodes from the cluster, or flattening and re-installing software on a node.  
   

--- a/docs/sql-server/failover-clusters/windows/wsfc-disaster-recovery-through-forced-quorum-sql-server.md
+++ b/docs/sql-server/failover-clusters/windows/wsfc-disaster-recovery-through-forced-quorum-sql-server.md
@@ -85,8 +85,8 @@ ms.author: mathoma
   
      You can minimize potential data loss and recovery time for the availability group replicas by bringing them back online in this sequence:  primary replica, synchronous secondary replicas, asynchronous secondary replicas.  
      
->[!NOTE]
->After using forced quorum it is necessary to perform a forced failover with possible data loss to bring the availability group back online. For more information, review [Perform a forced manual failover of an availability group &#40;SQL Server&#41;](../../../database-engine/availability-groups/windows/perform-a-forced-manual-failover-of-an-availability-group-sql-server.md).
+   >[!NOTE]
+   >After using forced quorum it is necessary to perform a forced failover with possible data loss to bring the availability group back online. For more information, review [Perform a forced manual failover of an availability group &#40;SQL Server&#41;](../../../database-engine/availability-groups/windows/perform-a-forced-manual-failover-of-an-availability-group-sql-server.md).
   
 6.  **Repair or replace failed components and re-validate cluster.** Now that you have recovered from the initial disaster and quorum failure, you should repair or replace the failed nodes and adjust related WSFC and Always On configurations accordingly.  This can include dropping availability group replicas, evicting nodes from the cluster, or flattening and re-installing software on a node.  
   

--- a/docs/sql-server/failover-clusters/windows/wsfc-disaster-recovery-through-forced-quorum-sql-server.md
+++ b/docs/sql-server/failover-clusters/windows/wsfc-disaster-recovery-through-forced-quorum-sql-server.md
@@ -85,7 +85,7 @@ ms.author: mathoma
   
      You can minimize potential data loss and recovery time for the availability group replicas by bringing them back online in this sequence:  primary replica, synchronous secondary replicas, asynchronous secondary replicas.  
      
-   >[!NOTE]
+   > [!NOTE]
    > After using forced quorum it is necessary to perform a forced failover with possible data loss to bring the availability group back online. For more information, review [Perform a forced manual failover of an availability group &#40;SQL Server&#41;](../../../database-engine/availability-groups/windows/perform-a-forced-manual-failover-of-an-availability-group-sql-server.md).
   
 6.  **Repair or replace failed components and re-validate cluster.** Now that you have recovered from the initial disaster and quorum failure, you should repair or replace the failed nodes and adjust related WSFC and Always On configurations accordingly.  This can include dropping availability group replicas, evicting nodes from the cluster, or flattening and re-installing software on a node.  


### PR DESCRIPTION
…Quorum was used

This article is not clear enough, we need to clearly state that after we used forced quorum, forced failover is necessary on AG side to bring the group back to usable state -  as described in the https://docs.microsoft.com/en-us/sql/database-engine/availability-groups/windows/perform-a-forced-manual-failover-of-an-availability-group-sql-server?view=sql-server-ver16&source=docs article:
After forcing quorum on the WSFC cluster (forced quorum), you need to force failover each availability group (with possible data loss). Forcing failover is required because the real state of the WSFC cluster values might have been lost. However, you can avoid data loss, if are able to force failover on the server instance that was hosting the replica that was the primary replica before you forced quorum or to a secondary replica that was synchronized before you forced quorum.