### PR TITLE
Corrected stop at mark example

### DIFF
--- a/docs/t-sql/statements/restore-statements-transact-sql.md
+++ b/docs/t-sql/statements/restore-statements-transact-sql.md
@@ -613,7 +613,7 @@ RESTORE LOG AdventureWorks2012
   FROM AdventureWorksBackups
     WITH FILE = 4,
     RECOVERY,
-    STOPATMARK = ListPriceUpdate;
+    STOPATMARK = 'UPDATE Product list prices';
 ```
 
 [&#91;Top of examples&#93;](#examples)


### PR DESCRIPTION
Example G shows the creation of a mark within a named transaction, but then shows the stopatmark using the transaction name. The example should be using the mark name.