### PR TITLE
Update sp-rename-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-rename-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-rename-transact-sql.md
@@ -28,7 +28,7 @@ monikerRange: "=azuresqldb-current||>=sql-server-2016||>=sql-server-linux-2017||
 Changes the name of a user-created object in the current database. This object can be a table, index, column, alias data type, or [!INCLUDE[msCoName](../../includes/msconame-md.md)] [!INCLUDE[dnprdnshort](../../includes/dnprdnshort-md.md)] common language runtime (CLR) user-defined type.
 
 > [!NOTE]  
-> In [!INCLUDE[ssazuresynapse](../../includes/ssazuresynapse_md.md)], `sp_rename` is in **Preview** for dedicated SQL pools and can only be used to rename a COLUMN in a user object.
+> In [!INCLUDE[ssazuresynapse](../../includes/ssazuresynapse_md.md)], `sp_rename` is in **Preview** for dedicated SQL pools and can only be used to rename a COLUMN in a user object. `sp_rename` is not available in serverless SQL pools.
 
 > [!CAUTION]  
 > Changing any part of an object name can break scripts and stored procedures. We recommend you do not use this statement to rename stored procedures, triggers, user-defined functions, or views; instead, drop the object and re-create it with the new name.
@@ -238,7 +238,7 @@ EXEC sp_rename 'Person.Person.ContactMail1', 'NewContact','Statistics';
 The following example renames the `c1` column in the `table1` table to `col1`.
 
 > [!NOTE]  
-> This [!INCLUDE[ssazuresynapse](../../includes/ssazuresynapse_md.md)] feature is still in preview for dedicated SQL pools and is currently available only for objects in the **dbo** schema.
+> This [!INCLUDE[ssazuresynapse](../../includes/ssazuresynapse_md.md)] feature is still in preview for dedicated SQL pools and is currently available only for objects in the **dbo** schema.  `sp_rename` is not available in serverless SQL pools.
 
 ```sql
 CREATE TABLE table1 (c1 INT, c2 INT);


### PR DESCRIPTION
Updated the Notes about support in Synapse Analytics to include that sp_rename is not available in serverless SQL pools.