### PR TITLE
changed max value for backup compression

### DIFF
--- a/docs/database-engine/configure-windows/server-configuration-options-sql-server.md
+++ b/docs/database-engine/configure-windows/server-configuration-options-sql-server.md
@@ -109,7 +109,7 @@ The following table lists all available configuration options, the range of poss
 | [allow updates](allow-updates-server-configuration-option.md) (Obsolete. Don't use. Will cause an error during reconfigure.) | 0 | 1 | 0 |
 | [automatic soft-NUMA disabled](soft-numa-sql-server.md) | 0 | 1 | 0 |
 | [backup checksum default](backup-checksum-default.md) | 0 | 1 | 0 |
-| [backup compression default](view-or-configure-the-backup-compression-default-server-configuration-option.md) | 0 | 1 | 0 |
+| [backup compression default](view-or-configure-the-backup-compression-default-server-configuration-option.md) | 0 | 2 | 0 |
 | [backup compression algorithm](view-or-configure-the-backup-compression-algorithm-server-configuration-option.md) (A)<br /><br />**Applies to:** [!INCLUDE [sssql22-md](../../includes/sssql22-md.md)] and later. | 0 | 1 | 0 |
 | [blocked process threshold](blocked-process-threshold-server-configuration-option.md) (A) | 5 | 86400 | 0 |
 | [c2 audit mode](c2-audit-mode-server-configuration-option.md) (A, RR) | 0 | 1 | 0 |


### PR DESCRIPTION
the backup_compression_default option has values of 0, 1, and 2 as of SQL 2022.  See: https://docs.microsoft.com/sql/database-engine/configure-windows/view-or-configure-the-backup-compression-algorithm-server-configuration-option?view=sql-server-ver16