### PR TITLE
Fix minor formatting error in substring-transact-sql.md

### DIFF
--- a/docs/t-sql/functions/substring-transact-sql.md
+++ b/docs/t-sql/functions/substring-transact-sql.md
@@ -32,7 +32,7 @@ Returns part of a character, binary, text, or image expression in [!INCLUDE[ssNo
 ## Syntax  
   
 ```syntaxsql
-SUBSTRING ( expression, start , length )  
+SUBSTRING ( expression, start, length )  
 ```  
   
 [!INCLUDE[sql-server-tsql-previous-offline-documentation](../../includes/sql-server-tsql-previous-offline-documentation.md)]

--- a/docs/t-sql/functions/substring-transact-sql.md
+++ b/docs/t-sql/functions/substring-transact-sql.md
@@ -32,7 +32,7 @@ Returns part of a character, binary, text, or image expression in [!INCLUDE[ssNo
 ## Syntax  
   
 ```syntaxsql
-SUBSTRING ( expression ,start , length )  
+SUBSTRING ( expression, start , length )  
 ```  
   
 [!INCLUDE[sql-server-tsql-previous-offline-documentation](../../includes/sql-server-tsql-previous-offline-documentation.md)]


### PR DESCRIPTION
Correct comma spacing in the "Syntax" section.