### PR TITLE
Add SQL Server 2022 to Source and Target

### DIFF
--- a/docs/dma/dma-overview.md
+++ b/docs/dma/dma-overview.md
@@ -79,6 +79,7 @@ DMA replaces all previous versions of SQL Server Upgrade Advisor and should be u
 - SQL Server 2016
 - SQL Server 2017
 - SQL Server 2019
+- SQL Server 2022
 - Amazon RDS for SQL Server
 
 ### Targets
@@ -88,6 +89,7 @@ DMA replaces all previous versions of SQL Server Upgrade Advisor and should be u
 - SQL Server 2016
 - SQL Server 2017 on Windows and Linux
 - SQL Server 2019
+- SQL Server 2022
 - Azure SQL Database single database
 - Azure SQL Managed Instance (assessment only)
 - SQL server running on an Azure Virtual Machine


### PR DESCRIPTION
Support for SQL Server 2022 has been added since DMA 5.7.

https://www.microsoft.com/en-us/download/details.aspx?id=53595
> What is new in V5.7?
> Added SQL Server 2022 as source and target platform to support SQL Server 2022 assessment and migration.