### PR TITLE
Update create-a-wmi-event-alert.md

### DIFF
--- a/docs/ssms/agent/create-a-wmi-event-alert.md
+++ b/docs/ssms/agent/create-a-wmi-event-alert.md
@@ -14,10 +14,7 @@ monikerRange: "= azuresqldb-mi-current || >= sql-server-2016"
 ---
 # Create a WMI event alert
 
-[!INCLUDE [SQL Server SQL MI](../../includes/applies-to-version/sql-asdbmi.md)]
-
-> [!IMPORTANT]  
-> On [Azure SQL Managed Instance](/azure/sql-database/sql-database-managed-instance), most, but not all SQL Server Agent features are currently supported. See [Azure SQL Managed Instance T-SQL differences from SQL Server](/azure/sql-database/sql-database-managed-instance-transact-sql-information#sql-server-agent) for details.
+[!INCLUDE [sqlserver2022](../../includes/applies-to-version/sqlserver2022.md)]
 
 This article describes how to a [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] Agent alert that is raised when a specific [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] event occurs that is monitored by the WMI Provider for Server Events in [!INCLUDE[ssnoversion](../../includes/ssnoversion-md.md)] by using SQL Server Management Studio or [!INCLUDE[tsql](../../includes/tsql-md.md)].
 


### PR DESCRIPTION
Update Applies to from SQL+MI to SQL only as alerts are not supported for MI at all.  also, removed the Important box which discusses the differences with Managed instance which is not needed.  Confirm Alerts are not supported here: https://learn.microsoft.com/en-us/azure/azure-sql/managed-instance/transact-sql-tsql-differences-sql-server?view=azuresql#sql-server-agent