### PR TITLE
Update optimize-json-processing-with-in-memory-oltp.md

### DIFF
--- a/docs/relational-databases/json/optimize-json-processing-with-in-memory-oltp.md
+++ b/docs/relational-databases/json/optimize-json-processing-with-in-memory-oltp.md
@@ -90,7 +90,7 @@ CREATE TABLE xtp.Product(
 	Data nvarchar(4000),
 
 	MadeIn AS CAST(JSON_VALUE(Data, '$.MadeIn') as NVARCHAR(50)) PERSISTED,
-	Cost   AS CAST(JSON_VALUE(Data, '$.ManufacturingCost') as float)
+	Cost   AS CAST(JSON_VALUE(Data, '$.ManufacturingCost') as float) PERSISTED
 
 ) WITH (MEMORY_OPTIMIZED=ON);
 ```


### PR DESCRIPTION
Preceding text implies that both columns are persisted, but in the sample code the `Cost` computed column is not defined as `PERSISTED`. Compare to the next code sample down in which both columns are defined as persisted.