### PR TITLE
fix 'AdventureWorks' typo

### DIFF
--- a/docs/relational-databases/indexes/create-nonclustered-indexes.md
+++ b/docs/relational-databases/indexes/create-nonclustered-indexes.md
@@ -92,7 +92,7 @@ You can create nonclustered indexes in [!INCLUDE[ssnoversion](../../includes/ssn
   
 #### To create a nonclustered index on a table  
   
-1.  In **Object Explorer**, connect to an instance of [!INCLUDE[ssDE](../../includes/ssde-md.md)] with AdventurWorks2019 installed. See [AdventureWorks sample databases](../../samples/adventureworks-install-configure.md?view=sql-server-ver15&tabs=ssms&preserve-view=true) to download AdventureWorks2019.
+1.  In **Object Explorer**, connect to an instance of [!INCLUDE[ssDE](../../includes/ssde-md.md)] with AdventureWorks2019 installed. See [AdventureWorks sample databases](../../samples/adventureworks-install-configure.md?view=sql-server-ver15&tabs=ssms&preserve-view=true) to download AdventureWorks2019.
 2.  On the Standard bar, click **New Query**.  
   
 3.  Copy and paste the following example into the query window and click **Execute**.  


### PR DESCRIPTION
Fixed a typo in the documentation that referenced the 'AdventureWorks' database.