### PR TITLE
Update sql-server-2022-release-notes.md

### DIFF
--- a/docs/sql-server/sql-server-2022-release-notes.md
+++ b/docs/sql-server/sql-server-2022-release-notes.md
@@ -91,7 +91,7 @@ An issue in the TDS 8.0 protocol implementation may cause RPC calls to fail if t
 
 The fix for this issue will be released in Cumulative Update 1 for [!INCLUDE [sssql22-md](../includes/sssql22-md.md)].
 
-To work around this issue, you can use Trace Flag 12342 as either as startup trace flag, or at the session level (using `DBCC TRACEON`).
+To work around this issue, you can use Trace Flag 12324 as either as startup trace flag, or at the session level (using `DBCC TRACEON`).
 
 ## Build number
 


### PR DESCRIPTION
Corrected typo - two digits were swapped in trace-flag number.