### PR TITLE
Remove the IsAlive /LooksAlive ref in the table and updates to lease timeout

### DIFF
--- a/docs/database-engine/availability-groups/windows/availability-group-lease-healthcheck-timeout.md
+++ b/docs/database-engine/availability-groups/windows/availability-group-lease-healthcheck-timeout.md
@@ -156,11 +156,11 @@ ALTER AVAILABILITY GROUP AG1 SET (HEALTH_CHECK_TIMEOUT =60000);
 
   - SameSubnetDelay \<= CrossSubnetDelay 
   
- | Timeout setting | Purpose | Between | Uses | IsAlive & LooksAlive | Causes | Outcome |
- | :-------------- | :------ | :------ | :--- | :------------------- | :----- | :------ |
- | Lease timeout </br> **Default: 20000** | Prevent splitbrain | Primary to Cluster </br> (HADR) | [Windows event objects](/windows/desktop/Sync/event-objects)| Used in both | OS not responding, low virtual memory, working set paging, generating dump, pegged CPU, WSFC down (loss of quorum) | AG resource offline-online, failover |  
- | Session timeout </br> **Default: 10000** | Inform of communication issue between Primary and Secondary | Secondary to Primary </br> (HADR) | [TCP Sockets (messages sent via DBM endpoint)](/windows/desktop/WinSock/windows-sockets-start-page-2) | Used in neither | Network communication, </br> Issues on secondary - down, OS not responding, resource contention | Secondary - DISCONNECTED | 
- |HealthCheck timeout  </br> **Default: 30000** | Indicate timeout while trying to determine health of the Primary replica | Cluster to Primary </br> (FCI & HADR) | T-SQL [sp_server_diagnostics](../../../relational-databases/system-stored-procedures/sp-server-diagnostics-transact-sql.md) | Used in both | Failure conditions met, OS not responding, low virtual memory, working set trim, generating dump, WSFC (loss of quorum), scheduler issues (dead locked schedulers)| AG resource Offline-online or Failover, FCI restart/failover |  
+ | Timeout setting | Purpose | Between | Uses |  Causes | Outcome |
+ | :-------------- | :------ | :------ | :--- |  :----- | :------ |
+ | Lease timeout </br> **Default: 20000** | Prevent splitbrain | Primary to Cluster </br> (HADR) | [Windows event objects](/windows/desktop/Sync/event-objects) | OS not responding, low virtual memory, working set paging, generating dump, pegged CPU, WSFC down (loss of quorum) | AG resource offline-online, failover |  
+ | Session timeout </br> **Default: 10000** | Inform of communication issue between Primary and Secondary | Secondary to Primary </br> (HADR) | [TCP Sockets (messages sent via DBM endpoint)](/windows/desktop/WinSock/windows-sockets-start-page-2) | Network communication, </br> Issues on secondary - down, OS not responding, resource contention | Secondary - DISCONNECTED | 
+ |HealthCheck timeout  </br> **Default: 30000** | Indicate timeout while trying to determine health of the Primary replica | Cluster to Primary </br> (FCI & HADR) | T-SQL [sp_server_diagnostics](../../../relational-databases/system-stored-procedures/sp-server-diagnostics-transact-sql.md) |  Failure conditions met, OS not responding, low virtual memory, working set trim, generating dump, WSFC (loss of quorum), scheduler issues (dead locked schedulers)| AG resource Offline-online or Failover, FCI restart/failover |  
 
 ## See Also    
 


### PR DESCRIPTION


These are not meaningful for lease timeout and session timeout and leads customers to confusion. Also they don't give practical application. So best is to remove them