### PR TITLE
Remove SQL DB and MI for optimized plan forcing

### DIFF
--- a/docs/t-sql/statements/alter-database-scoped-configuration-transact-sql.md
+++ b/docs/t-sql/statements/alter-database-scoped-configuration-transact-sql.md
@@ -461,7 +461,7 @@ If asynchronous statistics update is enabled, enabling this configuration will c
 
 #### OPTIMIZED_PLAN_FORCING **=** { **ON** | OFF }
 
-**Applies to:** [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] (Starting with [!INCLUDE[sql-server-2022](../../includes/sssql22-md.md)]), [!INCLUDE[ssSDSfull](../../includes/sssdsfull-md.md)] (Preview) and [!INCLUDE[ssSDSMIfull](../../includes/sssdsmifull-md.md)] (Preview)
+**Applies to:** [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] (Starting with [!INCLUDE[sql-server-2022](../../includes/sssql22-md.md)]) <!--, [!INCLUDE[ssSDSfull](../../includes/sssdsfull-md.md)] (Preview) and [!INCLUDE[ssSDSMIfull](../../includes/sssdsmifull-md.md)] (Preview)-->
 
 Optimized plan forcing reduces compilation overhead for repeating forced queries. Once the query execution plan is generated, specific compilation steps are stored for reuse as an optimization replay script. An optimization replay script is stored as part of the compressed showplan XML in [Query Store](../../relational-databases/performance/monitoring-performance-by-using-the-query-store.md), in a hidden `OptimizationReplay` attribute. Learn more in [Optimized plan forcing with Query Store](../../relational-databases/performance/optimized-plan-forcing-query-store.md).
 


### PR DESCRIPTION
The feature has not been delivered to those vehicles yet.  It is planned, so I just commented it out.