### PR TITLE
Update source_table to source_object

### DIFF
--- a/docs/relational-databases/replication/codesnippet/tsql/administer-a-peer-to-pee_3.sql
+++ b/docs/relational-databases/replication/codesnippet/tsql/administer-a-peer-to-pee_3.sql
@@ -9,7 +9,7 @@ USE AdventureWorks2012
 EXEC sp_addarticle 
   @publication = @publication,
   @article = @newtable,
-  @source_table = @newtable,
+  @source_object = @newtable,
   @destination_table = @newtable,
   @force_invalidate_snapshot = 0;
 GO


### PR DESCRIPTION
If you try to use the code provided, you get error 21827 as below. Source_object needs to be used instead.

Msg 21827, Level 16, State 1, Procedure sys.sp_MSrepl_addarticle, Line 286 [Batch Start Line 6]
The @source_table parameters have been deprecated and should no longer be used. For more information, see the 'sp_addarticle' documentation.