### PR TITLE
Updated JDBC Driver 6.4 support status

### DIFF
--- a/docs/connect/jdbc/microsoft-jdbc-driver-for-sql-server-support-matrix.md
+++ b/docs/connect/jdbc/microsoft-jdbc-driver-for-sql-server-support-matrix.md
@@ -34,12 +34,12 @@ The following Microsoft JDBC Drivers are supported, until the indicated End of S
 |Microsoft JDBC Driver 7.4 for SQL Server|7.4|mssql-jdbc-7.4.1.jre12.jar<br> mssql-jdbc-7.4.1.jre11.jar<br> mssql-jdbc-7.4.1.jre8.jar|July 31, 2024|
 |Microsoft JDBC Driver 7.2 for SQL Server|7.2|mssql-jdbc-7.2.2.jre11.jar<br> mssql-jdbc-7.2.2.jre8.jar|January 31, 2024|
 |Microsoft JDBC Driver 7.0 for SQL Server|7.0|mssql-jdbc-7.0.0.jre10.jar<br> mssql-jdbc-7.0.0.jre8.jar|July 31, 2023|
-|Microsoft JDBC Driver 6.4 for SQL Server|6.4|mssql-jdbc-6.4.0.jre9.jar<br> mssql-jdbc-6.4.0.jre8.jar<br> mssql-jdbc-6.4.0.jre7.jar|February 27, 2023|
 
  The following Microsoft JDBC Drivers are no longer supported.
 
 |Driver Name|Driver Package Version|End of Mainstream Support|
 |-|-|-|
+|Microsoft JDBC Driver 6.4 for SQL Server|6.4|February 27, 2023|
 |Microsoft JDBC Driver 6.2 for SQL Server|6.2|June 30, 2022|
 |Microsoft JDBC Driver 6.0 for SQL Server|6.0|July 14, 2021|
 |Microsoft JDBC Driver 4.2 for SQL Server|4.2|August 24, 2020|


### PR DESCRIPTION
Moved Microsoft JDBC Driver 6.4 for SQL Server from the supported list to the "no longer supported" list since end of support was on February 27th 2023