### PR TITLE
need to update info

### DIFF
--- a/docs/database-engine/availability-groups/windows/distributed-availability-groups.md
+++ b/docs/database-engine/availability-groups/windows/distributed-availability-groups.md
@@ -57,6 +57,8 @@ Because the distributed availability groups feature did not exist in SQL Server 
 > [!NOTE]
 > Distributed availability groups can not be configured with Standard edition or mix of Standard and Enterprise edition.
 
+---this needs to be changed to reflect that standard edition is now supported start in SQL 2019 CU17 
+
 Because there are two separate availability groups, the process of installing a service pack or cumulative update on a replica that's participating in a distributed availability group is slightly different from that of a traditional availability group:
 
 1. Start by updating the replicas of the second availability group in the distributed availability group.


### PR DESCRIPTION
under the version and edition requirements section, there is a purple note that says "Distributed availability groups can not be configured with Standard edition or mix of Standard and Enterprise edition" 

however, as of SQL Server 2019 CU17, we have enabled this feature for standard edition of SQL server. 


added a line (see line 60)

source: https://support.microsoft.com/en-us/topic/kb5016394-cumulative-update-17-for-sql-server-2019-3033f654-b09d-41aa-8e49-e9d0c353c5f7#bkmk_14899781