### PR TITLE
GZIP and ZIP

### DIFF
--- a/docs/t-sql/functions/decompress-transact-sql.md
+++ b/docs/t-sql/functions/decompress-transact-sql.md
@@ -34,7 +34,7 @@ DECOMPRESS ( expression )
 A **varbinary(**_n_**)**, **varbinary(max)**, or **binary(**_n_**)** value. See [Expressions &#40;Transact-SQL&#41;](../../t-sql/language-elements/expressions-transact-sql.md) for more information.  
   
 ## Return Types  
-A value of data type **varbinary(max)**. `DECOMPRESS` will use the ZIP algorithm to decompress the input argument. The user should explicitly cast result to a target type if necessary.  
+A value of data type **varbinary(max)**. `DECOMPRESS` will use the GZIP algorithm to decompress the input argument. The user should explicitly cast result to a target type if necessary.  
   
 ## Remarks  
   


### PR DESCRIPTION
Use `GZIP` on both points `DECOMPRESS`and `Return Types`

In the 1st part, it's mentioned GZIP but on the `Return Types` it mentions ZIP.

Checked the `COMPRESS` page (https://learn.microsoft.com/en-us/sql/t-sql/functions/compress-transact-sql?view=sql-server-ver16) and it's ok only one mention and it is GZIP.

