### PR TITLE
update tabColorMode setting

### DIFF
--- a/docs/azure-data-studio/settings.md
+++ b/docs/azure-data-studio/settings.md
@@ -52,7 +52,7 @@ By default, hot exit's off. Enable hot exit by editing the `files.hotExit` setti
 
 ## Tab color
 
-To simplify identifying what connections you're working with, open tabs in the editor can have their colors set to match the color of the Server Group the connection belongs to. By default, tab colors are off by default. Enable tab colors by editing the `sql.tabColorMode` setting.
+To simplify identifying what connections you're working with, open tabs in the editor can have their colors set to match the color of the Server Group the connection belongs to. By default, tab colors are off by default. Enable tab colors by editing the `queryEditor.tabColorMode` setting.
 
 ## Additional resources
 


### PR DESCRIPTION
When updating via the settings UI, these setting appears to use `queryEditor` instead of `sql` now:

`"queryEditor.tabColorMode": "fill"`