### PR TITLE
Disambiguate deprecation notice in disallow results from triggers

### DIFF
--- a/docs/database-engine/configure-windows/disallow-results-from-triggers-server-configuration-option.md
+++ b/docs/database-engine/configure-windows/disallow-results-from-triggers-server-configuration-option.md
@@ -18,7 +18,7 @@ helpviewer_keywords:
   Use the **disallow results from triggers** option to control whether triggers return result sets. Triggers that return result sets may cause unexpected behavior in applications that are not designed to work with them.  
   
 > [!IMPORTANT]  
->  [!INCLUDE[ssNoteDepFutureAvoid](../../includes/ssnotedepfutureavoid-md.md)] We recommend that you set this value to 1.  
+>  The ability to return result sets from triggers is deprecated. [!INCLUDE[ssNoteDepFutureAvoid](../../includes/ssnotedepfutureavoid-md.md)] We recommend that you set this value to 1.  
   
  When set to 1, the **disallow results from triggers** option is set to ON. The default setting for this option is 0 (OFF). If this option is set to 1 (ON), any attempt by a trigger to return a result set fails, and the user receives the following error message:  
   


### PR DESCRIPTION
The `disallow results from triggers` configuration option [documentation](https://learn.microsoft.com/en-us/sql/database-engine/configure-windows/disallow-results-from-triggers-server-configuration-option) has a deprecation notice about the ability to return result sets from triggers. But a generic deprecation notice is used, with the wording "this feature".

It is unclear whether "this feature" refers to the configuration option or to the feature of returning result sets from triggers. With the sentence "We recommend that you set this value to 1." added after the notice, we can understand that the notice is about the feature, not the option. But still, that is confusing.

It appears older versions of the documentation, dating back to MSDN, were more clear:
> The ability to return result sets from triggers will be removed in a future version of SQL Server. Avoid returning result sets from triggers in new development work, and plan to modify applications that currently do this. To prevent triggers from returning result sets in SQL Server 2005, set the disallow results from triggers Option to 1. The default setting of this option will be 1 in a future version of SQL Server.

(Seen [here](https://stackoverflow.com/a/30915837/1178314).)

This change combines the older documentation with the generic deprecation notice.

So, current notice is:
> This feature will be removed in a future version of Microsoft SQL Server. Avoid using this feature in new development work, and plan to modify applications that currently use this feature. We recommend that you set this value to 1.

Proposed change would cause it to be:
> The ability to return result sets from triggers is deprecated. This feature will be removed in a future version of Microsoft SQL Server. Avoid using this feature in new development work, and plan to modify applications that currently use this feature. We recommend that you set this value to 1.

Maybe it should be more explicit about `value` too, like this:
> The ability to return result sets from triggers is deprecated. This feature will be removed in a future version of Microsoft SQL Server. Avoid using this feature in new development work, and plan to modify applications that currently use this feature. We recommend that you set this option value to 1.