### PR TITLE
Update percent-character-wildcard-character-s-to-match-transact-sql.md

### DIFF
--- a/docs/t-sql/language-elements/percent-character-wildcard-character-s-to-match-transact-sql.md
+++ b/docs/t-sql/language-elements/percent-character-wildcard-character-s-to-match-transact-sql.md
@@ -25,18 +25,18 @@ dev_langs:
 # Percent character (Wildcard - Character(s) to Match) (Transact-SQL)
 [!INCLUDE [SQL Server Azure SQL Database Azure SQL Managed Instance](../../includes/applies-to-version/sql-asdb-asdbmi.md)]
 
-  Matches any string of zero or more characters. This wildcard character can be used as either a prefix or a suffix.  
-  
+Matches any string of zero or more characters. This wildcard character can be used as a prefix, a suffix, or in the middle of the string. The pattern string can contain more than one % wildcard.  
+
 ## Examples  
  The following example returns all the first names of people in the `Person` table of `AdventureWorks2012` that start with `Dan`.  
-  
-```syntaxsql  
--- Uses AdventureWorks  
-  
-SELECT FirstName, LastName  
-FROM Person.Person  
-WHERE FirstName LIKE 'Dan%';  
-GO  
+
+```syntaxsql
+-- Uses AdventureWorks
+
+SELECT FirstName, LastName
+FROM Person.Person
+WHERE FirstName LIKE 'Dan%';
+GO
 ```  
   
 ## See Also  


### PR DESCRIPTION
Clarified that LIKE parameters such as 'Jo%n' and '%ari%' would also match. The current description makes it seem like a single % has to go at the beginning or end of the string.

I also deleted 2 trailing spaces from several lines. I presume those aren't significant.