### PR TITLE
Update recovery-using-backups.md

### DIFF
--- a/azure-sql/database/recovery-using-backups.md
+++ b/azure-sql/database/recovery-using-backups.md
@@ -86,6 +86,7 @@ You generally restore a database to an earlier point for recovery purposes. You 
 > - You can run a restore only on the same server. Point-in-time restore doesn't support cross-server restoration.
 > - You can't perform a point-in-time restore on a geo-secondary database. You can do so only on a primary database.
 > - The `BackupFrequency` parameter isn't supported for Hyperscale databases. 
+> - Restoration operations can be CPU-intensive and often require a service tier of S3 or greater on the restoring (target) database
 
 - **Database replacement**
 

--- a/azure-sql/database/recovery-using-backups.md
+++ b/azure-sql/database/recovery-using-backups.md
@@ -86,7 +86,7 @@ You generally restore a database to an earlier point for recovery purposes. You 
 > - You can run a restore only on the same server. Point-in-time restore doesn't support cross-server restoration.
 > - You can't perform a point-in-time restore on a geo-secondary database. You can do so only on a primary database.
 > - The `BackupFrequency` parameter isn't supported for Hyperscale databases. 
-> - Restoration operations can be CPU-intensive and often require a service tier of S3 or greater on the restoring (target) database
+> - Database restore operations are resource-intensive and may require a service tier of S3 or greater for the restoring (target) database. Once restore completes, the database or elastic pool may be scaled down, if required.
 
 - **Database replacement**
 


### PR DESCRIPTION
As per feedback from our customers, this statement "Restoration operations can be CPU-intensive and often require a service tier of S3 or greater" which can be located on the DTU limits article https://docs.microsoft.com/en-us/azure/azure-sql/database/resource-limits-dtu-single-databases#standard-service-tier could have better visibility when customers read the "Azure SQL DB Restore article" and thus avoid trying to restore to sub-core service tiers (Basic, S0, S1 and S2) which may lead to an issue of CPU starvation.

Example of the feedback below:

I never would have found that when looking for information about doing Point In Time Restores, or possibly even restores in general, as that is not the main subject of that page.

Something like “info box” (clarifying that it is the scale of the restoring database that matters, not of the original source database) needs to be added to every page that discusses restoring Azure SQL Databases.