### PR TITLE
Update sys-dm-server-suspend-status.md

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-server-suspend-status.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-server-suspend-status.md
@@ -35,7 +35,7 @@ Returns a row for each database in a suspended state. For more information, see 
   
 ## Permissions  
 
-Principals must have the **VIEW SERVER STATE** permission.  
+Principals must have the **VIEW SERVER PERFORMANCE STATE** permission.  
   
 [!INCLUDE[ssCatViewPerm](../../includes/sscatviewperm-md.md)] For more information, see [Metadata Visibility Configuration](../../relational-databases/security/metadata-visibility-configuration.md).  
   

--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-server-suspend-status.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-server-suspend-status.md
@@ -16,6 +16,7 @@ helpviewer_keywords:
   - "sys.dm_server_suspend_status dynamic management view"
 dev_langs:
   - "TSQL"
+monikerRange: ">=sql-server-2022"
 ---
 
 # sys.dm_server_suspend_status (Transact-SQL)


### PR DESCRIPTION
There are two errors with this topic. 
1) The required permission is wrong. This I have corrected. 2) The other one I have not corrected, since I don't know how to do it. The page is incorrectly linked. When I search for "sys.dm_server_suspend_status" with SQL 2022 as the active session, I end up at https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-server-suspend-status?view=azuresqldb-current&viewFallbackFrom=sql-server-ver16, and there is a banner saying "The requested page is not available for SQL Server 2022. You have been redirected to the newest product version this page is available for." The DMV certainly exists in SQL 2022 (but not in earlier versions). It does not seem to exist in Azure SQL Database. in the Search box with