### PR TITLE
Updating language in sample code from 'R' to 'myR'

### DIFF
--- a/docs/machine-learning/install/custom-runtime-r.md
+++ b/docs/machine-learning/install/custom-runtime-r.md
@@ -76,7 +76,7 @@ Use the following SQL script to verify the installation and functionality of the
 
 ```sql
 EXEC sp_execute_external_script
-    @language =N'R',
+    @language =N'myR',
     @script=N'
 print(R.home());
 print(file.path(R.home("bin"), "R"));


### PR DESCRIPTION
Updating language in sample code from 'R' to 'myR' to be consistent with the rest of the documentation. R is reserved for the one we provide, and not BYOR.