### PR TITLE
Note for auto_create_table

### DIFF
--- a/docs/t-sql/statements/copy-into-transact-sql.md
+++ b/docs/t-sql/statements/copy-into-transact-sql.md
@@ -276,7 +276,7 @@ IDENTITY_INSERT specifies whether the identity value or values in the imported d
 
 *AUTO_CREATE_TABLE* specifies if the table could be automatically created by working alongside with automatic schema discovery. It is available only for parquet files.
 
-- ON: Enables automatic table creation. The COPY INTO process will create a new table automatically by discovering the structure of the file to be loaded.  Can also be used with preexisting tables to take advantage of automatic schema discovery of parquet files.
+- ON: Enables automatic table creation. The COPY INTO process will create a new table automatically by discovering the structure of the file to be loaded. Can also be used with preexisting tables to take advantage of automatic schema discovery of Parquet files.
 - OFF: Automatic table creation is not enabled. Default.
 
 >[!NOTE]  

--- a/docs/t-sql/statements/copy-into-transact-sql.md
+++ b/docs/t-sql/statements/copy-into-transact-sql.md
@@ -274,7 +274,7 @@ IDENTITY_INSERT specifies whether the identity value or values in the imported d
 
 #### *AUTO_CREATE_TABLE = { 'ON' | 'OFF' }*
 
-*AUTO_CREATE_TABLE* specifies if the table could be automatically created by working alongside with automatic schema discovery. It is available only for parquet files.
+*AUTO_CREATE_TABLE* specifies if the table could be automatically created by working alongside with automatic schema discovery. It is available only for Parquet files.
 
 - ON: Enables automatic table creation. The COPY INTO process will create a new table automatically by discovering the structure of the file to be loaded. Can also be used with preexisting tables to take advantage of automatic schema discovery of Parquet files.
 - OFF: Automatic table creation is not enabled. Default.
@@ -282,9 +282,9 @@ IDENTITY_INSERT specifies whether the identity value or values in the imported d
 >[!NOTE]  
 > The automatic table creation works alongside with automatic schema discovery. The automatic table creation is NOT enabled by default.
 
-Do not load into hash distributed tables from parquet files using COPY INTO with AUTO_CREATE_TABLE = 'ON'.
+Do not load into hash distributed tables from Parquet files using COPY INTO with AUTO_CREATE_TABLE = 'ON'.
 
-If parquet files are to be loaded into hash distributed tables using COPY INTO, load it into a round robin staging table followed by INSERT ... SELECT from that table to the target hash distributed table.
+If Parquet files are to be loaded into hash distributed tables using COPY INTO, load it into a round robin staging table followed by INSERT ... SELECT from that table to the target hash distributed table.
 
 ### Permissions  
 
@@ -377,7 +377,7 @@ WITH (
 
 ### D. Load Parquet or ORC using existing file format object
 
- This example uses a wildcard to load all parquet files under a folder. 
+ This example uses a wildcard to load all Parquet files under a folder. 
 
 ```sql
 COPY INTO test_parquet

--- a/docs/t-sql/statements/copy-into-transact-sql.md
+++ b/docs/t-sql/statements/copy-into-transact-sql.md
@@ -276,7 +276,7 @@ IDENTITY_INSERT specifies whether the identity value or values in the imported d
 
 *AUTO_CREATE_TABLE* specifies if the table could be automatically created by working alongside with automatic schema discovery. It is available only for parquet files.
 
-- ON: Enables automatic table creation. The COPY INTO process will create a new table automatically by discovering the structure of the file to be loaded.
+- ON: Enables automatic table creation. The COPY INTO process will create a new table automatically by discovering the structure of the file to be loaded.  Can also be used with preexisting tables to take advantage of automatic schema discovery of parquet files.
 - OFF: Automatic table creation is not enabled. Default.
 
 >[!NOTE]  


### PR DESCRIPTION
AUTO_CREATE_TABLE implies that it should only be used if the target table does not exist; however, this is not true.  This can be enabled which make use of more optimized code paths for parquet which can also impact data type mapping.  See IcM 379492745.