### PR TITLE
Clarifying monitor_server_security_mode for log shipping procedures.

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-add-log-shipping-primary-database-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-add-log-shipping-primary-database-transact-sql.md
@@ -69,7 +69,9 @@ sp_add_log_shipping_primary_database [ @database = ] 'database',
   
  1 = Windows Authentication.  
   
- 0 = [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] Authentication. *monitor_server_security_mode* is **bit** and cannot be NULL.  
+ 0 = [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] Authentication.
+
+ *monitor_server_security_mode* is **bit** with a default of 1, and cannot be NULL.
   
 `[ @monitor_server_login = ] 'monitor_server_login'`
  Is the username of the account used to access the monitor server.  

--- a/docs/relational-databases/system-stored-procedures/sp-add-log-shipping-secondary-primary-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-add-log-shipping-secondary-primary-transact-sql.md
@@ -75,7 +75,7 @@ sp_add_log_shipping_secondary_primary
   
  0 = [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] authentication.  
   
- *monitor_server_security_mode* is **bit** and cannot be NULL.  
+ *monitor_server_security_mode* is **bit** with a default of 1, and cannot be NULL.
   
 `[ @monitor_server_login = ] 'monitor_server_login'`
  Is the username of the account used to access the monitor server.  

--- a/docs/relational-databases/system-stored-procedures/sp-change-log-shipping-primary-database-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-change-log-shipping-primary-database-transact-sql.md
@@ -60,7 +60,7 @@ sp_change_log_shipping_primary_database [ @database = ] 'database'
   
  0 = SQL Server Authentication.  
   
- *monitor_server_security_mode* is **bit** and cannot be NULL.  
+ *monitor_server_security_mode* is **bit** and defaults to NULL.  
   
 `[ @monitor_server_login = ] 'monitor_server_login'`
  Is the username of the account used to access the monitor server.  

--- a/docs/relational-databases/system-stored-procedures/sp-change-log-shipping-secondary-primary-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-change-log-shipping-secondary-primary-transact-sql.md
@@ -58,7 +58,9 @@ sp_change_log_shipping_secondary_primary
   
  1 = Windows Authentication;  
   
- 0 = [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] Authentication. *monitor_server_security_mode* is **bit** and cannot be NULL.  
+ 0 = [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] Authentication.
+
+ *monitor_server_security_mode* is **bit** and defaults to NULL.  
   
 `[ @monitor_server_login = ] 'monitor_server_login'`
  Is the username of the account used to access the monitor server.  


### PR DESCRIPTION
While the parameter cannot be null, it does have a default value which was not documented.