### PR TITLE
Update sys-fn-get-audit-file-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-functions/sys-fn-get-audit-file-transact-sql.md
+++ b/docs/relational-databases/system-functions/sys-fn-get-audit-file-transact-sql.md
@@ -166,7 +166,7 @@ fn_get_audit_file ( file_pattern,
   This example reads all audit logs from servers that begin with `Sh`: 
   
   ```  
-  SELECT * FROM sys.fn_get_audit_file ('https://mystorage.blob.core.windows.net/sqldbauditlogs/Sh',default,default);
+  SELECT * FROM sys.fn_get_audit_file ('https://mystorage.blob.core.windows.net/sqldbauditlogs/Sh*',default,default);
   GO  
   ```
 


### PR DESCRIPTION
example with partial filename needs trailing asterisk to be functional and to match the description of partial file name matching earlier in article