### PR TITLE
Update alter-database-scoped-configuration-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/alter-database-scoped-configuration-transact-sql.md
+++ b/docs/t-sql/statements/alter-database-scoped-configuration-transact-sql.md
@@ -680,7 +680,7 @@ ALTER DATABASE SCOPED CONFIGURATION SET ELEVATE_RESUMABLE = WHEN_SUPPORTED ;
 
 ### K. Clear a query plan from the plan cache
 
-**Applies to:** [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] (Starting with [!INCLUDE[ssSQL17](../../includes/sssql17-md.md)]), [!INCLUDE[ssSDSfull](../../includes/sssdsfull-md.md)] and [!INCLUDE[ssSDSMIfull](../../includes/sssdsmifull-md.md)]
+**Applies to:** [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] (Starting with [!INCLUDE[ssSQL19](../../includes/sssql19-md.md)]), [!INCLUDE[ssSDSfull](../../includes/sssdsfull-md.md)] and [!INCLUDE[ssSDSMIfull](../../includes/sssdsmifull-md.md)]
 
 This example clears a specific plan from the procedure cache
 


### PR DESCRIPTION
The upper part of the same documentation page states that: Specifying a query plan handle is available in starting with SQL Server 2019 (15.x)

So here it's not 2017, it's 2019.