### PR TITLE
Update accelerated-database-recovery-concepts.md

### DIFF
--- a/docs/relational-databases/accelerated-database-recovery-concepts.md
+++ b/docs/relational-databases/accelerated-database-recovery-concepts.md
@@ -159,7 +159,7 @@ There are several improvements to address persistent version store (PVS) storage
   
   Beginning with [!INCLUDE[sssql22-md](../includes/sssql22-md.md)], this process uses multi-threaded version cleanup at the database level. This allows multiple threads for cleanup for each database. This improvement is valuable when you have multiple large databases.
 
-  To adjust the number of threads for version cleanup scalability, set `ADR Cleaner Thread Count` with `sp_configure`.
+  To adjust the number of threads for version cleanup scalability, set `ADR Cleaner Thread Count` with `sp_configure`. The thread count is capped at the number of cores for the instance.
 
   The example below changes the thread count to 4:
 


### PR DESCRIPTION
- **Multi-threaded version cleanup**  
  
  In [!INCLUDE[sssql19-md](../includes/sssql19-md.md)], the cleanup process is single threaded within a SQL Server instance.
  
  Beginning with [!INCLUDE[sssql22-md](../includes/sssql22-md.md)], this process uses multi-threaded version cleanup at the database level. This allows multiple threads for cleanup for each database. This improvement is valuable when you have multiple large databases.

  To adjust the number of threads for version cleanup scalability, set `ADR Cleaner Thread Count` with `sp_configure`. Is there a cap on the ADR cleaner thread count. Is it at capped to number of cores? If so, do we need to add something like "The thread count is capped at the number of cores for the instance." as added in the MD with this pull request. 

  The example below changes the thread count to 4:

  ```sql EXEC sp_configure 'ADR Cleaner Thread Count', '4' RECONFIGURE WITH OVERRIDE;  ```