### PR TITLE
Repetition of word Service tiers in 44th Line.

### DIFF
--- a/azure-sql/database/service-tiers-sql-database-vcore.md
+++ b/azure-sql/database/service-tiers-sql-database-vcore.md
@@ -41,7 +41,7 @@ The vCore purchasing model used by Azure SQL Database provides several benefits 
 
 ## Service tiers
 
-Service tier options in the vCore purchasing model include General Purpose, Business Critical, and Hyperscale. The service tier generally service tier defines hardware, storage type and IOPS, high availability and disaster recovery options, and other features like memory optimized object types.
+Service tier options in the vCore purchasing model include General Purpose, Business Critical, and Hyperscale. The service tier generally defines hardware, storage type and IOPS, high availability and disaster recovery options, and other features like memory optimized object types.
 
 For greater details, review resource limits for [logical server](resource-limits-logical-server.md), [single databases](resource-limits-vcore-single-databases.md), and [pooled databases](resource-limits-vcore-elastic-pools.md). 
 


### PR DESCRIPTION
Hello PR reviewers,

Update service-tiers-sql-database-vcore.md, 
In this doc there is a repetition of the word "service tier" in the 44th line under the header ##Service tiers. 
Before my changes: "The service tier generally service tier defines hardware,".
After my changes: "The service tier generally defines hardware, ".