### PR TITLE
Changing Linux CA folder location

### DIFF
--- a/docs/relational-databases/backup-restore/sql-server-backup-to-url-s3-compatible-object-storage.md
+++ b/docs/relational-databases/backup-restore/sql-server-backup-to-url-s3-compatible-object-storage.md
@@ -185,7 +185,7 @@ For more information see [SQL Server back up to URL for S3-compatible storage be
 
 ### Linux support
 
-SQL Server uses `WinHttp` to implement client of HTTP REST APIs it uses. It relies on OS certificate store for validations of the TLS certificates being presented by HTTP(s) endpoint. However, SQL Server on Linux the CA must be placed on a predefined location to be created at `/usr/local/share/ca-certificates/mssql-ca-certificates`, only the first 50 certificates can be stored and supported in this folder.
+SQL Server uses `WinHttp` to implement client of HTTP REST APIs it uses. It relies on OS certificate store for validations of the TLS certificates being presented by HTTP(s) endpoint. However, SQL Server on Linux the CA must be placed on a predefined location to be created at `/var/opt/mssql/security/ca-certificates`, only the first 50 certificates can be stored and supported in this folder.
 
 SQL Server will read the certificates from the folder during startup and add them to the trust store.
 


### PR DESCRIPTION
As a CTP 2.1 improvement we changed the path of Linux CA location to /var/opt/mssql/security/ca-certificates this way it is easier for container SQL to persist and reuse the CA.