### PR TITLE
Update managing-services-and-network-settings-by-using-wmi-provider.md

### DIFF
--- a/docs/relational-databases/server-management-objects-smo/tasks/managing-services-and-network-settings-by-using-wmi-provider.md
+++ b/docs/relational-databases/server-management-objects-smo/tasks/managing-services-and-network-settings-by-using-wmi-provider.md
@@ -14,7 +14,7 @@ helpviewer_keywords:
 monikerRange: "=azuresqldb-current||=azure-sqldw-latest||>=sql-server-2016||>=sql-server-linux-2017||=azuresqldb-mi-current"
 ---
 # Managing Services and Network Settings by Using WMI Provider
-[!INCLUDE [SQL Server ASDB, ASDBMI, ASDW](../../../includes/applies-to-version/sql-asdb-asdbmi-asa.md)]
+[!INCLUDE [sqlserver2022](../../includes/applies-to-version/sqlserver2022.md)]
 
   The WMI provider is a published interface that is used by [!INCLUDE[msCoName](../../../includes/msconame-md.md)] Management Console (MMC) to manage the [!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)] services and network protocols. In SMO, the <xref:Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer> object represents the WMI Provider.  
   

--- a/docs/relational-databases/server-management-objects-smo/tasks/managing-services-and-network-settings-by-using-wmi-provider.md
+++ b/docs/relational-databases/server-management-objects-smo/tasks/managing-services-and-network-settings-by-using-wmi-provider.md
@@ -14,7 +14,7 @@ helpviewer_keywords:
 monikerRange: "=azuresqldb-current||=azure-sqldw-latest||>=sql-server-2016||>=sql-server-linux-2017||=azuresqldb-mi-current"
 ---
 # Managing Services and Network Settings by Using WMI Provider
-[!INCLUDE [sqlserver2022](../../includes/applies-to-version/sqlserver2022.md)]
+[!INCLUDE [sqlserver2022](../../../includes/applies-to-version/sqlserver2022.md)]
 
   The WMI provider is a published interface that is used by [!INCLUDE[msCoName](../../../includes/msconame-md.md)] Management Console (MMC) to manage the [!INCLUDE[ssNoVersion](../../../includes/ssnoversion-md.md)] services and network protocols. In SMO, the <xref:Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer> object represents the WMI Provider.  
   


### PR DESCRIPTION
Changed "applies to" to SQL Server only, the cloud services, Azure SQL DB, Managed instance and Synapse does not have RPC interface and do not support WMI remote connection at all.