### PR TITLE
Update acquire-and-configure-loading-server.md

### DIFF
--- a/docs/analytics-platform-system/acquire-and-configure-loading-server.md
+++ b/docs/analytics-platform-system/acquire-and-configure-loading-server.md
@@ -32,13 +32,13 @@ The loading system can be designed as one or more loading servers that perform c
   
 The system requirements for a loading server depend almost completely on your own workload. Use the [Loading Server Capacity Planning Worksheet](loading-server-capacity-planning-worksheet.md) to help determine your capacity requirements.  
   
-## <a name="Step2"></a>Step 2: Acquire the sServer  
+## <a name="Step2"></a>Step 2: Acquire the Server  
 Now that you better understand your capacity requirements, you can plan the servers and networking components that you will need to purchase or provision. Incorporate the following list of requirements into your purchasing plan, and then purchase your server or provision an existing server.  
   
 ### <a name="R"></a>Software Requirements  
 Supported Operating Systems:  
   
--   Windows Server 2012 or Windows Server 2012 R2. These operating systems require the FDR network adapter.  
+-   Windows Server 2012, Windows Server 2012 R2 or beyond. These operating systems require the FDR network adapter.  
   
 -   Windows Server 2008 R2. This OS requires the DDR network adapter.  
   

--- a/docs/analytics-platform-system/acquire-and-configure-loading-server.md
+++ b/docs/analytics-platform-system/acquire-and-configure-loading-server.md
@@ -4,7 +4,7 @@ description: This article describes how to acquire and configure a loading serve
 author: charlesfeddersen
 ms.author: charlesf
 ms.reviewer: martinle
-ms.date: 04/17/2018
+ms.date: 01/31/2023
 ms.service: sql
 ms.subservice: data-warehouse
 ms.topic: conceptual

--- a/docs/analytics-platform-system/acquire-and-configure-loading-server.md
+++ b/docs/analytics-platform-system/acquire-and-configure-loading-server.md
@@ -38,7 +38,8 @@ Now that you better understand your capacity requirements, you can plan the serv
 ### <a name="R"></a>Software Requirements  
 Supported Operating Systems:  
   
--   Windows Server 2012, Windows Server 2012 R2 or beyond. These operating systems require the FDR network adapter.  
+-   Windows Server 2012, Windows Server 2012 R2, or later versions. These operating systems require the FDR network adapter.  
+
   
 -   Windows Server 2008 R2. This OS requires the DDR network adapter.  
   


### PR DESCRIPTION
One typo fixed. 

More importantly, trying to address inconsistency between Supported Operating Systems and Performance + Security, where Supported OS is currently limited to WS2008 & 2012, whereas Performance and Security Notices both refer to "Windows Server 2012 and beyond". I have customers that ask as this doc is unclear. I would expect newer versions to be supported but hope this edit brings the question to those that know so the documentation can be more consistent.