### PR TITLE
Update data-type-synonyms-transact-sql.md

### DIFF
--- a/docs/t-sql/data-types/data-type-synonyms-transact-sql.md
+++ b/docs/t-sql/data-types/data-type-synonyms-transact-sql.md
@@ -21,14 +21,14 @@ Data type synonyms are included in [!INCLUDE[ssNoVersion](../../includes/ssnover
   
 |Synonym|SQL Server system data type|  
 |---|---|
-|**Binary varying**|**varbinary**|  
+|**binary varying**|**varbinary**|  
 |**char varying**|**varchar**|  
 |**character**|**char**|  
 |**character**|**char(1)**|  
 |**character(**_n_**)**|**char(n)**|  
 |**character varying(**_n_**)**|**varchar(n)**|  
-|**Dec**|**decimal**|  
-|**Double precision**|**float**|  
+|**dec**|**decimal**|  
+|**double precision**|**float**|  
 |**float**[**(**_n_**)**] for _n_ = 1-7|**real**|  
 |**float**[**(**_n_**)**] for _n_ = 8-15|**float**|  
 |**integer**|**int**|  


### PR DESCRIPTION
There's no statement that the alias names are case-sensitive at all. It's confusing that a few of the alias names are shown with initial caps while the rest are all-lowercase. Let's make the capitalization consistent for all of them, unless there's some subtle nuance about the init-capped names.