### PR TITLE
Create Push Subscription - RMO Documentation updates

### DIFF
--- a/docs/relational-databases/replication/create-a-push-subscription.md
+++ b/docs/relational-databases/replication/create-a-push-subscription.md
@@ -190,7 +190,7 @@ You can create push subscriptions programmatically by using replication stored p
   
    - (Optional) A value of **true** (the default) for <xref:Microsoft.SqlServer.Replication.Subscription.CreateSyncAgentByDefault%2A> to create an agent job that is used to synchronize the subscription. If you specify **false**, the subscription can only be synchronized programmatically.  
   
-   - (Optional) Set the <xref:Microsoft.SqlServer.Replication.ConnectionSecurityContext.SqlStandardLogin%2A> and <xref:Microsoft.SqlServer.Replication.ConnectionSecurityContext.SqlStandardPassword%2A> or <xref:Microsoft.SqlServer.Replication.ConnectionSecurityContext.SecureSqlStandardPassword%2A> fields of <xref:Microsoft.SqlServer.Replication.Subscription.SubscriberSecurity%2A> when using SQL Server Authentication to connect to the Subscriber.  
+   - (Optional) Set the <xref:Microsoft.SqlServer.Replication.ConnectionSecurityContext.WindowsAuthentication%2A> to False, <xref:Microsoft.SqlServer.Replication.ConnectionSecurityContext.SqlStandardLogin%2A> and <xref:Microsoft.SqlServer.Replication.ConnectionSecurityContext.SqlStandardPassword%2A> or <xref:Microsoft.SqlServer.Replication.ConnectionSecurityContext.SecureSqlStandardPassword%2A> fields of <xref:Microsoft.SqlServer.Replication.Subscription.SubscriberSecurity%2A> when using SQL Server Authentication to connect to the Subscriber.  
   
 8. Call the <xref:Microsoft.SqlServer.Replication.Subscription.Create%2A> method.  
   
@@ -230,7 +230,7 @@ You can create push subscriptions programmatically by using replication stored p
   
    - (Optional) Set the <xref:Microsoft.SqlServer.Replication.ConnectionSecurityContext.SqlStandardLogin%2A> and <xref:Microsoft.SqlServer.Replication.ConnectionSecurityContext.SqlStandardPassword%2A> or <xref:Microsoft.SqlServer.Replication.ConnectionSecurityContext.SecureSqlStandardPassword%2A> fields of <xref:Microsoft.SqlServer.Replication.Subscription.SubscriberSecurity%2A> when using SQL Server Authentication to connect to the Subscriber.  
   
-   - (Optional) Set the <xref:Microsoft.SqlServer.Replication.ConnectionSecurityContext.SqlStandardLogin%2A> and <xref:Microsoft.SqlServer.Replication.ConnectionSecurityContext.SqlStandardPassword%2A> or <xref:Microsoft.SqlServer.Replication.ConnectionSecurityContext.SecureSqlStandardPassword%2A> fields of <xref:Microsoft.SqlServer.Replication.PullSubscription.PublisherSecurity%2A> when using SQL Server Authentication to connect to the Publisher.  
+   - (Optional) Set the <xref:Microsoft.SqlServer.Replication.ConnectionSecurityContext.WindowsAuthentication%2A> to False, <xref:Microsoft.SqlServer.Replication.ConnectionSecurityContext.SqlStandardLogin%2A> and <xref:Microsoft.SqlServer.Replication.ConnectionSecurityContext.SqlStandardPassword%2A> or <xref:Microsoft.SqlServer.Replication.ConnectionSecurityContext.SecureSqlStandardPassword%2A> fields of <xref:Microsoft.SqlServer.Replication.PullSubscription.PublisherSecurity%2A> when using SQL Server Authentication to connect to the Publisher.  
   
 8. Call the <xref:Microsoft.SqlServer.Replication.Subscription.Create%2A> method.  
   


### PR DESCRIPTION
Working on using RMO to create subscriptions and I found that I needed to set the `WindowsAuthentication` setting to False for the change to be picked up.

Following the docs I ended up with True still for WindowsAuth and it didn't show the change in SSMS\replication monitor. The second results set shows setting it to False.
![image](https://user-images.githubusercontent.com/981370/228808103-99f969c6-5f98-4a0c-9d61-e7d4c5efdf6a.png)

Then it shows up here - believe that true\false is that radio button.
![image](https://user-images.githubusercontent.com/981370/228808272-8daac0aa-4639-472c-a3d8-6558ac4801f2.png)

It's also on [create-a-pull-subscription](https://learn.microsoft.com/en-us/sql/relational-databases/replication/create-a-pull-subscription?view=sql-server-ver16) but I haven't tested that yet - I can test and get back to you on this.