### PR TITLE
Updating CAB table to reflect 2017 CU29 work through CU31

### DIFF
--- a/docs/machine-learning/install/sql-ml-cab-downloads.md
+++ b/docs/machine-learning/install/sql-ml-cab-downloads.md
@@ -101,7 +101,7 @@ CAB files are listed in reverse chronological order. When you download the CAB f
 
 |Release  |Component | Download link  | Issues addressed |
 |---------|----------|----------------|------------------|
-|**[SQL Server 2017 CU29](https://support.microsoft.com//help/5010786/)** |  |  |  |
+|**[SQL Server 2017 CU29](https://support.microsoft.com//help/5010786/)-[CU31](https://support.microsoft.com//help/5016884/)** |  |  |  |
 | | Microsoft R Open      | [SRO_3.5.2.777_1033.cab](https://go.microsoft.com/fwlink/?linkid=2134897)  |  |
 | | R Server              | [SRS_9.4.7.1162_1033.cab](https://go.microsoft.com/fwlink/?linkid=2174362)  |  |
 | | Microsoft Python Open | [SPO_4.5.12.479_1033.cab](https://go.microsoft.com/fwlink/?LinkId=2118341) |  |


### PR DESCRIPTION
Updating CAB table to reflect 2017 CU29 work through CU31, with appropriate links to CU31