### PR TITLE
Fix include in Synpase ACID note

### DIFF
--- a/docs/t-sql/statements/set-transaction-isolation-level-transact-sql.md
+++ b/docs/t-sql/statements/set-transaction-isolation-level-transact-sql.md
@@ -54,7 +54,7 @@ SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
 ```
 
 >[!NOTE]
-> [!INCLUDEssazuresynapse-md(../../includes/ssazuresynapse-md.md)] implements ACID transactions. The isolation level of the transactional support is default to READ UNCOMMITTED.  You can change it to READ COMMITTED SNAPSHOT ISOLATION by turning ON the READ_COMMITTED_SNAPSHOT database option for a user database when connected to the master database.  Once enabled, all transactions in this database are executed under READ COMMITTED SNAPSHOT ISOLATION and the setting READ UNCOMMITTED on session level will not be honored. Check [ALTER DATABASE SET options (Transact-SQL)](../../t-sql/statements/alter-database-transact-sql-set-options.md) for details.  
+> [!INCLUDE[ssazuresynapse-md](../../includes/ssazuresynapse-md.md)] implements ACID transactions. The isolation level of the transactional support is default to READ UNCOMMITTED.  You can change it to READ COMMITTED SNAPSHOT ISOLATION by turning ON the READ_COMMITTED_SNAPSHOT database option for a user database when connected to the master database.  Once enabled, all transactions in this database are executed under READ COMMITTED SNAPSHOT ISOLATION and the setting READ UNCOMMITTED on session level will not be honored. Check [ALTER DATABASE SET options (Transact-SQL)](../../t-sql/statements/alter-database-transact-sql-set-options.md) for details.  
 
 [!INCLUDE[sql-server-tsql-previous-offline-documentation](../../includes/sql-server-tsql-previous-offline-documentation.md)]
 


### PR DESCRIPTION
Missing space/square brackets causes rendering error:

![image](https://user-images.githubusercontent.com/13032613/211283264-75c0ae84-0bb9-49a3-b82a-e9d48b03d89e.png)
