### PR TITLE
Update dbcc-shrinkdatabase-transact-sql.md

### DIFF
--- a/docs/t-sql/database-console-commands/dbcc-shrinkdatabase-transact-sql.md
+++ b/docs/t-sql/database-console-commands/dbcc-shrinkdatabase-transact-sql.md
@@ -102,7 +102,6 @@ The wait at low priority feature reduces lock contention. For more information, 
 
 This feature is similar to the [WAIT_AT_LOW_PRIORITY with online index operations](../statements/alter-table-transact-sql.md#wait_at_low_priority), with some differences.
 
-- You cannot modify MAX_DURATION. The wait duration is 60000 milliseconds (1 minute).
 - You cannot specify ABORT_AFTER_WAIT option NONE.
 
 #### WAIT_AT_LOW_PRIORITY


### PR DESCRIPTION
Removed the statement indicating the inability to modify the timeout parameter with WAIT_AT_LOW_PRIORITY.