### PR TITLE
Fix typo in parameter name to get a correct result

### DIFF
--- a/docs/relational-databases/system-functions/managed-backup-fn-get-parameter-transact-sql.md
+++ b/docs/relational-databases/system-functions/managed-backup-fn-get-parameter-transact-sql.md
@@ -68,7 +68,7 @@ FROM managed_backup.fn_get_parameter (NULL)
 USE MSDB  
 GO  
 SELECT *  
-FROM managed_backup.fn_get_parameter ('SSMBackup2WANotficationEmailIds')  
+FROM managed_backup.fn_get_parameter ('SSMBackup2WANotificationEmailIds')  
   
 ```  
   


### PR DESCRIPTION
The current example returns 0 row because the parameter name SSMBackup2WANotficationEmailIds is not correct. The correct parameter name is SSMBackup2WANot**i**ficationEmailIds.