### PR TITLE
Changing the Applies to section to say SQL 2022

### DIFF
--- a/docs/relational-databases/system-catalog-views/sys-query-store-query-hints-transact-sql.md
+++ b/docs/relational-databases/system-catalog-views/sys-query-store-query-hints-transact-sql.md
@@ -22,7 +22,7 @@ dev_langs:
 monikerRange: "=azuresqldb-current||=azuresqldb-mi-current||>=sql-server-ver16||>=sql-server-linux-ver16"
 ---
 # sys.query_store_query_hints (Transact-SQL)
-[!INCLUDE [sql-asdb-asdbmi](../../includes/applies-to-version/sql-asdb-asdbmi.md)]
+[!INCLUDE [sqlserver2022-asdb-asdbmi](../../includes/applies-to-version/sqlserver2022-asdb-asmi.md)]
 
  Returns query hints from [Query Store hints](../../relational-databases/performance/query-store-hints.md).
   


### PR DESCRIPTION
This function/DMV is related to Query Store Hints functionality that's available in SQL 2022 (https://learn.microsoft.com/en-us/sql/relational-databases/performance/query-store-hints?view=sql-server-ver16), but the article says it applies to all supported versions. I got some questions about it recently, so I thought to update the doc.