### PR TITLE
Add SELECT to auditable statements

### DIFF
--- a/azure-sql/database/data-discovery-and-classification-overview.md
+++ b/azure-sql/database/data-discovery-and-classification-overview.md
@@ -150,6 +150,7 @@ An important aspect of the classification is the ability to monitor access to se
 These are the activities that are actually auditable with sensitivity information:
 - ALTER TABLE ... DROP COLUMN
 - BULK INSERT
+- SELECT
 - DELETE
 - INSERT
 - MERGE


### PR DESCRIPTION
In my testing, issuing a SELECT statement that includes columns with sensitivity labels added results in the sensitivity information being added to the audit record for that query. The list of activities that are auditable does not include SELECT which would suggest to readers that the sensitivity labels would not be included in the audit record for a SELECT statement