### PR TITLE
Update columnstore-indexes-design-guidance.md

### DIFF
--- a/docs/relational-databases/indexes/columnstore-indexes-design-guidance.md
+++ b/docs/relational-databases/indexes/columnstore-indexes-design-guidance.md
@@ -57,7 +57,7 @@ Consider using a clustered columnstore index when:
 
 Don't use a clustered columnstore index when:
 
-* The table requires varchar(max), nvarchar(max), or varbinary(max) data types. Or, design the columnstore index so that it doesn't include these columns.
+* The table requires varchar(max), nvarchar(max), or varbinary(max) data types. Or, design the columnstore index so that it doesn't include these columns (Only for SQL 2016 or older).
 * The table data is not permanent. Consider using a heap or temporary table when you need to store and delete the data quickly.
 * The table has less than one million rows per partition. 
 * More than 10% of the operations on the table are updates and deletes. Large numbers of updates and deletes cause fragmentation. The fragmentation affects compression rates and query performance until you run an operation called reorganize that forces all data into the columnstore and removes fragmentation. For more information, see [Minimizing index fragmentation in columnstore index](/archive/blogs/sqlserverstorageengine/columnstore-index-defragmentation-using-reorganize-command).

--- a/docs/relational-databases/indexes/columnstore-indexes-design-guidance.md
+++ b/docs/relational-databases/indexes/columnstore-indexes-design-guidance.md
@@ -57,7 +57,7 @@ Consider using a clustered columnstore index when:
 
 Don't use a clustered columnstore index when:
 
-* The table requires varchar(max), nvarchar(max), or varbinary(max) data types. Or, design the columnstore index so that it doesn't include these columns (Only for SQL 2016 or older).
+* The table requires **varchar(max)**, **nvarchar(max)**, or **varbinary(max)** data types. Or, design the columnstore index so that it doesn't include these columns (**Applies to:** [!INCLUDE [sssql16-md](../../includes/sssql16-md.md)] and previous versions).
 * The table data is not permanent. Consider using a heap or temporary table when you need to store and delete the data quickly.
 * The table has less than one million rows per partition. 
 * More than 10% of the operations on the table are updates and deletes. Large numbers of updates and deletes cause fragmentation. The fragmentation affects compression rates and query performance until you run an operation called reorganize that forces all data into the columnstore and removes fragmentation. For more information, see [Minimizing index fragmentation in columnstore index](/archive/blogs/sqlserverstorageengine/columnstore-index-defragmentation-using-reorganize-command).

--- a/docs/relational-databases/indexes/columnstore-indexes-design-guidance.md
+++ b/docs/relational-databases/indexes/columnstore-indexes-design-guidance.md
@@ -57,7 +57,8 @@ Consider using a clustered columnstore index when:
 
 Don't use a clustered columnstore index when:
 
-* The table requires **varchar(max)**, **nvarchar(max)**, or **varbinary(max)** data types. Or, design the columnstore index so that it doesn't include these columns (**Applies to:** [!INCLUDE [sssql16-md](../../includes/sssql16-md.md)] and previous versions).
+* The table requires `varchar(max)`, `nvarchar(max)`, or `varbinary(max)` data types. Or, design the columnstore index so that it doesn't include these columns (Applies to: [!INCLUDE [sssql16-md](../../includes/sssql16-md.md)] and previous versions).
+
 * The table data is not permanent. Consider using a heap or temporary table when you need to store and delete the data quickly.
 * The table has less than one million rows per partition. 
 * More than 10% of the operations on the table are updates and deletes. Large numbers of updates and deletes cause fragmentation. The fragmentation affects compression rates and query performance until you run an operation called reorganize that forces all data into the columnstore and removes fragmentation. For more information, see [Minimizing index fragmentation in columnstore index](/archive/blogs/sqlserverstorageengine/columnstore-index-defragmentation-using-reorganize-command).


### PR DESCRIPTION
Since lob columns are supported starting on SQL 2017, this detail is missing in this article.

As stated here, starting on SQL 2017, lob columns are supported

https://learn.microsoft.com/en-us/sql/t-sql/statements/create-columnstore-index-transact-sql?view=sql-server-ver16#LimitRest

