### PR TITLE
Update sql-server-iaas-agent-extension-automate-management.md

### DIFF
--- a/azure-sql/virtual-machines/windows/sql-server-iaas-agent-extension-automate-management.md
+++ b/azure-sql/virtual-machines/windows/sql-server-iaas-agent-extension-automate-management.md
@@ -57,8 +57,10 @@ The SQL Server IaaS Agent extension allows for integration with the Azure portal
    $ az sql vm list --query "[?sqlServerLicenseType=='AHUB']"
    ```
    ---
+> [!NOTE]
 
-
+Once you delete the IAAS VM where the sql extension is installed, the sql server also gets deleted. Because the SQL server works with the extension installed on IAAS VM.
+>
 
 ## Feature benefits 
 


### PR DESCRIPTION
Once you delete the IAAS VM where the sql extension is installed, the sql server also gets deleted. Because the SQL server works with the extension installed on IAAS VM.

This information is mandatory for this document as it gives customers awareness that SQL server is going to get deleted along with the VM