### PR TITLE
SQLDW or Synapse, and some more MI in left menu

### DIFF
--- a/docs/sql-server/index.yml
+++ b/docs/sql-server/index.yml
@@ -26,7 +26,7 @@ landingContent:
       - text: Azure SQL Managed Instance
         url: /azure/sql-database/sql-database-managed-instance
       - text: Azure Synapse Analytics
-        url: /azure/sql-data-warehouse/sql-data-warehouse-overview-what-is
+        url: /azure/synapse-analytics
       - text: SQL Server on a Windows VM
         url: /azure/virtual-machines/windows/sql/virtual-machines-windows-sql-server-iaas-overview
       - text: SQL Server on a Linux VM


### PR DESCRIPTION
Hi docs team,
Do we specifically want to refer to 'dedicated SQL pool (formerly SQL DW)' in the link for Azure Synapse Analytics or to (the entire) Azure Synapse Analytics in https://learn.microsoft.com/en-us/azure/synapse-analytics/overview-what-is ? It's in this page but also in the left menu under 'SQL on Azure'.
 
On the left menu. I don't know how to provide feedback on that: SQL on Azure
- Azure SQL Database -> now goes to Azure SQL documentation (which is larger than SQL db). More consistent to lead to 'What is' https://learn.microsoft.com/en-us/azure/azure-sql/database/sql-database-paas-overview?view=azuresql
- Can you add Azure SQL Managed Instance in the left menu? SQL Server on Azure VM has its own menu-item, MI deserves one as well. Link to 'What is' in https://learn.microsoft.com/en-us/azure/azure-sql/managed-instance/sql-managed-instance-paas-overview?view=azuresql 
- Azure Synapse Analytics -> see above, SQL DW vs Synapse Analytics?
- SQL Server on an Azure VM -> goes to 'What is', leave as is.
 
Thank you for reviewing. Kind regards, inge