### PR TITLE
Update elastic-jobs-tsql-create-manage.md

### DIFF
--- a/azure-sql/database/elastic-jobs-tsql-create-manage.md
+++ b/azure-sql/database/elastic-jobs-tsql-create-manage.md
@@ -676,7 +676,7 @@ If not null, the name of the table that the command's first result set will be w
 Output parameter that will be assigned the new job version number. job_version is int.
 
 [ **\@max_parallelism =** ] max_parallelism OUTPUT  
-The maximum level of parallelism per elastic pool. If set, then the job step will be restricted to only run on a maximum of that many databases per elastic pool. This applies to each elastic pool that is either directly included in the target group or is inside a server that is included in the target group. max_parallelism is int.
+The maximum level of parallelism per elastic pool. If set, then the job step will be restricted to only run on a maximum of that many databases per elastic pool. This applies to each elastic pool that is either directly included in the target group or to the elatic pools inside a server that is included in the target group. max_parallelism is int.
 
 #### Return Code Values
 
@@ -801,7 +801,7 @@ If not null, the name of the table that the command's first result set will be w
 Output parameter that will be assigned the new job version number. job_version is int.
 
 [ **\@max_parallelism =** ] max_parallelism OUTPUT  
-The maximum level of parallelism per elastic pool. If set, then the job step will be restricted to only run on a maximum of that many databases per elastic pool. This applies to each elastic pool that is either directly included in the target group or is inside a server that is included in the target group. To reset the value of max_parallelism back to null, set this parameter's value to -1. max_parallelism is int.
+The maximum level of parallelism per elastic pool. If set, then the job step will be restricted to only run on a maximum of that many databases per elastic pool. This applies to each elastic pool that is either directly included in the target group or to the elatic pools inside a server that is included in the target group. To reset the value of max_parallelism back to null, set this parameter's value to -1. max_parallelism is int.
 
 #### Return Code Values
 


### PR DESCRIPTION
Updated to make it explicit that max_parallelism applies only to elastic pools in a target group