### PR TITLE
Update sql-server-backup-to-url-best-practices-and-troubleshooting.md

### DIFF
--- a/docs/relational-databases/backup-restore/sql-server-backup-to-url-best-practices-and-troubleshooting.md
+++ b/docs/relational-databases/backup-restore/sql-server-backup-to-url-best-practices-and-troubleshooting.md
@@ -60,7 +60,7 @@ Parallel backups to the same blob cause one of the backups to fail with an **Ini
 
 If you're using page blobs, for example, `BACKUP... TO URL... WITH CREDENTIAL`, use the following error logs to help with troubleshooting backup errors:  
   
-Set trace flag 3051 to turn on logging to a specific error log with the following format in:  
+Set trace flag 3051 (only applicable to page blobs, not block blobs) to turn on logging to a specific error log with the following format in:  
   
 `BackupToUrl-\<instname>-\<dbname>-action-\<PID>.log` Where `\<action>` is one of the following:  
   


### PR DESCRIPTION
I don't know that this is the best means of reminding readers that the trace flag referenced is only applicable for page blobs, and not block blobs, but the number of times lately I've had customers AND customer engineers/CSAs point to that trace flag and then be stunned when they get no additional logging is pretty high. 

Which is what I'd expect knowing that the trace flag in question will only work for page blobs, not block blobs - which is what more and more of our customers have switched into.