### PR TITLE
Limitation of Snapshot backup

### DIFF
--- a/docs/relational-databases/backup-restore/create-a-transact-sql-snapshot-backup.md
+++ b/docs/relational-databases/backup-restore/create-a-transact-sql-snapshot-backup.md
@@ -97,6 +97,7 @@ WITH METADATA_ONLY, FORMAT
 ```
 > [!NOTE]
 > None of these commands support suspending system databases: master, model, and msdb for snapshot backup.
+> The maximum number of databases for the above command is 64.
 
 ### Suspend multiple user databases with a single command
 


### PR DESCRIPTION
Case Reference -  2302170010000055 
If DB count is more than 64 , Snapshot backup failed with below error:

Error message:
Msg 925, Level 19, State 1, Line 4
Maximum number of databases used for each query has been exceeded. The maximum allowed is 64.