### PR TITLE
Include information about the recovery time on the new primary replica when CT is enabled

### DIFF
--- a/docs/database-engine/availability-groups/windows/replicate-track-change-data-capture-always-on-availability.md
+++ b/docs/database-engine/availability-groups/windows/replicate-track-change-data-capture-always-on-availability.md
@@ -181,7 +181,11 @@ If Change Data Capture needs to be disabled on a database that is part of an Alw
 >  Msg 22117, Level 16, State 1, Line1  
 >   
 >  For databases that are members of a secondary replica (that is, for secondary databases), change tracking is not supported. As an alternative to running change tracking queries on the primary replica, you can create a database snapshot of an AG database from the secondary replica and then use that to query change data. A database snapshot is a read-only, static view of a SQL Server database (the source database), so change tracking data in the database snapshot will be of the time when the snapshot was taken on the AG database from the secondary replica.
-  
+
+> [!NOTE]  
+>  When a failover occurs and databases have Change Tracking enabled, the recovery time spent on the new primary node will be longer than usual because a restart of the databases will be required.
+
+
 ##  <a name="Prereqs"></a> Prerequisites, Restrictions, and Considerations for Using Replication  
  This section describes considerations for deploying replication with [!INCLUDE[ssHADR](../../../includes/sshadr-md.md)], including prerequisites, restrictions, and recommendations.  
   

--- a/docs/database-engine/availability-groups/windows/replicate-track-change-data-capture-always-on-availability.md
+++ b/docs/database-engine/availability-groups/windows/replicate-track-change-data-capture-always-on-availability.md
@@ -183,7 +183,7 @@ If Change Data Capture needs to be disabled on a database that is part of an Alw
 >  For databases that are members of a secondary replica (that is, for secondary databases), change tracking is not supported. As an alternative to running change tracking queries on the primary replica, you can create a database snapshot of an AG database from the secondary replica and then use that to query change data. A database snapshot is a read-only, static view of a SQL Server database (the source database), so change tracking data in the database snapshot will be of the time when the snapshot was taken on the AG database from the secondary replica.
 
 > [!NOTE]  
->  When a failover occurs and databases have Change Tracking enabled, the recovery time spent on the new primary node will be longer than usual because a restart of the databases will be required.
+>  When a failover occurs on a database with Change Tracking enabled, recovery time on the new primary replica may take longer than usual as Change Tracking requires a full database restart. 
 
 
 ##  <a name="Prereqs"></a> Prerequisites, Restrictions, and Considerations for Using Replication  


### PR DESCRIPTION
As per the internal TFS #13093998, databases with Change Tracking enabled will be restarted upon the occurrence of a failover. The reason for the restart is to avoid  internal table syscommittab inconsistent between replicas.