### PR TITLE
Update database-copy.md

### DIFF
--- a/azure-sql/database/database-copy.md
+++ b/azure-sql/database/database-copy.md
@@ -87,7 +87,6 @@ Start copying the source database with the [CREATE DATABASE ... AS COPY OF](/sql
 > [!NOTE]  
 > Terminating the T-SQL statement does not terminate the database copy operation. To terminate the operation, drop the target database.
 >  
-> Database copy using T-SQL is not supported when connecting to the destination server over a [private endpoint](private-endpoint-overview.md). If a private endpoint is configured but public network access is allowed, database copy is supported when connected to the destination server from a public IP address. Once the copy operation completes, public access can be [denied](connectivity-settings.md#deny-public-network-access).
 
 > [!IMPORTANT]  
 > Selecting backup storage redundancy when using T-SQL CREATE DATABASE ... AS COPY OF command is not supported yet.


### PR DESCRIPTION
Statement regarding copying db while connecting using private endpoit doesnt seem to be true anymore. I was able to copy db between servers with public access disabled without any issue, using only t-sql.