### PR TITLE
Corrected possible causes and fixes for the error

### DIFF
--- a/docs/relational-databases/errors-events/mssqlserver-233-database-engine-error.md
+++ b/docs/relational-databases/errors-events/mssqlserver-233-database-engine-error.md
@@ -30,14 +30,12 @@ helpviewer_keywords:
 The [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] client cannot connect to an instance residing on the same host as the client. 
  
 ### Potential causes:
-[!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)]
 - Unable to connect through the Shared Memory protocol.
 - The instance has reached its maximum concurrent user connections limit
   
 ## User Action 
-[!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)]
 Depending on the cause:
-- Try to disable the Shared Memory protocol in Configuration Manager and use TCP/IP instead.
+- Try to disable the Shared Memory protocol in [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] Configuration Manager and use TCP/IP instead.
 - Restart the instance in single user mode and make sure that the maximum number of concurrent user connections has not been changed from its default value of 0 (0 = unlimited)
   
 ## See Also  

--- a/docs/relational-databases/errors-events/mssqlserver-233-database-engine-error.md
+++ b/docs/relational-databases/errors-events/mssqlserver-233-database-engine-error.md
@@ -26,15 +26,25 @@ helpviewer_keywords:
 |Symbolic Name||  
 |Message Text|A connection was successfully established with the server, but then an error occurred during the login process. (provider: Shared Memory Provider, error: 0 - No process is on the other end of the pipe.) (Microsoft SQL Server, Error: 233)|  
   
-## Explanation  
-The [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] client cannot connect to the server. This error could occur because the server is not configured to accept remote connections.  
+## Explanations  
+The [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] client cannot connect to an instance residing on the same host as the client. 
+ 
+### Potential causes:
+[!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)]
+- Unable to connect through the Shared Memory protocol.
+- The instance has reached its maximum concurrent user connections limit
   
-## User Action  
-Use the [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] Configuration Manager tool to allow [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] to accept remote connections.  
+## User Action 
+[!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)]
+Depending on the cause:
+- Try to disable the Shared Memory protocol in Configuration Manager and use TCP/IP instead.
+- Restart the instance in single user mode and make sure that the maximum number of concurrent user connections has not been changed from its default value of 0 (0 = unlimited)
   
 ## See Also  
-[Network Protocols and Network Libraries](~/sql-server/install/network-protocols-and-network-libraries.md)  
+[Network Protocols and Network Libraries](~/sql-server/install/network-protocols-and-network-libraries.md)
+[Shared Memory Properties](~/tools/configuration-manager/shared-memory-properties.md)
 [Client Network Configuration](~/database-engine/configure-windows/client-network-configuration.md)  
 [Configure Client Protocols](~/database-engine/configure-windows/configure-client-protocols.md)  
-[Enable or Disable a Server Network Protocol](~/database-engine/configure-windows/enable-or-disable-a-server-network-protocol.md)  
+[Enable or Disable a Server Network Protocol](~/database-engine/configure-windows/enable-or-disable-a-server-network-protocol.md)
+[Configure the user connections Server Configuration Option](~/database-engine/configure-windows/configure-the-user-connections-server-configuration-option.md)
   


### PR DESCRIPTION
Since this error pertains to Shared Memory, the original explanation stating that "the instance is not configured for remote connections" was incorrect due to shared memory being a local protocol (meaning that the client is on the same host as the instance it's trying to connect to).