### PR TITLE
Documentation of AAD group behavior in SQL DB

### DIFF
--- a/azure-sql/database/authentication-aad-overview.md
+++ b/azure-sql/database/authentication-aad-overview.md
@@ -118,7 +118,7 @@ To create a contained database user in Azure SQL Database, Azure SQL Managed Ins
   - `SUSER_ID(<name>)`
   - `SUSER_SID(<name>)`
 
-- Azure SQL Database doesn't create implicit users for users logged in as part of an Azure Active Directory (Azure AD) group membership. Because of this, various operations that require assigning ownership will fail, even if the Azure AD group is added as a member to a role with those permissions.
+- Azure SQL Database doesn't create implicit users for users logged in as part of an Azure AD group membership. Because of this, various operations that require assigning ownership will fail, even if the Azure AD group is added as a member to a role with those permissions.
 
 For example, a user signed into a database via an Azure AD group with the **db_ddladmin** role, will not be able to execute CREATE SCHEMA, ALTER SCHEMA, and other object creation statements without a schema explicitly defined (such as table, view, or type, for example). To resolve this, an Azure AD user must be created for that user, or the Azure AD group must be altered to assign a DEFAULT_SCHEMA.
 

--- a/azure-sql/database/authentication-aad-overview.md
+++ b/azure-sql/database/authentication-aad-overview.md
@@ -118,6 +118,8 @@ To create a contained database user in Azure SQL Database, Azure SQL Managed Ins
   - `SUSER_ID(<name>)`
   - `SUSER_SID(<name>)`
 
+- Azure SQL DB does not create implicit users for users logged in as part of an AAD group membership. Because of this various operations that require assigning ownership will fail, even if the AAD group is added as a member to a role with those permissions. For example, a user logged into a database via an AAD group with the db_ddladmin role will not be able to execute CREATE SCHEMA, ALTER SCHEMA, and other object creation statements without a schema explicitly defined (table, view, type, etc.). To resolve this, an Azure AD user must be created for that user, or the AAD group must be altered to assign a DEFAULT_SCHEMA.
+
 ### SQL Managed Instance
 
 - Azure AD server principals (logins) and users are supported for [SQL Managed Instance](../managed-instance/sql-managed-instance-paas-overview.md).

--- a/azure-sql/database/authentication-aad-overview.md
+++ b/azure-sql/database/authentication-aad-overview.md
@@ -120,7 +120,7 @@ To create a contained database user in Azure SQL Database, Azure SQL Managed Ins
 
 - Azure SQL Database doesn't create implicit users for users logged in as part of an Azure AD group membership. Because of this, various operations that require assigning ownership will fail, even if the Azure AD group is added as a member to a role with those permissions.
 
-For example, a user signed into a database via an Azure AD group with the **db_ddladmin** role, will not be able to execute CREATE SCHEMA, ALTER SCHEMA, and other object creation statements without a schema explicitly defined (such as table, view, or type, for example). To resolve this, an Azure AD user must be created for that user, or the Azure AD group must be altered to assign a DEFAULT_SCHEMA.
+   For example, a user signed into a database via an Azure AD group with the **db_ddladmin** role, will not be able to execute CREATE SCHEMA, ALTER SCHEMA, and other object creation statements without a schema explicitly defined (such as table, view, or type, for example). To resolve this, an Azure AD user must be created for that user, or the Azure AD group must be altered to assign a DEFAULT_SCHEMA.
 
 ### SQL Managed Instance
 

--- a/azure-sql/database/authentication-aad-overview.md
+++ b/azure-sql/database/authentication-aad-overview.md
@@ -118,7 +118,9 @@ To create a contained database user in Azure SQL Database, Azure SQL Managed Ins
   - `SUSER_ID(<name>)`
   - `SUSER_SID(<name>)`
 
-- Azure SQL DB does not create implicit users for users logged in as part of an AAD group membership. Because of this various operations that require assigning ownership will fail, even if the AAD group is added as a member to a role with those permissions. For example, a user logged into a database via an AAD group with the db_ddladmin role will not be able to execute CREATE SCHEMA, ALTER SCHEMA, and other object creation statements without a schema explicitly defined (table, view, type, etc.). To resolve this, an Azure AD user must be created for that user, or the AAD group must be altered to assign a DEFAULT_SCHEMA.
+- Azure SQL Database doesn't create implicit users for users logged in as part of an Azure Active Directory (Azure AD) group membership. Because of this, various operations that require assigning ownership will fail, even if the Azure AD group is added as a member to a role with those permissions.
+
+For example, a user signed into a database via an Azure AD group with the **db_ddladmin** role, will not be able to execute CREATE SCHEMA, ALTER SCHEMA, and other object creation statements without a schema explicitly defined (such as table, view, or type, for example). To resolve this, an Azure AD user must be created for that user, or the Azure AD group must be altered to assign a DEFAULT_SCHEMA.
 
 ### SQL Managed Instance
 


### PR DESCRIPTION
This documentation change is to address a few customer reported incidents in which the customer expected to be able to execute statements since they were logged in via an AAD group which had been granted those permissions. Instead, they were met with errors stating the user doesn't exist, because of the implicit user limitation on SQL DB. By calling out this limitation publicly, customers should be able to resolve this issue more quickly without having to engage customer support.