### PR TITLE
Remove driver list from paragraph talking about supportability of Subject Alternative Names

### DIFF
--- a/docs/database-engine/availability-groups/windows/listeners-client-connectivity-application-failover.md
+++ b/docs/database-engine/availability-groups/windows/listeners-client-connectivity-application-failover.md
@@ -126,7 +126,7 @@ Server=tcp:AGListener,1433;Database=AdventureWorks;Integrated Security=SSPI; Mul
   
 ##  <a name="SSLcertificates"></a> Listeners & TLS/SSL certificates  
 
-When connecting to an availability group listener, if the participating instances of SQL Server use TLS/SSL certificates in conjunction with session encryption, the connecting client driver will need to support the Subject Alternate Name in the TLS/SSL certificate in order to force encryption.  SQL Server driver support for certificate Subject Alternative Name is planned for ADO.NET (SqlClient), Microsoft JDBC, and SQL Native Client (SNAC).  
+When connecting to an availability group listener, if the participating instances of SQL Server use TLS/SSL certificates in conjunction with session encryption, the connecting client driver will need to support the Subject Alternate Name in the TLS/SSL certificate in order to force encryption. 
   
 An X.509 certificate must be configured for each participating server node in the failover cluster with a list of all availability group listeners set in the Subject Alternate Name of the certificate. 
 


### PR DESCRIPTION
…ject Alternative Name

Information seems to be outdated as SQL Native Client, SQLClient, MSJDBC, MSODBCSQL/MSOLEDBSQL already support the feature. Some public evidences about using SAN:

- SQLClient: https://github.com/dotnet/SqlClient/issues/1437
- MSJDBC: https://github.com/microsoft/mssql-jdbc/issues/816