### PR TITLE
adding note about "Force Strict Encryption"

### DIFF
--- a/docs/relational-databases/security/networking/tds-8-and-tls-1-3.md
+++ b/docs/relational-databases/security/networking/tds-8-and-tls-1-3.md
@@ -72,7 +72,7 @@ In order to prevent a man-in-the-middle attack with `strict` connection encrypti
 > 
 > The following is a list of features or tools that still use previous version of drivers that don't support TDS 8.0, and as such, may not work with the `strict` connection encryption:
 > - Always On failover cluster instance (FCI)
-> - Always On availability group
+> - Always On availability groups
 > - Replication
 > - SQL Server Management Studio (SSMS)
 > - sqlcmd utility

--- a/docs/relational-databases/security/networking/tds-8-and-tls-1-3.md
+++ b/docs/relational-databases/security/networking/tds-8-and-tls-1-3.md
@@ -70,7 +70,7 @@ In order to prevent a man-in-the-middle attack with `strict` connection encrypti
 > [!NOTE]  
 > The `Force Strict Encryption` option in SQL Server Network Configuration forces all clients to use `strict` as the encryption type. Any clients or features without the `strict` connection encryption fail to connect to SQL Server.
 > 
-> The following is a list of features or tools that may not work with the `strict` connection encryption:
+> The following is a list of features or tools that may not work with `strict` connection encryption:
 > - Always On failover cluster instance (FCI)
 > - Always On availability group
 > - Replication

--- a/docs/relational-databases/security/networking/tds-8-and-tls-1-3.md
+++ b/docs/relational-databases/security/networking/tds-8-and-tls-1-3.md
@@ -68,9 +68,9 @@ To leverage TDS 8.0, [!INCLUDE [sssql22-md](../../../includes/sssql22-md.md)] ad
 In order to prevent a man-in-the-middle attack with `strict` connection encryption, users won't be able to set the `TrustServerCertificate` option to **true** and trust any certificate the server provided. Instead, users would use the `HostNameInCertificate` option to specify the certificate that should be trusted. The certificate supplied by the server would need to pass the certificate validation.
 
 > [!NOTE]  
-> "Force Strict Encryption" option in SQL Server Network Configuration will force all clients to use Strict as Encryption, just like "Force Encryption", so any clients or features do not use Strict Encryption fail to connect SQL Server.
+> The `Force Strict Encryption` option in SQL Server Network Configuration will force all clients to use `strict` as the encryption type. Any clients or features that don't use `strict` connection encryption fails to connect to SQL Server.
 > 
-> Following features or tools are some example that does not work for now:
+> The following features or tools are some example that does not work with the `strict` connection encryption:
 > - AlwaysOn Failover Cluster Instance (FCI)
 > - AlwaysOn Availability Group
 > - Replication

--- a/docs/relational-databases/security/networking/tds-8-and-tls-1-3.md
+++ b/docs/relational-databases/security/networking/tds-8-and-tls-1-3.md
@@ -67,6 +67,17 @@ To leverage TDS 8.0, [!INCLUDE [sssql22-md](../../../includes/sssql22-md.md)] ad
 
 In order to prevent a man-in-the-middle attack with `strict` connection encryption, users won't be able to set the `TrustServerCertificate` option to **true** and trust any certificate the server provided. Instead, users would use the `HostNameInCertificate` option to specify the certificate that should be trusted. The certificate supplied by the server would need to pass the certificate validation.
 
+> [!NOTE]  
+> "Force Strict Encryption" option in SQL Server Network Configuration will force all clients to use Strict as Encryption, just like "Force Encryption", so any clients or features do not use Strict Encryption fail to connect SQL Server.
+> 
+> Following features or tools are some example that does not work for now:
+> - AlwaysOn Failover Cluster Instance (FCI)
+> - AlwaysOn Availability Group
+> - Replication
+> - SQL Server Management Studio (SSMS)
+> - sqlcmd utility
+> - bcp utility
+
 ## Additional changes to connection string encryption properties
 
 The following additions are added to connection strings for encryption:

--- a/docs/relational-databases/security/networking/tds-8-and-tls-1-3.md
+++ b/docs/relational-databases/security/networking/tds-8-and-tls-1-3.md
@@ -68,9 +68,9 @@ To leverage TDS 8.0, [!INCLUDE [sssql22-md](../../../includes/sssql22-md.md)] ad
 In order to prevent a man-in-the-middle attack with `strict` connection encryption, users won't be able to set the `TrustServerCertificate` option to **true** and trust any certificate the server provided. Instead, users would use the `HostNameInCertificate` option to specify the certificate that should be trusted. The certificate supplied by the server would need to pass the certificate validation.
 
 > [!NOTE]  
-> The `Force Strict Encryption` option in SQL Server Network Configuration forces all clients to use `strict` as the encryption type. Any clients or features without the `strict` connection encryption fail to connect to SQL Server.
+> The `Force Strict Encryption` option added with TDS 8.0 in SQL Server Network Configuration forces all clients to use `strict` as the encryption type. Any clients or features without the `strict` connection encryption fail to connect to SQL Server.
 > 
-> The following is a list of features or tools that may not work with `strict` connection encryption:
+> The following is a list of features or tools that still use previous version of drivers that don't support TDS 8.0, and as such, may not work with the `strict` connection encryption:
 > - Always On failover cluster instance (FCI)
 > - Always On availability group
 > - Replication

--- a/docs/relational-databases/security/networking/tds-8-and-tls-1-3.md
+++ b/docs/relational-databases/security/networking/tds-8-and-tls-1-3.md
@@ -68,11 +68,11 @@ To leverage TDS 8.0, [!INCLUDE [sssql22-md](../../../includes/sssql22-md.md)] ad
 In order to prevent a man-in-the-middle attack with `strict` connection encryption, users won't be able to set the `TrustServerCertificate` option to **true** and trust any certificate the server provided. Instead, users would use the `HostNameInCertificate` option to specify the certificate that should be trusted. The certificate supplied by the server would need to pass the certificate validation.
 
 > [!NOTE]  
-> The `Force Strict Encryption` option in SQL Server Network Configuration will force all clients to use `strict` as the encryption type. Any clients or features that don't use `strict` connection encryption fails to connect to SQL Server.
+> The `Force Strict Encryption` option in SQL Server Network Configuration forces all clients to use `strict` as the encryption type. Any clients or features without the `strict` connection encryption fail to connect to SQL Server.
 > 
-> The following features or tools are some example that does not work with the `strict` connection encryption:
-> - AlwaysOn Failover Cluster Instance (FCI)
-> - AlwaysOn Availability Group
+> The following is a list of features or tools that may not work with the `strict` connection encryption:
+> - Always On failover cluster instance (FCI)
+> - Always On availability group
 > - Replication
 > - SQL Server Management Studio (SSMS)
 > - sqlcmd utility


### PR DESCRIPTION
Some customers enabled "Force Strict Encryption" on FCI and it failed as it use older driver. As SQL Server 2022 ships with ODBC Driver for SQL Server 17 for now, many features will not work with it, so adding note should prevent many customers to avoid confusion. I have tested limited features, so if you can add more, it will be better.