### PR TITLE
Fix ssazuresynapse-md leaking into !INCLUDE directives

### DIFF
--- a/docs/t-sql/statements/alter-materialized-view-transact-sql.md
+++ b/docs/t-sql/statements/alter-materialized-view-transact-sql.md
@@ -81,6 +81,6 @@ ALTER MATERIALIZED VIEW My_Indexed_View REBUILD;
 [sys.pdw_materialized_view_distribution_properties &#40;Transact-SQL&#41;](../../relational-databases/system-catalog-views/sys-pdw-materialized-view-distribution-properties-transact-sql.md?view=azure-sqldw-latest&preserve-view=true)   
 [sys.pdw_materialized_view_mappings &#40;Transact-SQL&#41;](../../relational-databases/system-catalog-views/sys-pdw-materialized-view-mappings-transact-sql.md?view=azure-sqldw-latest&preserve-view=true)   
 [DBCC PDW_SHOWMATERIALIZEDVIEWOVERHEAD &#40;Transact-SQL&#41;](../database-console-commands/dbcc-pdw-showmaterializedviewoverhead-transact-sql.md?view=azure-sqldw-latest&preserve-view=true)   
-[[!INCLUDE ssazuresynapse-md(../../includes/ssazuresynapse-md.md)] and [!INCLUDE[ssPDW](../../includes/sspdw-md.md)] Views](../../relational-databases/system-catalog-views/sql-data-warehouse-and-parallel-data-warehouse-catalog-views.md)   
+[[!INCLUDE[ssazuresynapse-md](../../includes/ssazuresynapse-md.md)] and [!INCLUDE[ssPDW](../../includes/sspdw-md.md)] Views](../../relational-databases/system-catalog-views/sql-data-warehouse-and-parallel-data-warehouse-catalog-views.md)   
 [System views supported in [!INCLUDEssazuresynapse-md(../../includes/ssazuresynapse-md.md)]](/azure/sql-data-warehouse/sql-data-warehouse-reference-tsql-system-views)   
-[T-SQL statements supported in [!INCLUDE ssazuresynapse-md(../../includes/ssazuresynapse-md.md)]](/azure/sql-data-warehouse/sql-data-warehouse-reference-tsql-statements)
+[T-SQL statements supported in [!INCLUDE[ssazuresynapse-md](../../includes/ssazuresynapse-md.md)]](/azure/sql-data-warehouse/sql-data-warehouse-reference-tsql-statements)

--- a/docs/t-sql/statements/alter-materialized-view-transact-sql.md
+++ b/docs/t-sql/statements/alter-materialized-view-transact-sql.md
@@ -81,6 +81,6 @@ ALTER MATERIALIZED VIEW My_Indexed_View REBUILD;
 [sys.pdw_materialized_view_distribution_properties &#40;Transact-SQL&#41;](../../relational-databases/system-catalog-views/sys-pdw-materialized-view-distribution-properties-transact-sql.md?view=azure-sqldw-latest&preserve-view=true)   
 [sys.pdw_materialized_view_mappings &#40;Transact-SQL&#41;](../../relational-databases/system-catalog-views/sys-pdw-materialized-view-mappings-transact-sql.md?view=azure-sqldw-latest&preserve-view=true)   
 [DBCC PDW_SHOWMATERIALIZEDVIEWOVERHEAD &#40;Transact-SQL&#41;](../database-console-commands/dbcc-pdw-showmaterializedviewoverhead-transact-sql.md?view=azure-sqldw-latest&preserve-view=true)   
-[[!INCLUDEssazuresynapse-md(../../includes/ssazuresynapse-md.md)] and [!INCLUDE[ssPDW](../../includes/sspdw-md.md)] Views](../../relational-databases/system-catalog-views/sql-data-warehouse-and-parallel-data-warehouse-catalog-views.md)   
+[[!INCLUDE ssazuresynapse-md(../../includes/ssazuresynapse-md.md)] and [!INCLUDE[ssPDW](../../includes/sspdw-md.md)] Views](../../relational-databases/system-catalog-views/sql-data-warehouse-and-parallel-data-warehouse-catalog-views.md)   
 [System views supported in [!INCLUDEssazuresynapse-md(../../includes/ssazuresynapse-md.md)]](/azure/sql-data-warehouse/sql-data-warehouse-reference-tsql-system-views)   
-[T-SQL statements supported in [!INCLUDEssazuresynapse-md(../../includes/ssazuresynapse-md.md)]](/azure/sql-data-warehouse/sql-data-warehouse-reference-tsql-statements)
+[T-SQL statements supported in [!INCLUDE ssazuresynapse-md(../../includes/ssazuresynapse-md.md)]](/azure/sql-data-warehouse/sql-data-warehouse-reference-tsql-statements)

--- a/docs/t-sql/statements/alter-materialized-view-transact-sql.md
+++ b/docs/t-sql/statements/alter-materialized-view-transact-sql.md
@@ -82,5 +82,5 @@ ALTER MATERIALIZED VIEW My_Indexed_View REBUILD;
 [sys.pdw_materialized_view_mappings &#40;Transact-SQL&#41;](../../relational-databases/system-catalog-views/sys-pdw-materialized-view-mappings-transact-sql.md?view=azure-sqldw-latest&preserve-view=true)   
 [DBCC PDW_SHOWMATERIALIZEDVIEWOVERHEAD &#40;Transact-SQL&#41;](../database-console-commands/dbcc-pdw-showmaterializedviewoverhead-transact-sql.md?view=azure-sqldw-latest&preserve-view=true)   
 [[!INCLUDE[ssazuresynapse-md](../../includes/ssazuresynapse-md.md)] and [!INCLUDE[ssPDW](../../includes/sspdw-md.md)] Views](../../relational-databases/system-catalog-views/sql-data-warehouse-and-parallel-data-warehouse-catalog-views.md)   
-[System views supported in [!INCLUDEssazuresynapse-md(../../includes/ssazuresynapse-md.md)]](/azure/sql-data-warehouse/sql-data-warehouse-reference-tsql-system-views)   
+[System views supported in [!INCLUDE[ssazuresynapse-md](../../includes/ssazuresynapse-md.md)]](/azure/sql-data-warehouse/sql-data-warehouse-reference-tsql-system-views)   
 [T-SQL statements supported in [!INCLUDE[ssazuresynapse-md](../../includes/ssazuresynapse-md.md)]](/azure/sql-data-warehouse/sql-data-warehouse-reference-tsql-statements)


### PR DESCRIPTION
I'm not familiar with whether the right fix is a space, or some square brackets or something else. So my proposed change is just a placeholder to point out the spots with the problem. On this page, the !INCLUDE lines for ssazuresynapse-md are leaking through into the text. On https://learn.microsoft.com/en-us/sql/t-sql/statements/alter-materialized-view-transact-sql?view=azure-sqldw-latest I see this text rendered under "See also":
```
DBCC PDW_SHOWMATERIALIZEDVIEWOVERHEAD (Transact-SQL)
[!INCLUDEssazuresynapse-md(../../includes/ssazuresynapse-md.md)] and Analytics Platform System (PDW) Views
System views supported in [!INCLUDEssazuresynapse-md(../../includes/ssazuresynapse-md.md)]
T-SQL statements supported in [!INCLUDEssazuresynapse-md(../../includes/ssazuresynapse-md.md)]
```

The same malformed include directives occur in other places. I have been seeing the same sort of !INCLUDE text on other T-SQL doc pages lately, so I think all these files are affected:
```
t-sql/database-console-commands/dbcc-checkident-transact-sql.md
t-sql/database-console-commands/dbcc-dropcleanbuffers-transact-sql.md
t-sql/database-console-commands/dbcc-dropresultsetcache-transact-sql.md
t-sql/database-console-commands/dbcc-freeproccache-transact-sql.md
t-sql/database-console-commands/dbcc-pdw-showexecutionplan-transact-sql.md
t-sql/database-console-commands/dbcc-pdw-showmaterializedviewoverhead-transact-sql.md
t-sql/database-console-commands/dbcc-pdw-showpartitionstats-transact-sql.md
t-sql/database-console-commands/dbcc-pdw-showspaceused-transact-sql.md
t-sql/database-console-commands/dbcc-show-statistics-transact-sql.md
t-sql/database-console-commands/dbcc-showresultcachespaceused-transact-sql.md
t-sql/database-console-commands/dbcc-shrinkdatabase-transact-sql.md
t-sql/functions/databasepropertyex-transact-sql.md
t-sql/functions/serverproperty-transact-sql.md
t-sql/functions/session-id-transact-sql.md
t-sql/functions/version-transact-sql-metadata-functions.md
t-sql/language-elements/begin-transaction-transact-sql.md
t-sql/language-elements/commit-transaction-transact-sql.md
t-sql/language-elements/expressions-transact-sql.md
t-sql/language-elements/like-transact-sql.md
t-sql/language-elements/reserved-keywords-transact-sql.md
t-sql/language-elements/transactions-sql-data-warehouse.md
t-sql/queries/aliasing-azure-sql-data-warehouse-parallel-data-warehouse.md
t-sql/queries/explain-transact-sql.md
t-sql/queries/from-transact-sql.md
t-sql/queries/queries.md
t-sql/queries/select-group-by-transact-sql.md
t-sql/queries/subqueries-azure-sql-data-warehouse-parallel-data-warehouse.md
t-sql/queries/top-transact-sql.md
t-sql/queries/update-transact-sql.md
t-sql/queries/with-common-table-expression-transact-sql.md
t-sql/statements/alter-authorization-transact-sql.md
t-sql/statements/alter-database-transact-sql-set-options.md
t-sql/statements/alter-external-data-source-transact-sql.md
t-sql/statements/alter-index-transact-sql.md
t-sql/statements/alter-materialized-view-transact-sql.md
t-sql/statements/alter-role-transact-sql.md
t-sql/statements/backup-transact-sql.md
t-sql/statements/copy-into-transact-sql.md
t-sql/statements/create-columnstore-index-transact-sql.md
t-sql/statements/create-database-scoped-credential-transact-sql.md
t-sql/statements/create-database-transact-sql.md
t-sql/statements/create-external-data-source-transact-sql.md
t-sql/statements/create-external-file-format-transact-sql.md
t-sql/statements/create-function-sql-data-warehouse.md
t-sql/statements/create-function-transact-sql.md
t-sql/statements/create-index-transact-sql.md
t-sql/statements/create-materialized-view-as-select-transact-sql.md
t-sql/statements/create-table-as-select-azure-sql-data-warehouse.md
t-sql/statements/create-table-azure-sql-data-warehouse.md
t-sql/statements/create-table-transact-sql.md
t-sql/statements/create-user-transact-sql.md
t-sql/statements/create-view-transact-sql.md
t-sql/statements/create-workload-classifier-transact-sql.md
t-sql/statements/drop-workload-classifier-transact-sql.md
t-sql/statements/execute-as-transact-sql.md
t-sql/statements/permissions-grant-deny-revoke-azure-sql-data-warehouse-parallel-data-warehouse.md
t-sql/statements/pick-a-product-template.md
t-sql/statements/rename-transact-sql.md
t-sql/statements/restore-statements-transact-sql.md
t-sql/statements/set-result-set-caching-transact-sql.md
t-sql/statements/set-statements-transact-sql.md
t-sql/statements/update-statistics-transact-sql.md
```