### PR TITLE
Update the reverse migration limitations

### DIFF
--- a/azure-sql/database/manage-hyperscale-database.md
+++ b/azure-sql/database/manage-hyperscale-database.md
@@ -126,7 +126,7 @@ Reverse migration is available under the following conditions:
 - Reverse migration is only available within 45 days of the original migration to Hyperscale.
 - Databases originally created in the Hyperscale service tier are not eligible for reverse migration.
 - You may reverse migrate to the [General Purpose](service-tier-general-purpose.md) service tier only. Your migration from Hyperscale to General Purpose can target either the serverless or provisioned compute tiers. If you wish to migrate the database to another service tier, such as [Business Critical](service-tier-business-critical.md) or a [DTU based service tier](service-tiers-dtu.md), first reverse migrate to the General Purpose service tier, then change the service tier.
-- Direct reverse Migration to Elastic pools in General Purpose tier are not supported. If you wish to migrate your Hyperscale database to an Elastic Pool, first migrate it to General purpose tier and then move it to the target elastic pool. 
+- Direct reverse migration to an elastic pool is not supported. If you wish to migrate your Hyperscale database to an elastic pool, first migrate it to a General Purpose single database, and then move this database to the target elastic pool. 
 
 ### Duration and downtime
 

--- a/azure-sql/database/manage-hyperscale-database.md
+++ b/azure-sql/database/manage-hyperscale-database.md
@@ -126,6 +126,7 @@ Reverse migration is available under the following conditions:
 - Reverse migration is only available within 45 days of the original migration to Hyperscale.
 - Databases originally created in the Hyperscale service tier are not eligible for reverse migration.
 - You may reverse migrate to the [General Purpose](service-tier-general-purpose.md) service tier only. Your migration from Hyperscale to General Purpose can target either the serverless or provisioned compute tiers. If you wish to migrate the database to another service tier, such as [Business Critical](service-tier-business-critical.md) or a [DTU based service tier](service-tiers-dtu.md), first reverse migrate to the General Purpose service tier, then change the service tier.
+- Direct reverse Migration to Elastic pools in General Purpose tier are not supported. If you wish to migrate your Hyperscale database to an Elastic Pool, first migrate it to General purpose tier and then move it to the target elastic pool. 
 
 ### Duration and downtime
 


### PR DESCRIPTION
Direct reverse Migration to Elastic pools in General Purpose tier are not supported. If you wish to migrate your Hyperscale database to an Elastic Pool, first migrate it to General purpose tier and then move it to the target elastic pool.