### PR TITLE
Update F1 keyword

### DIFF
--- a/docs/t-sql/data-types/rowversion-transact-sql.md
+++ b/docs/t-sql/data-types/rowversion-transact-sql.md
@@ -10,6 +10,8 @@ ms.topic: "reference"
 f1_keywords:
   - "timestamp_TSQL"
   - "timestamp"
+  - "rowversion_TSQL"
+  - "rowversion"
 helpviewer_keywords:
   - "rowversion data type"
   - "size [SQL Server], rowversion"


### PR DESCRIPTION
Since `timestamp` is a deprecated name, I think the F1 keyword should reflect this.