### PR TITLE
Update T-SQL Linux Restore Script

### DIFF
--- a/docs/samples/adventureworks-install-configure.md
+++ b/docs/samples/adventureworks-install-configure.md
@@ -104,8 +104,8 @@ GO
 RESTORE DATABASE [AdventureWorks2019]
 FROM DISK = '/var/opt/mssql/backup/AdventureWorks2019.bak'
 WITH
-    MOVE 'AdventureWorks2019' TO '/var/opt/mssql/data/AdventureWorks2019.mdf',
-    MOVE 'AdventureWorks2019_log' TO '/var/opt/mssql/data/AdventureWorks2019_log.ldf',
+    MOVE 'AdventureWorks2017' TO '/var/opt/mssql/data/AdventureWorks2019.mdf',
+    MOVE 'AdventureWorks2017_log' TO '/var/opt/mssql/data/AdventureWorks2019_log.ldf',
     FILE = 1,
     NOUNLOAD,
     STATS = 5;


### PR DESCRIPTION
I was getting an error that Logical File `AdventureWorks2019` does not exist on the file until I got that it's a typo in the documentation itself as well please change the logical file name to `AdventureWorks2017`.

Basically `AdventureWorks2019.bak` contains old logical file names like `AdventureWorks2017` so that worked.