### PR TITLE
use SINGLE_BLOB to import XML, rather than CLOB

### DIFF
--- a/docs/relational-databases/xml/load-xml-data.md
+++ b/docs/relational-databases/xml/load-xml-data.md
@@ -36,7 +36,7 @@ This example shows how to insert a row in table T. The value of the XML column i
 INSERT INTO T
 SELECT 10, xCol
 FROM    (SELECT *
-    FROM OPENROWSET (BULK 'C:\MyFile\xmlfile.xml', SINGLE_CLOB)
+    FROM OPENROWSET (BULK 'C:\MyFile\xmlfile.xml', SINGLE_BLOB)
 AS xCol) AS R(xCol);
 ```
 


### PR DESCRIPTION
Per the guidance in the OPENROWSET() documentation, use `SINGLE_BLOB` when loading XML. ref: https://github.com/MicrosoftDocs/sql-docs/blob/live/docs/t-sql/functions/openrowset-transact-sql.md#single_blob