### PR TITLE
fix typo for decimal notation for 0.000000000000000005

### DIFF
--- a/docs/t-sql/data-types/decimal-and-numeric-transact-sql.md
+++ b/docs/t-sql/data-types/decimal-and-numeric-transact-sql.md
@@ -58,7 +58,7 @@ Converting from **decimal** or **numeric** to **float** or **real** can cause so
   
 By default, [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] uses rounding when converting a number to a **decimal** or **numeric** value with a lower precision and scale. Conversely, if the SET ARITHABORT option is ON, [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] raises an error when overflow occurs. Loss of only precision and scale isn't sufficient to raise an error.
   
-Prior to [!INCLUDE[ssSQL16](../../includes/sssql16-md.md)], conversion of **float** values to **decimal** or **numeric** is restricted to values of precision 17 digits only. Any **float** value less than 5E-18 (when set using either the scientific notation of 5E-18 or the decimal notation of 0.0000000000000000050000000000000005) rounds down to 0. This is no longer a restriction as of [!INCLUDE[ssSQL16](../../includes/sssql16-md.md)].
+Prior to [!INCLUDE[ssSQL16](../../includes/sssql16-md.md)], conversion of **float** values to **decimal** or **numeric** is restricted to values of precision 17 digits only. Any **float** value less than 5E-18 (when set using either the scientific notation of 5E-18 or the decimal notation of 0.000000000000000005) rounds down to 0. This is no longer a restriction as of [!INCLUDE[ssSQL16](../../includes/sssql16-md.md)].
   
 ## Examples  
 The following example creates a table using the **decimal** and **numeric** data types.  Values are inserted into each column. The results are returned by using a SELECT statement.


### PR DESCRIPTION
replace 0.0000000000000000050000000000000005 by 0.000000000000000005  (5E-18)