### PR TITLE
Remove duplicate link in drop-symmetric-key-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/drop-symmetric-key-transact-sql.md
+++ b/docs/t-sql/statements/drop-symmetric-key-transact-sql.md
@@ -64,7 +64,7 @@ DROP SYMMETRIC KEY GailSammamishKey6;
 GO  
 ```  
   
-## See Also     
+## See also     
  [CREATE SYMMETRIC KEY &#40;Transact-SQL&#41;](../../t-sql/statements/create-symmetric-key-transact-sql.md)   
  [ALTER SYMMETRIC KEY &#40;Transact-SQL&#41;](../../t-sql/statements/alter-symmetric-key-transact-sql.md)   
  [Encryption Hierarchy](../../relational-databases/security/encryption/encryption-hierarchy.md)   

--- a/docs/t-sql/statements/drop-symmetric-key-transact-sql.md
+++ b/docs/t-sql/statements/drop-symmetric-key-transact-sql.md
@@ -64,8 +64,7 @@ DROP SYMMETRIC KEY GailSammamishKey6;
 GO  
 ```  
   
-## See Also  
- [CREATE SYMMETRIC KEY &#40;Transact-SQL&#41;](../../t-sql/statements/create-symmetric-key-transact-sql.md)   
+## See Also     
  [CREATE SYMMETRIC KEY &#40;Transact-SQL&#41;](../../t-sql/statements/create-symmetric-key-transact-sql.md)   
  [ALTER SYMMETRIC KEY &#40;Transact-SQL&#41;](../../t-sql/statements/alter-symmetric-key-transact-sql.md)   
  [Encryption Hierarchy](../../relational-databases/security/encryption/encryption-hierarchy.md)   


### PR DESCRIPTION
minor correction. "See Also" had 'Create symmetric key' listed twice. This update removes duplication.