### PR TITLE
CREATE INDEX: "rebuild" should not be a keyword in DROP_EXISTING description

### DIFF
--- a/docs/t-sql/statements/create-index-transact-sql.md
+++ b/docs/t-sql/statements/create-index-transact-sql.md
@@ -464,10 +464,10 @@ If per partition statistics are not supported the option is ignored and a warnin
 Is an option to drop and rebuild the existing clustered or nonclustered index with modified column specifications, and keep the same name for the index. The default is **OFF**.
 
 ON  
-Specifies to `DROP` and `REBUILD` the existing index, which must have the same name as the parameter *index_name*.
+Specifies to `DROP` and rebuild the existing index, which must have the same name as the parameter *index_name*.
 
 OFF  
-Specifies not to `DROP` and `REBUILD` the existing index. SQL Server displays an error if the specified index name already exists.
+Specifies not to `DROP` and rebuild the existing index. SQL Server displays an error if the specified index name already exists.
 
 With `DROP_EXISTING`, you can change:
 


### PR DESCRIPTION
It makes no sense to do a `REBUILD` of the index after it is dropped. The meaning in this context of "rebuild" is to re-create the index, it's not a keyword.