### PR TITLE
Update loginproperty-transact-sql.md

### DIFF
--- a/docs/t-sql/functions/loginproperty-transact-sql.md
+++ b/docs/t-sql/functions/loginproperty-transact-sql.md
@@ -61,7 +61,7 @@ LOGINPROPERTY ( 'login_name' , 'property_name' )
 |**DefaultDatabase**|Returns the [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] login default database as stored in metadata or **master** if no database is specified. Returns NULL for non-[!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] provisioned users (for example, Windows authenticated users).|  
 |**DefaultLanguage**|Returns the login default language as stored in metadata. Returns NULL for non-[!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] provisioned users, for example, Windows authenticated users.|  
 |**HistoryLength**|Returns the number of passwords tracked for the login, using the password-policy enforcement mechanism. 0 if the password policy is not enforced. Resuming password policy enforcement restarts at 1.|  
-|**IsExpired**|Indicates whether the login has expired.|  
+|**IsExpired**|Indicates whether the login's password has expired.|  
 |**IsLocked**|Indicates whether the login is locked.|  
 |**IsMustChange**|Indicates whether the login must change its password the next time it connects.|  
 |**LockoutTime**|Returns the date when the [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] login was locked out because it had exceeded the permitted number of failed login attempts.|  


### PR DESCRIPTION
Currently reads "Indicates whether the login has expired".

I propose it should read ""Indicates whether the principal's password has expired".

The former is a bit ambiguous.

That is the reader may wonder whether an account can actually have expiration date in SQL Server.

Akin to an account that will auto expire ( disappear ) upon its expiration date.

Personally, my current read is that an account cannot have expiration date.

But, an account's password can have an expiration date.  

It is subtle read.

An implicit or inferred statement.

But, I think the explanation/documentation can be more explicit as to what is expiring.