### PR TITLE
Fixed typo

### DIFF
--- a/docs/t-sql/queries/update-transact-sql.md
+++ b/docs/t-sql/queries/update-transact-sql.md
@@ -99,7 +99,7 @@ UPDATE
 ```  
   
 ```syntaxsql 
--- Syntax for Azure Synapse Analysis
+-- Syntax for Azure Synapse Analytics
 
 [ WITH <common_table_expression> [ ,...n ] ]
 UPDATE [ database_name . [ schema_name ] . | schema_name . ] table_name


### PR DESCRIPTION
There is a typo referring to "Synapse Analysis". It should read "Synapse Analytics".