### PR TITLE
Update dbcc-checkconstraints-transact-sql.md

### DIFF
--- a/docs/t-sql/database-console-commands/dbcc-checkconstraints-transact-sql.md
+++ b/docs/t-sql/database-console-commands/dbcc-checkconstraints-transact-sql.md
@@ -82,7 +82,7 @@ WHERE <table_being_checked.fkey1> IS NOT NULL
   
 The query data is stored in a temp table. After all requested tables or constraints have been checked, the result set is returned.
 DBCC CHECKCONSTRAINTS checks the integrity of FOREIGN KEY and CHECK constraints but does not check the integrity of the on-disk data structures of a table. These data structure checks can be performed by using [DBCC CHECKDB](../../t-sql/database-console-commands/dbcc-checkdb-transact-sql.md) and [DBCC CHECKTABLE](../../t-sql/database-console-commands/dbcc-checktable-transact-sql.md).
-  
+
 **Applies to**: [!INCLUDE[sssql16-md](../../includes/sssql16-md.md)] and later
   
 If *table_name* or *table_id* is specified and it is enabled for system versioning, DBCC CHECKCONSTRAINTS also performs temporal data consistency checks on the specified table. When *NO_INFOMSGS* is not specified, this command will return each consistency violation in the output on a separate line. The format of the output will be ([pkcol1], [pkcol2]..) = (\<pkcol1_value>, \<pkcol2_value>...) AND \<what is wrong with temporal table record>.
@@ -105,7 +105,9 @@ DBCC CHECKCONSTRAINTS return a rowset with the following columns.
 |Table Name|**varchar**|Name of the table.|  
 |Constraint Name|**varchar**|Name of the constraint that is violated.|  
 |Where|**varchar**|Column value assignments that identify the row or rows violating the constraint.<br /><br /> The value in this column can be used in a WHERE clause of a SELECT statement querying for rows that violate the constraint.|  
-  
+
+Note that DBCC CHECKCONSTRAINTS is not guaranteed to find to ALL constraint violations. If a single row violates multiple constraints, only the Where clause for the first violation found will be listed. So unless another row exists with the same combination of values that produce the violation, AND has that violation as the first violation found, that combination of values will be missing from the returned result set. This means you might have to go through multiple iterations of running DBCC CHECKCONSTRAINTS and fixing problems before finding ALL constraint violations in the database. 
+
 ## Permissions  
 Requires membership in the **sysadmin** fixed server role or the **db_owner** fixed database role.
   


### PR DESCRIPTION
Clarify that DBCC CHECKCONSTRAINTS is not guaranteed to find ALL constraint violations, because it only finds the first violation for a row.