### PR TITLE
Updating 'language' from 'Python' to 'myPython'

### DIFF
--- a/docs/machine-learning/install/custom-runtime-python.md
+++ b/docs/machine-learning/install/custom-runtime-python.md
@@ -75,7 +75,7 @@ Use the following SQL script to verify the installation and functionality of the
 
 ```sql
 EXEC sp_execute_external_script
-@language =N'Python',
+@language =N'myPython',
 @script=N'
 import sys
 print(sys.path)


### PR DESCRIPTION
Updating 'Python' to 'myPython', to be consistent with there rest of the documentation, as 'Python' is reserved for the version we provide and not BYOR.