### PR TITLE
Update mssqlserver-17892-database-engine-error.md

### DIFF
--- a/docs/relational-databases/errors-events/mssqlserver-17892-database-engine-error.md
+++ b/docs/relational-databases/errors-events/mssqlserver-17892-database-engine-error.md
@@ -39,7 +39,7 @@ Logon failed for login \<Login Name> due to trigger execution.
 
 The problem could occur if there is an error when executing trigger code for that specific user account. Some of the scenarios include:
 
-- The trigger tires to insert data into a table that does not exist.
+- The trigger tries to insert data into a table that does not exist.
 - The login does not have permissions to the object that is referred to by the logon trigger.
 
 ## User action


### PR DESCRIPTION
Spelling error changing "tires" to "tries"