### PR TITLE
Update strategies-for-backing-up-and-restoring-snapshot-and-transacti…

### DIFF
--- a/docs/relational-databases/replication/administration/strategies-for-backing-up-and-restoring-snapshot-and-transactional-replication.md
+++ b/docs/relational-databases/replication/administration/strategies-for-backing-up-and-restoring-snapshot-and-transactional-replication.md
@@ -64,6 +64,13 @@ monikerRange: "=azuresqldb-current||>=sql-server-2016"
   
     > [!NOTE]  
     >  The **sync with backup** option ensures consistency between the publication database and the distribution database, but the option does not guarantee against data loss. For example, if the transaction log is lost, transactions that have been committed since the last transaction log backup will not be available in the publication database or the distribution database. This is the same behavior as a nonreplicated database.  
+    
+    >  Setting of sync with backup option on distribution database is not compatible when publisher database is part of availability group. This could lead to following error when log reader agent runs post failover -  
+
+    > The process could not execute 'sp_repldone/sp_replcounters' on 'machinename\instance'. (Source: MSSQL_REPL, Error number: MSSQL_REPL20011)
+Get help: http://help/MSSQL_REPL20011
+Possible inconsistent state in the distribution database: dist_backup_lsn {nnnnnnnn:nnnnnnnn:nnnn}, dist_last_lsn {nnnnnnnn:nnnnnnnn:nnnn}. Execute "sp_repldone NULL, NULL, 0, 0, 1", and then execute sp_replflush. Reinitialize all subscriptions to the publication. (Source: MSSQLServer, Error number: 18846)
+
   
  **To set the sync with backup option**  
   


### PR DESCRIPTION
…onal-replication.md

Updated note with this after discussing with akbarf: 
Setting of sync with backup option on distribution database is not compatible when publisher database is part of availability group. This could lead to following error when log reader agent runs post failover -