### PR TITLE
STOPATMARK using transaction name instead of MARK

### DIFF
--- a/docs/relational-databases/backup-restore/use-marked-transactions-to-recover-related-databases-consistently.md
+++ b/docs/relational-databases/backup-restore/use-marked-transactions-to-recover-related-databases-consistently.md
@@ -113,7 +113,7 @@ RESTORE LOG AdventureWorks
    FROM AdventureWorksBackups   
    WITH FILE = 4,  
    RECOVERY,   
-   STOPATMARK = 'ListPriceUpdate';  
+   STOPATMARK = 'UPDATE Product list prices';  
 ```  
   
 ## Forcing a Mark to Spread to Other Servers  


### PR DESCRIPTION
The code example is mentioning the wrong value for the `STOPATMARK` parameter. It's using the transaction name (`ListPriceUpdate`) instead of the `MARK` value (`UPDATE Product list prices`)

That same example is correct on the [RESTORE Statements (Transact-SQL)](https://learn.microsoft.com/en-us/sql/t-sql/statements/restore-statements-transact-sql?view=sql-server-ver16#restoring_transaction_log_to_mark) page