### PR TITLE
full syntax: added INCLUDE clause in table_index

### DIFF
--- a/docs/t-sql/statements/create-table-transact-sql.md
+++ b/docs/t-sql/statements/create-table-transact-sql.md
@@ -208,6 +208,7 @@ column_set_name XML COLUMN_SET FOR ALL_SPARSE_COLUMNS
     | INDEX index_name CLUSTERED COLUMNSTORE
     | INDEX index_name [ NONCLUSTERED ] COLUMNSTORE ( column_name [ ,... n ] )
     }
+    [ INCLUDE ( column_name [ ,...n ] ) ]
     [ WHERE <filter_predicate> ]
     [ WITH ( <index_option> [ ,... n ] ) ]
     [ ON { partition_scheme_name ( column_name )


### PR DESCRIPTION
The include works in Developer Edition 2022 (Microsoft SQL Server 2022 (RTM-GDR) (KB5021522) - 16.0.1050.5 (X64)) but was missing from this documentation. 

Also not recognised by IntelliSense for SQL Server Management Studio 19.0.20209.0+f9a9d8f6 (incorrect syntax).