### PR TITLE
Eliminate duplicate | wording - Update cardinality-estimation-sql-server.md

### DIFF
--- a/docs/relational-databases/performance/cardinality-estimation-sql-server.md
+++ b/docs/relational-databases/performance/cardinality-estimation-sql-server.md
@@ -180,11 +180,7 @@ Suppose that with CE 120 or above, a less efficient query plan is generated for 
   
   - Further, setting a lower compatibility level also misses a number of improvements in the query optimizer for latest versions, and affects all queries against the database.
   
-- You could use `LEGACY_CARDINALITY_ESTIMATION` database option, to have the whole database use the older CE, while retaining other improvements in the query optimizer.
-
-  - Further, setting a lower compatibility level also misses many improvements in the query optimizer for latest versions, and affects all queries against the database.
-
-- You could use `LEGACY_CARDINALITY_ESTIMATION` database option, to have the whole database use the older CE, while retaining other improvements in the query optimizer.
+- You could use `LEGACY_CARDINALITY_ESTIMATION` database scoped configuration option, to have the whole database use the older CE, while retaining other improvements in the query optimizer.
 
 - You could use `LEGACY_CARDINALITY_ESTIMATION` query hint, to have a single query use the older CE, while retaining other improvements in the query optimizer.
 


### PR DESCRIPTION
There was a duplicate statement.
The wording can be adapted for "database scoped configuration"

The red rectangle is a copy of the previous bullet.
The green it's a copy of 2 bullets before. Please confirm but I think that text only applies to the `compatibility level` change and not to the `database scoped configuration`
![image](https://user-images.githubusercontent.com/19521315/221246102-b2520f7f-fe04-422d-8e37-f74337f40b6a.png)