### PR TITLE
Fix include syntax

### DIFF
--- a/docs/t-sql/statements/create-columnstore-index-transact-sql.md
+++ b/docs/t-sql/statements/create-columnstore-index-transact-sql.md
@@ -125,7 +125,7 @@ Specifies the one-, two-, or three-part name of the table to be stored as a clus
 
 #### ORDER
 
-*Applies to [!INCLUDEssazuresynapse-md(../../includes/ssazuresynapse-md.md)], [!INCLUDE[ssPDW](../../includes/sspdw-md.md)], and [!INCLUDE[sssql22-md](../../includes/sssql22-md.md)] and later*
+*Applies to [!INCLUDE[ssazuresynapse-md](../../includes/ssazuresynapse-md.md)], [!INCLUDE[ssPDW](../../includes/sspdw-md.md)], and [!INCLUDE[sssql22-md](../../includes/sssql22-md.md)] and later*
 
 Use the `column_store_order_ordinal` column in [sys.index_columns](../../relational-databases/system-catalog-views/sys-index-columns-transact-sql.md) to determine the order of the column(s) for a clustered columnstore index. This aids with [segment elimination](../../relational-databases/indexes/columnstore-indexes-query-performance.md#segment-elimination), especially with string data. For more information, see [Performance tuning with ordered clustered columnstore index](/azure/synapse-analytics/sql-data-warehouse/performance-tuning-ordered-cci) and [Columnstore indexes design guidance](../../relational-databases/indexes/columnstore-indexes-design-guidance.md).
 


### PR DESCRIPTION
Fix syntax for ssazuresynapse-md include in [ORDER section](https://learn.microsoft.com/en-us/sql/t-sql/statements/create-columnstore-index-transact-sql?view=sql-server-ver16#order). Current syntax renders as:

![image](https://user-images.githubusercontent.com/13032613/212282780-acd0a742-5973-4539-9a08-7975262ab832.png)
