### PR TITLE
Update availability-group-distributed-network-name-dnn-listener-confi…

### DIFF
--- a/azure-sql/virtual-machines/windows/availability-group-distributed-network-name-dnn-listener-configure.md
+++ b/azure-sql/virtual-machines/windows/availability-group-distributed-network-name-dnn-listener-configure.md
@@ -144,7 +144,7 @@ Update the connection string for any application that needs to connect to the DN
 
 The following is an example of a connection string for listener name **DNN_Listener** and port 6789: 
 
-`DataSource=DNN_Listener,6789,MultiSubnetFailover=True`
+`DataSource=DNN_Listener,6789;MultiSubnetFailover=True`
 
 ## Test failover
 


### PR DESCRIPTION
…gure.md

`MultiSubnetFailover` is its own property in the connection string, and cannot be added comma separated to the `DataSource` property.