### PR TITLE
Fix Linux unattended install sample scripts

### DIFF
--- a/docs/linux/sample-unattended-install-redhat.md
+++ b/docs/linux/sample-unattended-install-redhat.md
@@ -48,7 +48,7 @@ MSSQL_SA_PASSWORD='<YourStrong!Passw0rd>'
 # Defaults to developer
 MSSQL_PID='evaluation'
 
-# Install SQL Server Agent (recommended)
+# Enable SQL Server Agent (recommended)
 SQL_ENABLE_AGENT='y'
 
 # Install SQL Server Full Text Search (optional)
@@ -90,7 +90,6 @@ if [ ! -z $SQL_ENABLE_AGENT ]
 then
   echo Enable SQL Server Agent...
   sudo /opt/mssql/bin/mssql-conf set sqlagent.enabled true
-  sudo systemctl restart mssql-server
 fi
 
 # Optional SQL Server Full Text Search installation:
@@ -189,7 +188,7 @@ The first thing the bash script does is set a few variables. These variables can
 
 1. Add the SQL Server command-line tools to the path for ease of use.
 
-1. Install the SQL Server Agent if the scripting variable `SQL_INSTALL_AGENT` is set, on by default.
+1. Enable the SQL Server Agent if the scripting variable `SQL_ENABLE_AGENT` is set, on by default.
 
 1. Optionally install SQL Server Full-Text search, if the variable `SQL_INSTALL_FULLTEXT` is set.
 
@@ -211,10 +210,9 @@ Simplify multiple unattended installs and create a stand-alone bash script that 
 #!/bin/bash
 export MSSQL_SA_PASSWORD='<YourStrong!Passw0rd>'
 export MSSQL_PID='evaluation'
-export SQL_INSTALL_AGENT='y'
+export SQL_ENABLE_AGENT='y'
 export SQL_INSTALL_USER='<Username>'
 export SQL_INSTALL_USER_PASSWORD='<YourStrong!Passw0rd>'
-export SQL_INSTALL_AGENT='y'
 ```
 
 Then run the bash script as follows:

--- a/docs/linux/sample-unattended-install-suse.md
+++ b/docs/linux/sample-unattended-install-suse.md
@@ -47,8 +47,8 @@ MSSQL_SA_PASSWORD='<YourStrong!Passw0rd>'
 # Defaults to developer
 MSSQL_PID='evaluation'
 
-# Install SQL Server Agent (recommended)
-SQL_INSTALL_AGENT='y'
+# Enable SQL Server Agent (recommended)
+SQL_ENABLE_AGENT='y'
 
 # Install SQL Server Full Text Search (optional)
 # SQL_INSTALL_FULLTEXT='y'
@@ -88,11 +88,11 @@ echo PATH="$PATH:/opt/mssql-tools/bin" >> ~/.bash_profile
 echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
 source ~/.bashrc
 
-# Optional SQL Server Agent installation:
-if [ ! -z $SQL_INSTALL_AGENT ]
+# Optional Enable SQL Server Agent:
+if [ ! -z $SQL_ENABLE_AGENT ]
 then
-  echo Installing SQL Server Agent...
-  sudo zypper install -y mssql-server-agent
+  echo Enable SQL Server Agent...
+  sudo /opt/mssql/bin/mssql-conf set sqlagent.enabled true
 fi
 
 # Optional SQL Server Full Text Search installation:
@@ -192,7 +192,7 @@ The first thing the bash script does is set a few variables. These variables can
 
 1. Add the SQL Server command-line tools to the path for ease of use.
 
-1. Install the SQL Server Agent if the scripting variable `SQL_INSTALL_AGENT` is set, on by default.
+1. Enable the SQL Server Agent if the scripting variable `SQL_ENABLE_AGENT` is set, on by default.
 
 1. Optionally install SQL Server Full-Text search, if the variable `SQL_INSTALL_FULLTEXT` is set.
 
@@ -214,10 +214,9 @@ Simplify multiple unattended installs and create a stand-alone bash script that 
 #!/bin/bash
 export MSSQL_SA_PASSWORD='<YourStrong!Passw0rd>'
 export MSSQL_PID='evaluation'
-export SQL_INSTALL_AGENT='y'
+export SQL_ENABLE_AGENT='y'
 export SQL_INSTALL_USER='<Username>'
 export SQL_INSTALL_USER_PASSWORD='<YourStrong!Passw0rd>'
-export SQL_INSTALL_AGENT='y'
 ```
 
 Then run the bash script as follows:

