### PR TITLE
Not implemented for Elastic Query

### DIFF
--- a/azure-sql/database/outbound-firewall-rule-overview.md
+++ b/azure-sql/database/outbound-firewall-rule-overview.md
@@ -23,7 +23,6 @@ Outbound firewall rules limit network traffic from the Azure SQL [logical server
 - [Import/Export service](database-import-export-azure-services-off.md)
 - [OPENROWSET](/sql/t-sql/functions/openrowset-transact-sql)
 - [Bulk Insert](/sql/t-sql/statements/bulk-insert-transact-sql)
-- [Elastic query](elastic-query-overview.md)
 - [sp_invoke_external_rest_endpoint](/sql/relational-databases/system-stored-procedures/sp-invoke-external-rest-endpoint-transact-sql)
 
 > [!IMPORTANT]


### PR DESCRIPTION
After feedback from the Product Team (Vlado Tosev) I got confirmation that this is not implemented with Elastic Query. In addition to the removal of Elastic Query, I suggest that the 2 images that show SQL Servers as the FQDN are also changed to only be Blob Storage Endpoint FQDNs