### PR TITLE
Added note for private endpoint limitations

### DIFF
--- a/azure-sql/database/connectivity-architecture.md
+++ b/azure-sql/database/connectivity-architecture.md
@@ -48,6 +48,9 @@ Servers in SQL Database and Azure Synapse support the following three options fo
 
 We highly recommend the `Redirect` connection policy over the `Proxy` connection policy for the lowest latency and highest throughput. However, you will need to meet the additional requirements for allowing network traffic as outlined above. If the client is an Azure Virtual Machine, you can accomplish this using Network Security Groups (NSG) with [service tags](/azure/virtual-network/network-security-groups-overview#service-tags). If the client is connecting from a workstation on-premises then you may need to work with your network admin to allow network traffic through your corporate firewall.
 
+> [!IMPORTANT]
+> Connections to private endpoint only support **Proxy** as the [connection policy](connectivity-architecture.md#connection-policy)
+
 ## Connectivity from within Azure
 
 If you are connecting from within Azure your connections have a connection policy of `Redirect` by default. A policy of `Redirect` means that after the TCP session is established to Azure SQL Database, the client session is then redirected to the right database cluster with a change to the destination virtual IP from that of the Azure SQL Database gateway to that of the cluster. Thereafter, all subsequent packets flow directly to the cluster, bypassing the Azure SQL Database gateway. The following diagram illustrates this traffic flow.

--- a/azure-sql/database/connectivity-architecture.md
+++ b/azure-sql/database/connectivity-architecture.md
@@ -49,7 +49,7 @@ Servers in SQL Database and Azure Synapse support the following three options fo
 We highly recommend the `Redirect` connection policy over the `Proxy` connection policy for the lowest latency and highest throughput. However, you will need to meet the additional requirements for allowing network traffic as outlined above. If the client is an Azure Virtual Machine, you can accomplish this using Network Security Groups (NSG) with [service tags](/azure/virtual-network/network-security-groups-overview#service-tags). If the client is connecting from a workstation on-premises then you may need to work with your network admin to allow network traffic through your corporate firewall.
 
 > [!IMPORTANT]
-> Connections to private endpoint only support **Proxy** as the [connection policy](connectivity-architecture.md#connection-policy)
+> Connections to private endpoint only support **Proxy** as the [connection policy](connectivity-architecture.md#connection-policy).
 
 ## Connectivity from within Azure
 


### PR DESCRIPTION
Added a note for private endpoint limitations on connection policy as it is mentioned here https://docs.microsoft.com/en-us/azure/azure-sql/database/private-endpoint-overview?view=azuresql#limitations, otherwise it is assumed that you can use any of them independently if you use private link or not. 