### PR TITLE
Update resource-limits-vcore-single-databases.md

### DIFF
--- a/azure-sql/database/resource-limits-vcore-single-databases.md
+++ b/azure-sql/database/resource-limits-vcore-single-databases.md
@@ -64,7 +64,7 @@ The [serverless compute tier](serverless-tier-overview.md) is currently availabl
 |Columnstore support|Yes <sup>1</sup>|Yes|Yes|Yes|Yes|
 |In-memory OLTP storage (GB)|N/A|N/A|N/A|N/A|N/A|
 |Max data size (GB)|512|1024|1024|1024|2048|
-|Max log size (GB) <sup>2</sup>|154|307|307|307|461|
+|Max log size (GB) <sup>2</sup>|154|307|307|460|614|
 |Tempdb max data size (GB)|32|64|128|192|256|
 |Storage type|Remote SSD|Remote SSD|Remote SSD|Remote SSD|Remote SSD|
 |Read IO latency (approximate)|5-10 ms|5-10 ms|5-10 ms|5-10 ms|5-10 ms|
@@ -98,7 +98,7 @@ The [serverless compute tier](serverless-tier-overview.md) is currently availabl
 |Columnstore support|Yes|Yes|Yes|Yes|Yes|
 |In-memory OLTP storage (GB)|N/A|N/A|N/A|N/A|N/A|
 |Max data size (GB)|2048|3072|3072|3072|3072|
-|Max log size (GB) <sup>1</sup>|461|461|461|922|922|
+|Max log size (GB) <sup>1</sup>|614|1024|1024|1024|1024|
 |Tempdb max data size (GB)|320|384|448|512|576|
 |Storage type|Remote SSD|Remote SSD|Remote SSD|Remote SSD|Remote SSD|
 |Read IO latency (approximate)|5-10 ms|5-10 ms|5-10 ms|5-10 ms|5-10 ms|
@@ -130,7 +130,7 @@ The [serverless compute tier](serverless-tier-overview.md) is currently availabl
 |Columnstore support|Yes|Yes|Yes|Yes|Yes|
 |In-memory OLTP storage (GB)|N/A|N/A|N/A|N/A|N/A|
 |Max data size (GB)|3072|4096|4096|4096|4096|
-|Max log size (GB) <sup>1</sup>|922|1024|1024|1024|1024|
+|Max log size (GB) <sup>1</sup>|1024|1024|1024|1024|1024|
 |Tempdb max data size (GB)|640|768|1024|1280|2560|
 |Storage type|Remote SSD|Remote SSD|Remote SSD|Remote SSD|Remote SSD|
 |Read IO latency (approximate)|5-10 ms|5-10 ms|5-10 ms|5-10 ms|5-10 ms|
@@ -272,7 +272,7 @@ The [serverless compute tier](serverless-tier-overview.md) is currently availabl
 |Columnstore support|Yes|Yes|Yes|Yes|Yes|Yes|Yes|
 |In-memory OLTP storage (GB)|N/A|N/A|N/A|N/A|N/A|N/A|N/A|
 |Max data size (GB)|1024|1024|1536|2048|2048|3072|3072|
-|Max log size (GB) <sup>1</sup>|307|307|461|461|461|922|922|
+|Max log size (GB) <sup>1</sup>|307|307|461|614|614|1024|1024|
 |Tempdb max data size (GB)|64|128|192|256|320|384|384|
 |Storage type|Remote SSD|Remote SSD|Remote SSD|Remote SSD|Remote SSD|Remote SSD|Remote SSD|
 |Read IO latency (approximate)|5-10 ms|5-10 ms|5-10 ms|5-10 ms|5-10 ms|5-10 ms|5-10 ms|
@@ -303,7 +303,7 @@ The [serverless compute tier](serverless-tier-overview.md) is currently availabl
 |Columnstore support|Yes|Yes|Yes|Yes|Yes|Yes|Yes|
 |In-memory OLTP storage (GB)|N/A|N/A|N/A|N/A|N/A|N/A|N/A|
 |Max data size (GB)|3072|3072|3072|4096|4096|4096|4096|
-|Max log size (GB) <sup>1</sup>|922|922|922|1024|1024|1024|1024|
+|Max log size (GB) <sup>1</sup>|1024|1024|1024|1024|1024|1024|1024|
 |Tempdb max data size (GB)|512|576|640|768|1024|1280|2560|
 |Storage type|Remote SSD|Remote SSD|Remote SSD|Remote SSD|Remote SSD|Remote SSD|Remote SSD|
 |Read IO latency (approximate)|5-10 ms|5-10 ms|5-10 ms|5-10 ms|5-10 ms|5-10 ms|5-10 ms|
@@ -433,7 +433,7 @@ The [serverless compute tier](serverless-tier-overview.md) is currently availabl
 |Columnstore support|Yes|Yes|Yes|Yes|Yes|Yes|Yes|
 |In-memory OLTP storage (GB)|1.57|3.14|4.71|6.28|8.65|11.02|13.39|
 |Max data size (GB)|1024|1024|1536|2048|2048|3072|3072|
-|Max log size (GB) <sup>1</sup>|307|307|461|461|461|922|922|
+|Max log size (GB) <sup>1</sup>|307|307|461|614|614|1024|1024|
 |Tempdb max data size (GB)|64|128|192|256|320|384|448|
 |[Max local storage size](resource-limits-logical-server.md#storage-space-governance) (GB)|4829|4829|4829|4829|4829|4829|4829|
 |Storage type|Local SSD|Local SSD|Local SSD|Local SSD|Local SSD|Local SSD|Local SSD|
@@ -466,7 +466,7 @@ The [serverless compute tier](serverless-tier-overview.md) is currently availabl
 |Columnstore support|Yes|Yes|Yes|Yes|Yes|Yes|Yes|
 |In-memory OLTP storage (GB)|15.77|18.14|20.51|25.25|37.94|52.23|131.64|
 |Max data size (GB)|3072|3072|3072|4096|4096|4096|4096|
-|Max log size (GB) <sup>1</sup>|922|922|922|1024|1024|1024|1024|
+|Max log size (GB) <sup>1</sup>|1024|1024|1024|1024|1024|1024|1024|
 |Tempdb max data size (GB)|512|576|640|768|1024|1280|2560|
 |[Max local storage size](resource-limits-logical-server.md#storage-space-governance) (GB)|4829|4829|4829|4829|4829|4829|4829|
 |Storage type|Local SSD|Local SSD|Local SSD|Local SSD|Local SSD|Local SSD|Local SSD|


### PR DESCRIPTION
Max log size (GB) is incorrect int tables for Standard-series (Gen5), provisioned and serverless (All with max available Data size)  BusinessCritical Edition with BC_Gen5 sku and 
GeneralPurpose Edition with GP_Gen5 sku
8 vCores 614.4 GB LOG SPACE ALLOCATED
10 vCores 614.4 GB LOG SPACE ALLOCATED
12 vCores 1 TB LOG SPACE ALLOCATED
14 vCores 1 TB LOG SPACE ALLOCATED
16 vCores 1 TB LOG SPACE ALLOCATED
...
80 vCores 1 TB LOG SPACE ALLOCATED
Cheers,
Zoran Barac