### PR TITLE
Update tablediff-utility.md

### DIFF
--- a/docs/tools/tablediff-utility.md
+++ b/docs/tools/tablediff-utility.md
@@ -31,6 +31,9 @@ monikerRange: ">=aps-pdw-2016||=azuresqldb-current||=azure-sqldw-latest||>=sql-s
   
 -   Log results to an output file or into a table in the destination database.  
   
+> [!IMPORTANT]  
+>  The tablediff Utility is part of the the SQL Server Replication tools. The tablediff.exe file can be found at its default location of “C:\Program Files\Microsoft SQL Server\160\COM” once the replication feature has been installed.
+
 ## Syntax  
   
 ```  


### PR DESCRIPTION
The document does not clarify where the file is and it is not clear that it is not exists if you do not add the replication feature of the SQL Server. There are many questions in the forum regarding where the file is and why it is not in the location people claim it should be.