### PR TITLE
Update overview-of-always-on-availability-groups-sql-server.md

### DIFF
--- a/docs/database-engine/availability-groups/windows/overview-of-always-on-availability-groups-sql-server.md
+++ b/docs/database-engine/availability-groups/windows/overview-of-always-on-availability-groups-sql-server.md
@@ -46,7 +46,7 @@ ms.author: mathoma
 > [!NOTE]  
 >  For information about the relationship of SQL Server Always On components to the WSFC cluster, see [Windows Server Failover Clustering &#40;WSFC&#41; with SQL Server](../../../sql-server/failover-clusters/windows/windows-server-failover-clustering-wsfc-with-sql-server.md).  
   
- The following illustration shows an availability group that contains one primary replica and four secondary replicas. Up to eight secondary replicas are supported, including one primary replica and two synchronous-commit secondary replicas.  
+ The following illustration shows an availability group that contains one primary replica and four secondary replicas. Up to eight secondary replicas are supported, including one primary replica and four synchronous-commit secondary replicas.  
   
  ![Availability group with five replicas](../../../database-engine/availability-groups/windows/media/aoag-agintrofigure.gif "Availability group with five replicas")  
   


### PR DESCRIPTION
SQL Server 2019 (15.x) increases the maximum number of synchronous replicas to 5, up from 3 in SQL Server 2017 (14.x). There is one primary replica, plus four synchronous secondary replicas.