### PR TITLE
Updating TSQL difference doc now that Machine Learning Services is su…

### DIFF
--- a/azure-sql/managed-instance/transact-sql-tsql-differences-sql-server.md
+++ b/azure-sql/managed-instance/transact-sql-tsql-differences-sql-server.md
@@ -487,7 +487,6 @@ Service broker is enabled by default and cannot be disabled. The following ALTER
   - `scan for startup procs`
 - The following [sp_configure](/sql/relational-databases/system-stored-procedures/sp-configure-transact-sql) options are ignored and have no effect: 
   - `Ole Automation Procedures`
-- `sp_execute_external_scripts` isn't supported. See [sp_execute_external_scripts](/sql/relational-databases/system-stored-procedures/sp-execute-external-script-transact-sql#examples).
 - `xp_cmdshell` isn't supported. See [xp_cmdshell](/sql/relational-databases/system-stored-procedures/xp-cmdshell-transact-sql).
 - `Extended stored procedures` aren't supported, and this includes `sp_addextendedproc` and `sp_dropextendedproc`. This functionality won't be supported because it's on a deprecation path for SQL Server. For more information, see [Extended Stored Procedures](/sql/relational-databases/extended-stored-procedures-programming/database-engine-extended-stored-procedures-programming).
 - `sp_attach_db`, `sp_attach_single_file_db`, and `sp_detach_db` aren't supported. See [sp_attach_db](/sql/relational-databases/system-stored-procedures/sp-attach-db-transact-sql), [sp_attach_single_file_db](/sql/relational-databases/system-stored-procedures/sp-attach-single-file-db-transact-sql), and [sp_detach_db](/sql/relational-databases/system-stored-procedures/sp-detach-db-transact-sql).


### PR DESCRIPTION
…pported

Both these docs correctly indicate that sp_execute_external_script is supported

https://docs.microsoft.com/en-us/azure/azure-sql/managed-instance/machine-learning-services-overview?view=azuresql
https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-execute-external-script-transact-sql?view=sql-server-ver16#examples