### PR TITLE
Update sp-delete-category-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-delete-category-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-delete-category-transact-sql.md
@@ -55,7 +55,7 @@ sp_delete_category [ @class = ] 'class' , [ @name = ] 'name'
  Deleting a category recategorizes any jobs, alerts, or operators in that category to the default category for the class.  
   
 ## Permissions  
- Only members of the **sysadmin** fixed server role can run this procedure.  
+ Requires membership in the **sysadmin** fixed server role, but permissions can be granted to other users.  
   
 ## Examples  
  The following example deletes the job category named `AdminJobs`.  


### PR DESCRIPTION
The store procedure can be executed by users not belonging to the sysadmin fixed role by being explicitly granted exec permissions. Example:

USE MSDB;
GO
GRANT EXEC ON dbo.sp_delete_category TO USER
GO

I am using the same wording used here: https://learn.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-delete-backuphistory-transact-sql#permissions

Please confirm this is the intended behavior with Product Group.