### PR TITLE
added [ CONSTRAINT constraint_name ] to NULL|NOT NULL constraint

### DIFF
--- a/docs/t-sql/statements/create-table-transact-sql.md
+++ b/docs/t-sql/statements/create-table-transact-sql.md
@@ -105,7 +105,7 @@ column_name <data_type>
     [ IDENTITY [ ( seed , increment ) ]
     [ NOT FOR REPLICATION ]
     [ GENERATED ALWAYS AS { ROW | TRANSACTION_ID | SEQUENCE_NUMBER } { START | END } [ HIDDEN ] ]
-    [ NULL | NOT NULL ]
+    [ [ CONSTRAINT constraint_name ] {NULL | NOT NULL} ]
     [ ROWGUIDCOL ]
     [ ENCRYPTED WITH
         ( COLUMN_ENCRYPTION_KEY = key_name ,


### PR DESCRIPTION
added [ CONSTRAINT constraint_name ] to NULL|NOT NULL constraint, according to the documentation "CONSTRAINT Is an optional keyword that indicates the start of the definition of a PRIMARY KEY, NOT NULL, UNIQUE, FOREIGN KEY, or CHECK constraint." and to the actual SQL server behavior.