### PR TITLE
Fixing the description of dbid

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-exec-sql-text-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-exec-sql-text-transact-sql.md
@@ -69,7 +69,7 @@ The *plan_handle* can be obtained from the following dynamic management objects:
   
 |Column name|Data type|Description|  
 |-----------------|---------------|-----------------|  
-|**dbid**|**smallint**|ID of database.<br /><br /> For ad hoc and prepared SQL statements, the ID of the database where the statements were compiled.|  
+|**dbid**|**smallint**|ID of database.<br /><br /> For static SQL in a stored procedure, the ID of the database containing the stored procedure.  Null otherwise.|  
 |**objectid**|**int**|ID of object.<br /><br /> Is NULL for ad hoc and prepared SQL statements.|  
 |**number**|**smallint**|For a numbered stored procedure, this column returns the number of the stored procedure. For more information, see [sys.numbered_procedures &#40;Transact-SQL&#41;](../../relational-databases/system-catalog-views/sys-numbered-procedures-transact-sql.md).<br /><br /> Is NULL for ad hoc and prepared SQL statements.|  
 |**encrypted**|**bit**|1 = SQL text is encrypted.<br /><br /> 0 = SQL text is not encrypted.|  


### PR DESCRIPTION
The Note points this out, but the description of the column was incorrect.  In this DMV dbid is only non-null for static SQL in stored procedures.