### PR TITLE
Update backup-symmetric-key applies to only SQL2022

### DIFF
--- a/docs/t-sql/statements/backup-symmetric-key-transact-sql.md
+++ b/docs/t-sql/statements/backup-symmetric-key-transact-sql.md
@@ -11,7 +11,7 @@ ms.topic: reference
 
 # BACKUP SYMMETRIC KEY (Transact-SQL)
 
-[!INCLUDE [sqlserver2022-asdb-asmi](../../includes/applies-to-version/sqlserver2022-asdb-asmi.md)]
+[!INCLUDE [sqlserver2022](../../includes/applies-to-version/sqlserver2022.md)]
 
 > [!NOTE]
 > [!INCLUDE [sssql22-md](../../includes/sssql22-md.md)] introduces support for exporting and importing symmetric keys, either to or from Azure Blob storage or file.


### PR DESCRIPTION
Update applies to section from SQLServer2022+AzureSQL+SQLMI to SQLServer2022 only.  based ICM 384700538
Backup symmetric key is not supported operation for Azure SQL DB or SQL MI