### PR TITLE
Update sys-fn-get-audit-file-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-functions/sys-fn-get-audit-file-transact-sql.md
+++ b/docs/relational-databases/system-functions/sys-fn-get-audit-file-transact-sql.md
@@ -166,14 +166,6 @@ ORDER BY event_time;
 GO
 ```
 
-This example reads all audit logs from servers that begin with `Sh`:
-
-```sql
-SELECT *
-FROM sys.fn_get_audit_file('https://mystorage.blob.core.windows.net/sqldbauditlogs/Sh*', DEFAULT, DEFAULT);
-GO
-```
-
 For a full example about how to create an audit, see [SQL Server Audit (Database Engine)](../../relational-databases/security/auditing/sql-server-audit-database-engine.md).
 
 For information on setting up Azure SQL Database auditing, see [Get Started with SQL Database auditing](/azure/sql-database/sql-database-auditing).


### PR DESCRIPTION
Using wildcard for querying sys.fn_get_audit_file is not supported for Azure SQL Database product. Have tested this, also documented here: https://learn.microsoft.com/en-us/sql/relational-databases/system-functions/sys-fn-get-audit-file-transact-sql?view=sql-server-ver16#:~:text=specific%20audit%20file.-,Azure%20SQL%20Database,-%3A

Please message me for context on why this change is proposed if needed. Thanks!