### PR TITLE
Updating the link to the resources

### DIFF
--- a/docs/machine-learning/tutorials/python-ski-rental-linear-regression.md
+++ b/docs/machine-learning/tutorials/python-ski-rental-linear-regression.md
@@ -80,7 +80,7 @@ The sample database used in this tutorial has been saved to a **.bak** database 
 ::: moniker-end
 
 ::: moniker range=">=sql-server-2017||>=sql-server-linux-ver15"
-1. Download the file [TutorialDB.bak](https://sqlchoice.blob.core.windows.net/sqlchoice/static/TutorialDB.bak).
+1. Download the file [TutorialDB.bak](https://rserverdistribution.blob.core.windows.net/production/sqlmldocument/TutorialDB.bak).
 
 1. Follow the directions in [Restore a database from a backup file](../../azure-data-studio/tutorial-backup-restore-sql-server.md#restore-a-database-from-a-backup-file) in Azure Data Studio, using these details:
 
@@ -96,7 +96,7 @@ The sample database used in this tutorial has been saved to a **.bak** database 
 
 ::: moniker-end
 ::: moniker range="=azuresqldb-mi-current"
-1. Download the file [TutorialDB.bak](https://sqlchoice.blob.core.windows.net/sqlchoice/static/TutorialDB.bak).
+1. Download the file [TutorialDB.bak](https://rserverdistribution.blob.core.windows.net/production/sqlmldocument/TutorialDB.bak).
 
 1. Follow the directions in [Restore a database to Azure SQL Managed Instance](/azure/sql-database/sql-database-managed-instance-get-started-restore) in SQL Server Management Studio, using these details:
 


### PR DESCRIPTION
We needed to migrate the resources required in this tutorial to a production container with public access so users can keep their access to this resource. This PR addresses the issue of broken links to those resources.