### PR TITLE
SQL Connector used for EKM using AKV is unsupported in Linux

### DIFF
--- a/docs/relational-databases/security/encryption/setup-steps-for-extensible-key-management-using-the-azure-key-vault.md
+++ b/docs/relational-databases/security/encryption/setup-steps-for-extensible-key-management-using-the-azure-key-vault.md
@@ -21,6 +21,8 @@ ms.author: arupp
 
 [!INCLUDE [SQL Server](../../../includes/applies-to-version/sqlserver.md)]
 
+**Note:** SQL Server TDE Extensible Key Management by using Azure Key Vault is currently unsupported for SQL Server on Linux.
+
 In this article, you install and configure the [!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)] Connector for Azure Key Vault.  
   
 ## Prerequisites

--- a/docs/relational-databases/security/encryption/setup-steps-for-extensible-key-management-using-the-azure-key-vault.md
+++ b/docs/relational-databases/security/encryption/setup-steps-for-extensible-key-management-using-the-azure-key-vault.md
@@ -21,7 +21,8 @@ ms.author: arupp
 
 [!INCLUDE [SQL Server](../../../includes/applies-to-version/sqlserver.md)]
 
-**Note:** SQL Server TDE Extensible Key Management by using Azure Key Vault is currently unsupported for SQL Server on Linux.
+> [!NOTE] 
+> SQL Server TDE Extensible Key Management by using Azure Key Vault is currently unsupported for SQL Server on Linux.
 
 In this article, you install and configure the [!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)] Connector for Azure Key Vault.  
   


### PR DESCRIPTION
The SQL Connector used for EKM using AKV is currently available for Windows alone. It is not available for SQL Server on Linux.  SQL Connector available at: https://www.microsoft.com/en-us/download/details.aspx?id=45344 However, the documentation says it applies to all versions. Request to update the documentation stating this feature is specific to SQL Server on Windows.

Added a note "Note: SQL Server TDE Extensible Key Management by using Azure Key Vault is currently unsupported for SQL Server on Linux."