### PR TITLE
Caps the number of active sessions

### DIFF
--- a/azure-sql/database/xevent-db-diff-from-svr.md
+++ b/azure-sql/database/xevent-db-diff-from-svr.md
@@ -172,6 +172,12 @@ If you receive an error message that says a memory maximum was enforced, some co
 - Run fewer concurrent event sessions.
 - Through your **CREATE** and **ALTER** statements for event sessions, reduce the amount of memory you specify on the **MAX\_MEMORY** clause.
 
+There is a cap on number of active XEvent sessions in Azure SQL Database:
+  - In single Azure SQL Database, the limit is 100.
+  - In an elastic pool, the number of active Xevent sessions of all databases is 100.
+  
+
+
 ### Network latency
 
 The **Event File** target might experience network latency or failures while persisting data to Azure Storage blobs. Other events in Azure SQL Database might be delayed while they wait for the network communication to complete. This delay can slow your workload.

--- a/azure-sql/database/xevent-db-diff-from-svr.md
+++ b/azure-sql/database/xevent-db-diff-from-svr.md
@@ -173,7 +173,7 @@ If you receive an error message that says a memory maximum was enforced, some co
 - Through your **CREATE** and **ALTER** statements for event sessions, reduce the amount of memory you specify on the **MAX\_MEMORY** clause.
 
 There is a cap on number of started XEvent sessions in Azure SQL Database:
-  - In single Azure SQL Database, the limit is 100.
+  - In a single Azure SQL Database, the limit is 100.
   - In an elastic pool, the limit is 100 database-scoped sessions per pool.
  
 In [dense elastic pools](elastic-pool-resource-management.md), starting a new extended event session may fail due to memory constraints even when the total number of started sessions is below 100.

--- a/azure-sql/database/xevent-db-diff-from-svr.md
+++ b/azure-sql/database/xevent-db-diff-from-svr.md
@@ -172,9 +172,11 @@ If you receive an error message that says a memory maximum was enforced, some co
 - Run fewer concurrent event sessions.
 - Through your **CREATE** and **ALTER** statements for event sessions, reduce the amount of memory you specify on the **MAX\_MEMORY** clause.
 
-There is a cap on number of active XEvent sessions in Azure SQL Database:
+There is a cap on number of started XEvent sessions in Azure SQL Database:
   - In single Azure SQL Database, the limit is 100.
-  - In an elastic pool, the number of active Xevent sessions of all databases is 100.
+  - In an elastic pool, the limit is 100 database-scoped sessions per pool.
+ 
+In [dense elastic pools](elastic-pool-resource-management.md), starting a new extended event session may fail due to memory constraints even when the total number of started sessions is below 100.
   
 
 

--- a/azure-sql/database/xevent-db-diff-from-svr.md
+++ b/azure-sql/database/xevent-db-diff-from-svr.md
@@ -4,7 +4,7 @@ description: Describes extended events (XEvents) in Azure SQL Database, and how 
 author: WilliamDAssafMSFT
 ms.author: wiassaf
 ms.reviewer: wiassaf, mathoma
-ms.date: 04/27/2022
+ms.date: 01/30/2023
 ms.service: sql-database
 ms.subservice: performance
 ms.topic: reference


### PR DESCRIPTION
There is a cap on number of active XEvent sessions in Azure SQL Database:
  - In single Azure SQL Database, the limit is 100.
  - In an elastic pool, the number of active Xevent sessions of all databases is 100.