### PR TITLE
Fix broken link to mssql-tools in install steps

### DIFF
--- a/docs/linux/sql-server-linux-setup-tools.md
+++ b/docs/linux/sql-server-linux-setup-tools.md
@@ -229,7 +229,7 @@ sudo ACCEPT_EULA=Y apt-get install mssql-tools unixodbc-dev
 
 ### [Red Hat](#tab/redhat-offline)
 
-1. First, locate and copy the **mssql-tools** package for your Linux distribution. For Red Hat 8.0, this is located at [https://packages.microsoft.com/rhel/8.0/prod](https://packages.microsoft.com/rhel/7.3/prod).
+1. First, locate and copy the **mssql-tools** package for your Linux distribution. For Red Hat 8.0, this is located at [https://packages.microsoft.com/rhel/8/prod](https://packages.microsoft.com/rhel/8/prod).
 
 1. Also locate and copy the **msodbcsql** package, which is a dependency. The **msodbcsql** package also has a dependency on **unixODBC-devel**. For Red Hat, the **msodbcsql** package is located at [https://packages.microsoft.com/rhel/8/prod](https://packages.microsoft.com/rhel/8/prod).
 


### PR DESCRIPTION
This fixes broken link/text for mssql-tools in SQL Server command-line tools offline installation step on Red Hat.
This updates both text and URL to https://packages.microsoft.com/rhel/8/prod, while the previous text was for non-existent path 8.0/prod and URL was for 7.3/prod.