### PR TITLE
Fixes incorrect quotation of multiple word search

### DIFF
--- a/docs/relational-databases/search/full-text-search.md
+++ b/docs/relational-databases/search/full-text-search.md
@@ -59,7 +59,7 @@ A full-text index includes one or more character-based columns in a table. These
     ```sql  
     SELECT product_id   
     FROM products   
-    WHERE CONTAINS(product_description, "Snap Happy 100EZ" OR FORMSOF(THESAURUS,'Snap Happy') OR '100EZ')   
+    WHERE CONTAINS(product_description, '"Snap Happy 100EZ"' OR FORMSOF(THESAURUS,'"Snap Happy"') OR '100EZ')   
     AND product_cost < 200 ;  
     ```  
   
@@ -68,7 +68,7 @@ A full-text index includes one or more character-based columns in a table. These
     ```sql  
     SELECT candidate_name,SSN   
     FROM candidates   
-    WHERE CONTAINS(candidate_resume,"SQL Server") AND candidate_division = 'DBA';  
+    WHERE CONTAINS(candidate_resume, '"SQL Server"') AND candidate_division = 'DBA';  
     ```  
   
  For more information, see [Query with Full-Text Search](../../relational-databases/search/query-with-full-text-search.md).  


### PR DESCRIPTION
Using double-quotes in the `CONTAINS` search query gives an error; however, if you enclose the multiple word search with single quotes it works as expected