### PR TITLE
Changing the Applies to section to say SQL 2022

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sys-sp-query-store-set-hints-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sys-sp-query-store-set-hints-transact-sql.md
@@ -24,7 +24,7 @@ ms.author: randolphwest
 monikerRange: "=azuresqldb-current||=azuresqldb-mi-current||>=sql-server-ver16||>=sql-server-linux-ver16"
 ---
 # sp_query_store_set_hints (Transact-SQL)
-[!INCLUDE [sql-asdb-asdbmi](../../includes/applies-to-version/sql-asdb-asdbmi.md)]
+[!INCLUDE [sqlserver2022-asdb-asdbmi](../../includes/applies-to-version/sqlserver2022-asdb-asmi.md)]
 
  Creates or updates [Query Store hints](../performance/query-store-hints.md) for a given `query_id`.
   


### PR DESCRIPTION
This function/DMV is related to Query Store Hints functionality that's available in SQL 2022 (https://learn.microsoft.com/en-us/sql/relational-databases/performance/query-store-hints?view=sql-server-ver16), but the article says it applies to all supported versions. I got some questions about it recently, so I thought to update the doc.