### PR TITLE
Update sp-add-category-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-add-category-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-add-category-transact-sql.md
@@ -67,7 +67,7 @@ sp_add_category
  **sp_add_category** must be run from the **msdb** database.  
   
 ## Permissions  
- Only members of the **sysadmin** fixed server role can execute **sp_add_category**.  
+Requires membership in the **sysadmin** fixed server role, but permissions can be granted to other users.
   
 ## Examples  
  The following example creates a local job category named `AdminJobs`.  


### PR DESCRIPTION
The store procedure can be executed by users not belonging to the sysadmin fixed role by being explicitly granted exec permissions. Example:

USE MSDB; 
GO
GRANT EXEC ON dbo.sp_add_category TO <USER>
GO

I am using the same wording used here: https://learn.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-delete-backuphistory-transact-sql#permissions

Please confirm this is the intended behavior with Product Group.