### PR TITLE
remove deprecated homebrew env filtering arg

### DIFF
--- a/docs/connect/odbc/linux-mac/install-microsoft-odbc-driver-sql-server-macos.md
+++ b/docs/connect/odbc/linux-mac/install-microsoft-odbc-driver-sql-server-macos.md
@@ -30,7 +30,7 @@ To install Microsoft ODBC driver 18 for SQL Server on macOS, run the following c
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 brew tap microsoft/mssql-release https://github.com/Microsoft/homebrew-mssql-release
 brew update
-HOMEBREW_NO_ENV_FILTERING=1 ACCEPT_EULA=Y brew install msodbcsql18 mssql-tools18
+brew install msodbcsql18 mssql-tools18
 ```
 
 ## Previous versions
@@ -45,7 +45,7 @@ To install Microsoft ODBC driver 17 for SQL Server on macOS, run the following c
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 brew tap microsoft/mssql-release https://github.com/Microsoft/homebrew-mssql-release
 brew update
-HOMEBREW_NO_ENV_FILTERING=1 ACCEPT_EULA=Y brew install msodbcsql17 mssql-tools
+brew install msodbcsql17 mssql-tools
 ```
 
 > [!IMPORTANT]


### PR DESCRIPTION
resolves #8052 

```
Error: HOMEBREW_NO_ENV_FILTERING was deprecated for over a year and has now been removed (because it breaks many things)!
```