### PR TITLE
minor update to reflect new snapshot backup technology

### DIFF
--- a/docs/relational-databases/databases/database-snapshots-sql-server.md
+++ b/docs/relational-databases/databases/database-snapshots-sql-server.md
@@ -25,7 +25,7 @@ A database snapshot is a read-only, static view of a [!INCLUDE[ssNoVersion](../.
  Multiple snapshots can exist on a given source database. Each database snapshot persists until it is explicitly dropped by the database owner.  
   
 > [!NOTE]  
->  Database snapshots are unrelated to snapshot backups, snapshot isolation of transactions, or snapshot replication.  
+>  Database snapshots are unrelated to Transact-SQL snapshot backup, snapshot isolation of transactions, or snapshot replication.  
   
  **In this Topic:**  
   

--- a/docs/relational-databases/databases/database-snapshots-sql-server.md
+++ b/docs/relational-databases/databases/database-snapshots-sql-server.md
@@ -25,7 +25,7 @@ A database snapshot is a read-only, static view of a [!INCLUDE[ssNoVersion](../.
  Multiple snapshots can exist on a given source database. Each database snapshot persists until it is explicitly dropped by the database owner.  
   
 > [!NOTE]  
->  Database snapshots are unrelated to Transact-SQL snapshot backup, snapshot isolation of transactions, or snapshot replication.  
+>  Database snapshots are unrelated to snapshot backups, Transact-SQL snapshot backups, snapshot isolation of transactions, or snapshot replication.  
   
  **In this Topic:**  
   


### PR DESCRIPTION
minor update to reference SQL Server 2022 technology name : Transact-SQL snapshot backup instead of "snapshot backups"