--- a/docs/linux/sample-unattended-install-ubuntu.md
+++ b/docs/linux/sample-unattended-install-ubuntu.md
@@ -49,8 +49,8 @@ MSSQL_SA_PASSWORD='<YourStrong!Passw0rd>'
 # Defaults to developer
 MSSQL_PID='evaluation'
 
-# Install SQL Server Agent (recommended)
-SQL_INSTALL_AGENT='y'
+# Enable SQL Server Agent (recommended)
+SQL_ENABLE_AGENT='y'
 
 # Install SQL Server Full Text Search (optional)
 # SQL_INSTALL_FULLTEXT='y'
@@ -92,11 +92,11 @@ echo PATH="$PATH:/opt/mssql-tools/bin" >> ~/.bash_profile
 echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
 source ~/.bashrc
 
-# Optional SQL Server Agent installation:
-if [ ! -z $SQL_INSTALL_AGENT ]
+# Optional Enable SQL Server Agent:
+if [ ! -z $SQL_ENABLE_AGENT ]
 then
-  echo Installing SQL Server Agent...
-  sudo apt-get install -y mssql-server-agent
+  echo Enabling SQL Server Agent...
+  sudo /opt/mssql/bin/mssql-conf set sqlagent.enabled true
 fi
 
 # Optional SQL Server Full Text Search installation:
@@ -195,7 +195,7 @@ The first thing the bash script does is set a few variables. These variables can
 
 1. Add the SQL Server command-line tools to the path for ease of use.
 
-1. Install the SQL Server Agent if the scripting variable `SQL_INSTALL_AGENT` is set, on by default.
+1. Enable the SQL Server Agent if the scripting variable `SQL_ENABLE_AGENT` is set, on by default.
 
 1. Optionally install SQL Server Full-Text search, if the variable `SQL_INSTALL_FULLTEXT` is set.
 
@@ -217,10 +217,9 @@ Simplify multiple unattended installs and create a stand-alone bash script that 
 #!/bin/bash
 export MSSQL_SA_PASSWORD='<YourStrong!Passw0rd>'
 export MSSQL_PID='evaluation'
-export SQL_INSTALL_AGENT='y'
+export SQL_ENABLE_AGENT='y'
 export SQL_INSTALL_USER='<Username>'
 export SQL_INSTALL_USER_PASSWORD='<YourStrong!Passw0rd>'
-export SQL_INSTALL_AGENT='y'
 ```
 
 Then run the bash script as follows:


### PR DESCRIPTION
# **Purpose of the PR**

This PR fixes a couple of issues I have found with Linux sample unnatended install scripts and properly aligns them with existing documentation for SQL Server 2019.

## **RedHat sample**

- removing `sudo systemctl restart mssql-server` because it is redundant and causes install script deadlock
- renaming leftover `SQL_INSTALL_AGENT` to `SQL_ENABLE_AGENT` in the comments to keep consistency with existing script
- removing redundant environment variable declaration

## **SUSE and Ubuntu samples**

- fixing SQL Server Agent enabling process aligning it with [existing documentation](https://github.com/MicrosoftDocs/sql-docs/blob/ea37403af78d0e4186c8af76d2db9d088721c5d1/docs/linux/sql-server-linux-setup-sql-agent.md#enable-the-sql-server-agent) for SQL Server 2019 (note: service restart occurs further down in the scipt). The error found was:

```bash
Package mssql-server-agent is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  mssql-server

E: Package 'mssql-server-agent' has no installation candidate
```

- renaming `SQL_INSTALL_AGENT` variable to `SQL_ENABLE_AGENT`
- removing redundant environment variable declaration
