### PR TITLE
Update create-external-table-as-select-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/create-external-table-as-select-transact-sql.md
+++ b/docs/t-sql/statements/create-external-table-as-select-transact-sql.md
@@ -903,7 +903,7 @@ These common error messages have quick explanations for CETAS for Azure SQL Mana
 
 1. Access problems (invalid credential, expired credential or credential with insufficient permissions). Alternate possibility is an invalid path, where the SQL managed instance received an Error 404 from storage.
 
-   Solution: Verify credential validity and permissions. Alternatively, validate the path is valid and storage exists. For ADLS URL use format adls://container@mystorageaccount.blob.core.windows.net/mybaseoutputfolderpath
+   Solution: Verify credential validity and permissions. Alternatively, validate the path is valid and storage exists. Use the URL path `adls://<container>@<storage_account>.blob.core.windows.net/<path>/`.
 
    Sample error message: `Msg 15883: Access check for '<Read/Write>' operation against '<Storage>' failed with HRESULT = '0x...'`
 

--- a/docs/t-sql/statements/create-external-table-as-select-transact-sql.md
+++ b/docs/t-sql/statements/create-external-table-as-select-transact-sql.md
@@ -903,7 +903,7 @@ These common error messages have quick explanations for CETAS for Azure SQL Mana
 
 1. Access problems (invalid credential, expired credential or credential with insufficient permissions). Alternate possibility is an invalid path, where the SQL managed instance received an Error 404 from storage.
 
-   Solution: Verify credential validity and permissions. Alternatively, validate the path is valid and storage exists.
+   Solution: Verify credential validity and permissions. Alternatively, validate the path is valid and storage exists. For ADLS URL use format adls://container@mystorageaccount.blob.core.windows.net/mybaseoutputfolderpath
 
    Sample error message: `Msg 15883: Access check for '<Read/Write>' operation against '<Storage>' failed with HRESULT = '0x...'`
 
@@ -978,7 +978,7 @@ CREATE EXTERNAL FILE FORMAT [ParquetFF] WITH (
 GO
 
 CREATE EXTERNAL DATA SOURCE [SQLwriteable] WITH (
-    LOCATION = 'adls://container@mystorageaccount.dfs.core.windows.net/mybaseoutputfolderpath',
+    LOCATION = 'adls://container@mystorageaccount.blob.core.windows.net/mybaseoutputfolderpath',
     CREDENTIAL = [WorkspaceIdentity]
 );
 GO
@@ -1019,7 +1019,7 @@ CREATE EXTERNAL FILE FORMAT [ParquetFF] WITH (
 GO
 
 CREATE EXTERNAL DATA SOURCE [SQLwriteable] WITH (
-    LOCATION = 'adls://container@mystorageaccount.dfs.core.windows.net/mybaseoutputfolderpath',
+    LOCATION = 'adls://container@mystorageaccount.blob.core.windows.net/mybaseoutputfolderpath',
     CREDENTIAL = [SAS_token]
 );
 GO


### PR DESCRIPTION
For Azure SQL Server Managed Instance and ADLS: Url with .blob. has to be used instead of .dfs. 

I've changed 2 examples and also error message section. It is briefly explained at the beginning but examples were incorrect.