### PR TITLE
Extending explanation about port exclusions

### DIFF
--- a/azure-sql/virtual-machines/windows/hadr-cluster-best-practices.md
+++ b/azure-sql/virtual-machines/windows/hadr-cluster-best-practices.md
@@ -305,6 +305,7 @@ You can avoid this scenario by assigning an unused static IP address to the clus
 If the SQL Server database engine, Always On availability group listener, failover cluster instance health probe, database mirroring endpoint, cluster core IP resource, or any other SQL resource is configured to use a port between 49,152 and 65,536 (the [default dynamic port range for TCP/IP](/windows/client-management/troubleshoot-tcpip-port-exhaust#default-dynamic-port-range-for-tcpip)), add an exclusion for each port. Doing so will prevent other system process from being dynamically assigned the same port. The following example creates an exclusion for port 59999: 
 `netsh int ipv4 add excludedportrange tcp startport=59999 numberofports=1 store=persistent`
 It is important to configure the port exclusion when the port is not in use, otherwise the command will fail with a message like “The process cannot access the file because it is being used by another process.”
+
 To confirm that the exclusions have been configured correctly, use the following command: `netsh int ipv4 show excludedportrange tcp`  
 Setting this exclusion for the AG role IP probe port should prevent events such as **Event ID: 1069** with status 10048. This event can be seen in the Windows Failover cluster events with the following message:
 ```

--- a/azure-sql/virtual-machines/windows/hadr-cluster-best-practices.md
+++ b/azure-sql/virtual-machines/windows/hadr-cluster-best-practices.md
@@ -302,13 +302,13 @@ Consider the scenario when a two-node cluster is created and brought online:
 
 You can avoid this scenario by assigning an unused static IP address to the cluster network name in order to bring the cluster network name online and add the IP address to [Azure Load Balancer](availability-group-load-balancer-portal-configure.md).
 
-If the SQL Server database engine, Always On availability group listener, failover cluster instance health probe, database mirroring endpoint, cluster core IP resource, or any other SQL resource is configured to use a port between 49,152 and 65,536 (the [default dynamic port range for TCP/IP](/windows/client-management/troubleshoot-tcpip-port-exhaust#default-dynamic-port-range-for-tcpip)), add an exclusion for each port. Doing so will prevent other system process from being dynamically assigned the same port. The following example creates an exclusion for port 59999: 
+If the SQL Server database engine, Always On availability group listener, failover cluster instance health probe, database mirroring endpoint, cluster core IP resource, or any other SQL resource is configured to use a port between 49,152 and 65,536 (the [default dynamic port range for TCP/IP](/windows/client-management/troubleshoot-tcpip-port-exhaust#default-dynamic-port-range-for-tcpip)), add an exclusion for each port. Doing so will prevent other system processes from being dynamically assigned the same port. The following example creates an exclusion for port 59999: 
 
 `netsh int ipv4 add excludedportrange tcp startport=59999 numberofports=1 store=persistent`
 
 It is important to configure the port exclusion when the port is not in use, otherwise the command will fail with a message like “The process cannot access the file because it is being used by another process.”
 
-To confirm that the exclusions have been configured correctly, use the following command: `netsh int ipv4 show excludedportrange tcp`  
+To confirm that the exclusions have been configured correctly, use the following command: `netsh int ipv4 show excludedportrange tcp`. 
 
 Setting this exclusion for the AG role IP probe port should prevent events such as **Event ID: 1069** with status 10048. This event can be seen in the Windows Failover cluster events with the following message:
 ```
@@ -320,7 +320,7 @@ Resource IP Address 10.0.1.0 called SetResourceStatusEx: checkpoint 5. Old state
 IP Address <IP Address 10.0.1.0>: IpaOnlineThread: **Listening on probe port 59999** failed with status **10048**
 ```
 Status [**10048**](/win32/desktop-src/WinSock/windows-sockets-error-codes-2) refers to: **This error occurs** if an application attempts to bind a socket to an **IP address/port that has already been used** for an existing socket.
-This can be caused by an internal process taking the same port defined as probe port, remember that probe port is used to check the status of a backend pool instance from the Azure Load Balancer. 
+This can be caused by an internal process taking the same port defined as probe port. Remember that probe port is used to check the status of a backend pool instance from the Azure Load Balancer. 
 If the **health probe fails** to get a response from a backend instance, then **no new connections will be sent to that backend instance** until the health probe succeeds again.
 
 ## Known issues

--- a/azure-sql/virtual-machines/windows/hadr-cluster-best-practices.md
+++ b/azure-sql/virtual-machines/windows/hadr-cluster-best-practices.md
@@ -309,6 +309,7 @@ If the SQL Server database engine, Always On availability group listener, failov
 It is important to configure the port exclusion when the port is not in use, otherwise the command will fail with a message like “The process cannot access the file because it is being used by another process.”
 
 To confirm that the exclusions have been configured correctly, use the following command: `netsh int ipv4 show excludedportrange tcp`  
+
 Setting this exclusion for the AG role IP probe port should prevent events such as **Event ID: 1069** with status 10048. This event can be seen in the Windows Failover cluster events with the following message:
 ```
 Cluster resource '<IP name in AG role>' of type 'IP Address' in cluster role '<AG Name>' failed.

--- a/azure-sql/virtual-machines/windows/hadr-cluster-best-practices.md
+++ b/azure-sql/virtual-machines/windows/hadr-cluster-best-practices.md
@@ -303,7 +303,9 @@ Consider the scenario when a two-node cluster is created and brought online:
 You can avoid this scenario by assigning an unused static IP address to the cluster network name in order to bring the cluster network name online and add the IP address to [Azure Load Balancer](availability-group-load-balancer-portal-configure.md).
 
 If the SQL Server database engine, Always On availability group listener, failover cluster instance health probe, database mirroring endpoint, cluster core IP resource, or any other SQL resource is configured to use a port between 49,152 and 65,536 (the [default dynamic port range for TCP/IP](/windows/client-management/troubleshoot-tcpip-port-exhaust#default-dynamic-port-range-for-tcpip)), add an exclusion for each port. Doing so will prevent other system process from being dynamically assigned the same port. The following example creates an exclusion for port 59999: 
+
 `netsh int ipv4 add excludedportrange tcp startport=59999 numberofports=1 store=persistent`
+
 It is important to configure the port exclusion when the port is not in use, otherwise the command will fail with a message like “The process cannot access the file because it is being used by another process.”
 
 To confirm that the exclusions have been configured correctly, use the following command: `netsh int ipv4 show excludedportrange tcp`  

--- a/azure-sql/virtual-machines/windows/hadr-cluster-best-practices.md
+++ b/azure-sql/virtual-machines/windows/hadr-cluster-best-practices.md
@@ -302,6 +302,23 @@ Consider the scenario when a two-node cluster is created and brought online:
 
 You can avoid this scenario by assigning an unused static IP address to the cluster network name in order to bring the cluster network name online and add the IP address to [Azure Load Balancer](availability-group-load-balancer-portal-configure.md).
 
+If the SQL Server database engine, Always On availability group listener, failover cluster instance health probe, database mirroring endpoint, cluster core IP resource, or any other SQL resource is configured to use a port between 49,152 and 65,536 (the [default dynamic port range for TCP/IP](/windows/client-management/troubleshoot-tcpip-port-exhaust#default-dynamic-port-range-for-tcpip)), add an exclusion for each port. Doing so will prevent other system process from being dynamically assigned the same port. The following example creates an exclusion for port 59999: 
+`netsh int ipv4 add excludedportrange tcp startport=59999 numberofports=1 store=persistent`
+It is important to configure the port exclusion when the port is not in use, otherwise the command will fail with a message like “The process cannot access the file because it is being used by another process.”
+To confirm that the exclusions have been configured correctly, use the following command: `netsh int ipv4 show excludedportrange tcp`  
+Setting this exclusion for the AG role IP probe port should prevent events such as **Event ID: 1069** with status 10048. This event can be seen in the Windows Failover cluster events with the following message:
+```
+Cluster resource '<IP name in AG role>' of type 'IP Address' in cluster role '<AG Name>' failed.
+```
+An Event ID: 1069 with status 10048 can be identified from cluster logs with events like: 
+```
+Resource IP Address 10.0.1.0 called SetResourceStatusEx: checkpoint 5. Old state OnlinePending, new state OnlinePending, AppSpErrorCode 0, Flags 0, nores=false
+IP Address <IP Address 10.0.1.0>: IpaOnlineThread: **Listening on probe port 59999** failed with status **10048**
+```
+Status [**10048**](/win32/desktop-src/WinSock/windows-sockets-error-codes-2) refers to: **This error occurs** if an application attempts to bind a socket to an **IP address/port that has already been used** for an existing socket.
+This can be caused by an internal process taking the same port defined as probe port, remember that probe port is used to check the status of a backend pool instance from the Azure Load Balancer. 
+If the **health probe fails** to get a response from a backend instance, then **no new connections will be sent to that backend instance** until the health probe succeeds again.
+
 ## Known issues
 
 Review the resolutions for some commonly known issues and errors: 


### PR DESCRIPTION
extending explanation about port exclusions when SQL server or cluster core resources are using ports from dynamic pool range  This replaces https://github.com/MicrosoftDocs/sql-docs/pull/7927 due to this is too much content for the checklist.