### PR TITLE
Update managed-instance-link-feature-overview.md

### DIFF
--- a/azure-sql/managed-instance/managed-instance-link-feature-overview.md
+++ b/azure-sql/managed-instance/managed-instance-link-feature-overview.md
@@ -32,7 +32,7 @@ To use the link feature, you'll need a supported version of SQL Server. The foll
 
 In addition to the supported version, you'll need:
 
-- Network connectivity between your SQL Server and managed instance is required. If your SQL Server is running on-premises, use a VPN link or Express route. If your SQL Server is running on an Azure VM, either deploy your VM to the same subnet as your managed instance, or use global VNet peering to connect two separate subnets. 
+- Network connectivity between your SQL Server and managed instance is required. If your SQL Server is running on-premises, use a VPN link or Express route. If your SQL Server is running on an Azure VM, either deploy your VM to the same vnet as your managed instance, or use global VNet peering to connect two separate subnets. 
 - Azure SQL Managed Instance provisioned on any service tier.
 
 You'll also need the following tooling:

--- a/azure-sql/managed-instance/managed-instance-link-feature-overview.md
+++ b/azure-sql/managed-instance/managed-instance-link-feature-overview.md
@@ -32,7 +32,7 @@ To use the link feature, you'll need a supported version of SQL Server. The foll
 
 In addition to the supported version, you'll need:
 
-- Network connectivity between your SQL Server and managed instance is required. If your SQL Server is running on-premises, use a VPN link or Express route. If your SQL Server is running on an Azure VM, either deploy your VM to the same vnet as your managed instance, or use global VNet peering to connect two separate subnets. 
+- Network connectivity between your SQL Server and managed instance is required. If your SQL Server is running on-premises, use a VPN link or Express route. If your SQL Server is running on an Azure VM, either deploy your VM to the same VNet as your managed instance, or use global VNet peering to connect two separate subnets. 
 - Azure SQL Managed Instance provisioned on any service tier.
 
 You'll also need the following tooling:


### PR DESCRIPTION
One cannot deploy a VM to the same subnet as the managed instance. It should be corrected to vnet.  Managed instance subnet cannot have any other resource types in its subnet. https://learn.microsoft.com/en-us/azure/azure-sql/managed-instance/connectivity-architecture-overview?view=azuresql#network-requirements