### PR TITLE
Update ssis-catalog.md

### DIFF
--- a/docs/integration-services/catalog/ssis-catalog.md
+++ b/docs/integration-services/catalog/ssis-catalog.md
@@ -610,6 +610,9 @@ Provide the password that you specified while creating the SSIS Catalog in the *
 
 ![New Availability Group](../../integration-services/service/media/ssis-newavailabilitygroup.png "New Availability Group")  
   
+  > [!IMPORTANT]  
+  >  To prevent issues with the master key after a failover, use the method **Full database and log backup** to add the SSISDB database to the Always On Availability Group.
+  
 ####  <a name="Step3"></a> Step 3: Enable SSIS support for Always On  
  After you create the Integration Service Catalog, right-click the **Integration Service Catalogs** node, and click **Enable Always On Support.** You should see the following **Enable Support for Always On** dialog box. If this menu item is disabled, confirm that you have all the prerequisites installed and click **Refresh**.  
   


### PR DESCRIPTION
If customers use automatic seeding or manual backup/restore method + join only in the wizard, the error described in the article below happens (I could reproduce the same issue on different SQL versions, 2017 and 2019). The only way to fix the issue is using the Full database and log backup method when adding the database to the AG.

https://techcommunity.microsoft.com/t5/sql-server-support-blog/ssis-always-on-ag-availability-group-and-error-please-create-a/ba-p/414236

Because of that, I think we must mention that in the article