### PR TITLE
Adjust wording for user_type_id

### DIFF
--- a/docs/relational-databases/system-catalog-views/sys-types-transact-sql.md
+++ b/docs/relational-databases/system-catalog-views/sys-types-transact-sql.md
@@ -30,7 +30,7 @@ monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-s
 |-----------------|---------------|-----------------|  
 |**name**|**sysname**|Name of the type. Is unique within the schema.|  
 |**system_type_id**|**tinyint**|ID of the internal system-type of the type.|  
-|**user_type_id**|**int**|ID of the type. Is unique within the database. For system data types, **user_type_id** = **system_type_id**.|  
+|**user_type_id**|**int**|ID of the type. Is unique within the database. For most system data types, **user_type_id** = **system_type_id**.|  
 |**schema_id**|**int**|ID of the schema to which the type belongs.|  
 |**principal_id**|**int**|ID of the individual owner if different from schema owner. By default, schema-contained objects are owned by the schema owner. However, an alternate owner can be specified by using the ALTER AUTHORIZATION statement to change ownership.<br /><br /> NULL if there is no alternate individual owner.|  
 |**max_length**|**smallint**|Maximum length (in bytes) of the type.<br /><br /> -1 = Column data type is **varchar(max)**, **nvarchar(max)**, **varbinary(max)**, or **xml**.<br /><br /> For **text** columns, the **max_length** value will be 16.|  


### PR DESCRIPTION
What's a system data type? 
The **is_user_defined** column seems to define it as types that are not user defined. In other words, any type shipped by Microsoft. 
But there are a few system types where **system_type_id** <> **user_type_id**, specifically **hierarchyid**, **geometry**, **geography**, and **sysname**

So it's a mistake to say 
> For system data types, **user_type_id** = **system_type_id**.

(A colleague used `user_type_id = system_type_id` as a filter when they really wanted `is_user_defined = 0`)