### PR TITLE
Update cryptographic-functions-transact-sql.md - fix typo in function name

### DIFF
--- a/docs/t-sql/functions/cryptographic-functions-transact-sql.md
+++ b/docs/t-sql/functions/cryptographic-functions-transact-sql.md
@@ -110,7 +110,7 @@ These functions support digital signing, digital signature validation, encryptio
         [SIGNBYCERT](../../t-sql/functions/signbycert-transact-sql.md)
     :::column-end:::
     :::column:::
-        [VERIGYSIGNEDBYCERT](../../t-sql/functions/verifysignedbycert-transact-sql.md)
+        [VERIFYSIGNEDBYCERT](../../t-sql/functions/verifysignedbycert-transact-sql.md)
     :::column-end:::
 :::row-end:::
 :::row:::

--- a/docs/t-sql/functions/cryptographic-functions-transact-sql.md
+++ b/docs/t-sql/functions/cryptographic-functions-transact-sql.md
@@ -102,7 +102,7 @@ These functions support digital signing, digital signature validation, encryptio
         [SIGNBYASYMKEY](../../t-sql/functions/signbyasymkey-transact-sql.md)
     :::column-end:::
     :::column:::
-        [VERIFYSIGNEDBYASMKEY](../../t-sql/functions/verifysignedbyasymkey-transact-sql.md)
+        [VERIFYSIGNEDBYASYMKEY](../../t-sql/functions/verifysignedbyasymkey-transact-sql.md)
     :::column-end:::
 :::row-end:::
 :::row:::


### PR DESCRIPTION
Fix typo 'VERIGYSIGNEDBYCERT' in function name. The link had the name spelled correctly so clicking on it still worked as expected.