### PR TITLE
Fix create external table example query

### DIFF
--- a/azure-sql/database/elastic-query-vertical-partitioning.md
+++ b/azure-sql/database/elastic-query-vertical-partitioning.md
@@ -109,7 +109,10 @@ CREATE EXTERNAL TABLE [dbo].[customer]
       [c_lastname] nvarchar(256) NOT NULL,
       [street] nvarchar(256) NOT NULL,
       [city] nvarchar(256) NOT NULL,
-      [state] nvarchar(20) NULL,
+      [state] nvarchar(20) NULL
+   )
+   WITH
+   (
       DATA_SOURCE = RemoteReferenceData
    );
 ```


### PR DESCRIPTION
Based on my experimentation the example query to create external table isn't correct. The correct syntax is to have the `DATA_SOURCE` in `WITH` section.

See [here](https://docs.microsoft.com/sql/t-sql/statements/create-external-table-transact-sql?view=sql-server-ver16&tabs=dedicated#syntax)