### PR TITLE
Update sp-update-category-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-update-category-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-update-category-transact-sql.md
@@ -55,7 +55,7 @@ sp_update_category
  **sp_update_category** must be run from the **msdb** database.  
   
 ## Permissions  
- To run this stored procedure, users must be granted the **sysadmin** fixed server role.  
+ Requires membership in the **sysadmin** fixed server role, but permissions can be granted to other users.
   
 ## Examples  
  The following example renames a job category from `AdminJobs` to `Administrative Jobs`.  


### PR DESCRIPTION
The store procedure can be executed by users not belonging to the sysadmin fixed role by being explicitly granted exec permissions. Example:

USE MSDB;
GO
GRANT EXEC ON dbo.sp_update_category TO USER
GO

I am using the same wording used here: https://learn.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-delete-backuphistory-transact-sql#permissions

Please confirm this is the intended behavior with Product Group.