### PR TITLE
fix: added the missing keyword 'WITH'  in the statement

### DIFF
--- a/docs/relational-databases/sql-server-transaction-locking-and-row-versioning-guide.md
+++ b/docs/relational-databases/sql-server-transaction-locking-and-row-versioning-guide.md
@@ -729,7 +729,7 @@ In most cases, the [!INCLUDE[ssde_md](../includes/ssde_md.md)] delivers the best
   
     ```sql
     BEGIN TRAN
-    SELECT * FROM mytable (UPDLOCK, HOLDLOCK) WHERE 1=0
+    SELECT * FROM mytable WITH (UPDLOCK, HOLDLOCK) WHERE 1=0
     WAITFOR DELAY '1:00:00'
     COMMIT TRAN
     ```


### PR DESCRIPTION
File: `docs/relational-databases/sql-server-transaction-locking-and-row-versioning-guide.md`
