### PR TITLE
Update allow-polybase-export.md

### DIFF
--- a/docs/database-engine/configure-windows/allow-polybase-export.md
+++ b/docs/database-engine/configure-windows/allow-polybase-export.md
@@ -13,7 +13,7 @@ ms.topic: conceptual
 
 [!INCLUDE [sqlserver2016](../../includes/applies-to-version/sqlserver2016.md)]
 
-`allow polybase export` server configuration option  allows `INSERT` into a Hadoop external table. 
+`allow polybase export` server configuration option  allows `INSERT` into an external table. 
 
 This feature does not support insert into other external data sources.
 
@@ -36,7 +36,7 @@ sp_configure 'show advanced options', 1;
 GO
 RECONFIGURE;
 GO
-sp_configure 'allow polybase export', 0;
+sp_configure 'allow polybase export', 1;
 GO
 RECONFIGURE;
 GO


### PR DESCRIPTION
The documentation is inconsistent, https://learn.microsoft.com/en-us/sql/t-sql/statements/create-external-table-as-select-transact-sql?view=sql-server-linux-ver16 states: For SQL Server 2022 (16.x), the option allow polybase export must be enabled on sp_configure. For more information, see Set allow polybase export configuration option. On this page the documentation limits this setting to hadoop external tables, however it also applies to S3 external tables etc. Sample code states the code should enable the setting, sample code however used to run with 0 which means the the feature gets disabled. Looks like this sample code was never run on a machine ;-)