### PR TITLE
Update options-transact-sql.md adding Review @@OPTIONS directly using…

### DIFF
--- a/docs/t-sql/functions/options-transact-sql.md
+++ b/docs/t-sql/functions/options-transact-sql.md
@@ -131,6 +131,30 @@ CROSS APPLY (
     ) AS Flags;
 ```
 
+### D. Review @@OPTIONS directly using the function GET_BIT (SQL Server 2022 and above)
+
+The following example uses GET_BIT function to get the value in specific bit for the BINARY value of @@OPTIONS
+
+```sql
+SELECT
+      GET_BIT(CONVERT(VARBINARY(MAX), @@OPTIONS), 0) AS [DISABLE_DEF_CNST_CHK]     -- 1     : Controls interim or deferred constraint checking.
+    , GET_BIT(CONVERT(VARBINARY(MAX), @@OPTIONS), 1) AS [IMPLICIT_TRANSACTIONS]    -- 2     : For dblib network library connections, controls whether a transaction is started implicitly when a statement is executed. The IMPLICIT_TRANSACTIONS setting has no effect on ODBC or OLEDB connections.
+    , GET_BIT(CONVERT(VARBINARY(MAX), @@OPTIONS), 2) AS [CURSOR_CLOSE_ON_COMMIT]   -- 4     : Controls behavior of cursors after a commit operation has been performed.
+    , GET_BIT(CONVERT(VARBINARY(MAX), @@OPTIONS), 3) AS [ANSI_WARNINGS]            -- 8     : Controls truncation and NULL in aggregate warnings.
+    , GET_BIT(CONVERT(VARBINARY(MAX), @@OPTIONS), 4) AS [ANSI_PADDING]             -- 16    : Controls padding of fixed-length variables.
+    , GET_BIT(CONVERT(VARBINARY(MAX), @@OPTIONS), 5) AS [ANSI_NULLS]               -- 32    : Controls NULL handling when using equality operators.
+    , GET_BIT(CONVERT(VARBINARY(MAX), @@OPTIONS), 6) AS [ARITHABORT]               -- 64    : Terminates a query when an overflow or divide-by-zero error occurs during query execution.
+    , GET_BIT(CONVERT(VARBINARY(MAX), @@OPTIONS), 7) AS [ARITHIGNORE]              -- 128   : Returns NULL when an overflow or divide-by-zero error occurs during a query.
+    , GET_BIT(CONVERT(VARBINARY(MAX), @@OPTIONS), 8) AS [QUOTED_IDENTIFIER]        -- 256   : Differentiates between single and double quotation marks when evaluating an expression.
+    , GET_BIT(CONVERT(VARBINARY(MAX), @@OPTIONS), 9) AS [NOCOUNT]                  -- 512   : Turns off the message returned at the end of each statement that states how many rows were affected.
+    , GET_BIT(CONVERT(VARBINARY(MAX), @@OPTIONS), 10) AS [ANSI_NULL_DFLT_ON]       -- 1024  : Alters the session's behavior to use ANSI compatibility for nullability. New columns defined without explicit nullability are defined to allow nulls.
+    , GET_BIT(CONVERT(VARBINARY(MAX), @@OPTIONS), 11) AS [ANSI_NULL_DFLT_OFF]      -- 2048  : Alters the session's behavior not to use ANSI compatibility for nullability. New columns defined without explicit nullability do not allow nulls.
+    , GET_BIT(CONVERT(VARBINARY(MAX), @@OPTIONS), 12) AS [CONCAT_NULL_YIELDS_NULL] -- 4096  : Returns NULL when concatenating a NULL value with a string.
+    , GET_BIT(CONVERT(VARBINARY(MAX), @@OPTIONS), 13) AS [NUMERIC_ROUNDABORT]      -- 8192  : Generates an error when a loss of precision occurs in an expression.
+    , GET_BIT(CONVERT(VARBINARY(MAX), @@OPTIONS), 14) AS [XACT_ABORT]              -- 16384 : Rolls back a transaction if a Transact-SQL statement raises a run-time error.*/
+GO
+```
+
 ## See also
 
 - [Configuration Functions (Transact-SQL)](../../t-sql/functions/configuration-functions-transact-sql.md)


### PR DESCRIPTION
… the function GET_BIT

Using SQL Server 2022 we can use the function GET_BIT in order to get the specific option we want. For example in order to get the value of [QUOTED_IDENTIFIER] I can simply check the value of bit 8 on the @@OPTIONS binary value.