### PR TITLE
Update query-processing-architecture-guide.md

### DIFF
--- a/docs/relational-databases/query-processing-architecture-guide.md
+++ b/docs/relational-databases/query-processing-architecture-guide.md
@@ -1127,9 +1127,11 @@ Degree of parallelism (DOP) determines the maximum number of CPUs that are being
 
 The [!INCLUDE[ssNoVersion](../includes/ssnoversion-md.md)] Query Optimizer doesn't use a parallel execution plan for a query if any one of the following conditions is true:
 
-- The serial execution cost of the query isn't high enough to consider an alternative, parallel execution plan.
-- A serial execution plan is considered faster than any possible parallel execution plan for the particular query.
+- The serial execution plan is trivial, or does not exceed the cost threshold for paralllelism setting.
+- The serial execution plan has a lower total estimated subtree cost than any parallel execution plan explored by the optimizer.
 - The query contains scalar or relational operators that can't be run in parallel. Certain operators can cause a section of the query plan to run in serial mode, or the whole plan to run in serial mode.
+
+Note that the total estimated subtree cost of a parallel plan may be lower than the cost threshold for parallelism setting. This indicates that the total estimated subtree cost of the serial plan exceeded it, and the query plan with the lower total estimated subtree cost was chosen.
 
 ### Degree of parallelism (DOP)
 <a id="DOP"></a>

--- a/docs/relational-databases/query-processing-architecture-guide.md
+++ b/docs/relational-databases/query-processing-architecture-guide.md
@@ -1127,7 +1127,7 @@ Degree of parallelism (DOP) determines the maximum number of CPUs that are being
 
 The [!INCLUDE[ssNoVersion](../includes/ssnoversion-md.md)] Query Optimizer doesn't use a parallel execution plan for a query if any one of the following conditions is true:
 
-- The serial execution plan is trivial, or does not exceed the cost threshold for paralllelism setting.
+- The serial execution plan is trivial, or does not exceed the cost threshold for parallelism setting.
 - The serial execution plan has a lower total estimated subtree cost than any parallel execution plan explored by the optimizer.
 - The query contains scalar or relational operators that can't be run in parallel. Certain operators can cause a section of the query plan to run in serial mode, or the whole plan to run in serial mode.
 

--- a/docs/relational-databases/query-processing-architecture-guide.md
+++ b/docs/relational-databases/query-processing-architecture-guide.md
@@ -1131,7 +1131,8 @@ The [!INCLUDE[ssNoVersion](../includes/ssnoversion-md.md)] Query Optimizer doesn
 - The serial execution plan has a lower total estimated subtree cost than any parallel execution plan explored by the optimizer.
 - The query contains scalar or relational operators that can't be run in parallel. Certain operators can cause a section of the query plan to run in serial mode, or the whole plan to run in serial mode.
 
-Note that the total estimated subtree cost of a parallel plan may be lower than the cost threshold for parallelism setting. This indicates that the total estimated subtree cost of the serial plan exceeded it, and the query plan with the lower total estimated subtree cost was chosen.
+> [!NOTE]  
+> The total estimated subtree cost of a parallel plan may be lower than the cost threshold for parallelism setting. This indicates that the total estimated subtree cost of the serial plan exceeded it, and the query plan with the lower total estimated subtree cost was chosen.
 
 ### Degree of parallelism (DOP)
 <a id="DOP"></a>


### PR DESCRIPTION
This section is missing details and makes misleading statements when describing how cost-based optimization works. There's also room to improve the quality by addressing a common point of confusion, where parallel plans have lower overall costs than the cost threshold for parallelism setting.