### PR TITLE
Update view-or-change-the-recovery-model-of-a-database-sql-server.md

### DIFF
--- a/docs/relational-databases/backup-restore/view-or-change-the-recovery-model-of-a-database-sql-server.md
+++ b/docs/relational-databases/backup-restore/view-or-change-the-recovery-model-of-a-database-sql-server.md
@@ -94,6 +94,8 @@ GO
 USE [master] ;  
 ALTER DATABASE [model] SET RECOVERY FULL ;  
 ```  
+        > [!NOTE]  
+        > Changing the recovery model flushes out the plan cache  
   
 ##  <a name="FollowUp"></a> Recommendations: After you change the recovery model  
   

--- a/docs/relational-databases/backup-restore/view-or-change-the-recovery-model-of-a-database-sql-server.md
+++ b/docs/relational-databases/backup-restore/view-or-change-the-recovery-model-of-a-database-sql-server.md
@@ -94,8 +94,8 @@ GO
 USE [master] ;  
 ALTER DATABASE [model] SET RECOVERY FULL ;  
 ```  
-        > [!NOTE]  
-        > Changing the recovery model flushes out the plan cache  
+> [!NOTE]  
+> Changing the recovery model flushes out the plan cache  
   
 ##  <a name="FollowUp"></a> Recommendations: After you change the recovery model  
   

--- a/docs/relational-databases/backup-restore/view-or-change-the-recovery-model-of-a-database-sql-server.md
+++ b/docs/relational-databases/backup-restore/view-or-change-the-recovery-model-of-a-database-sql-server.md
@@ -94,8 +94,9 @@ GO
 USE [master] ;  
 ALTER DATABASE [model] SET RECOVERY FULL ;  
 ```  
+
 > [!NOTE]  
-> Changing the recovery model flushes out the plan cache  
+> Changing the recovery model flushes the plan cache.
   
 ##  <a name="FollowUp"></a> Recommendations: After you change the recovery model  
   


### PR DESCRIPTION
by design the cache is flushed out but it seems it is not documented anywhere - from the stack - when the recover model is changed, I see

```
0:138> kL
# Child-SP          RetAddr               Call Site00 000000c4`28bf5788 00007ffc`c6f015c1     _**sqlmin!CCache::RemoveByDbid01_** 000000c4`28bf5790 00007ffc`c9007ee9     sqlmin!NotifyEndStateOptionChange::HandleEvent+0x10102 000000c4`28bf57e0 00007ffc`c9007da6     sqlmin!XactRM::FireNotificationsInternal+0x12903 000000c4`28bf5930 00007ffc`c900633f     sqlmin!XactRM::FireNotifications+0x10604 000000c4`28bf5980 00007ffc`c900574b     sqlmin!XactRM::CommitLocalPrepared+0xadf05 000000c4`28bf6200 00007ffc`c8fe5da0     sqlmin!XactRM::CommitInternal+0xf1b06 000000c4`28bf65e0 00007ffc`c8fe5a97     sqlmin!XactRM::Commit+0x4007 000000c4`28bf6610 00007ffc`c2734f4b     sqlmin!FullXactImp::Commit+0x86708 000000c4`28bf7830 00007ffc`c2734d29     sqllang!CMsqlXactInternalBase::CommitInternal+0x1cb09 000000c4`28bf7890 00007ffc`c271f47a     sqllang!CMsqlXactInternalReadWrite::Commit+0x1290a 000000c4`28bf7900 00007ffc`c399f078     sqllang!CMsqlXactImp::Commit+0x49a0b 000000c4`28bf7a50 00007ffc`c213a541     sqllang!CAutoMsqlXact::CommitNestedXact+0xa80c 000000c4`28bf7aa0 00007ffc`c21725b1     sqllang!CStmtAlterDB::ChangeStateOption+0x59c10d 000000c4`28bfac70 00007ffc`c188838f     sqllang!CStmtAlterDB::XretExecute+0x22b10e 000000c4`28bfc430 00007ffc`c1fd0ec1     sqllang!CXStmtDDL::XretExecute+0x1ef0f 000000c4`28bfc4b0 00007ffc`c1fb8fbe     sqllang!CExecStmtLoopVars::ExecuteXStmtAndSetXretReturn+0x5110 000000c4`28bfc4f0 00007ffc`c1fd4062     sqllang!CMsqlExecContext::ExecuteStmts<1,1>+0x68e11 000000c4`28bfc770 00007ffc`c20fc9e7     sqllang!CMsqlExecContext::FExecute+0x139212 000000c4`28bfd370 00007ffc`c1b72442     sqllang!CSQLSource::Execute+0x17c713 000000c4`28bfdd90 00007ffc`c1c500a5     sqllang!process_request+0x145214 000000c4`28bfe990 00007ffc`c1c521f7     sqllang!process_commands_internal+0x4d515 000000c4`28bfebc0 00007ffc`c1bf990f     sqllang!process_messages+0x2e716 000000c4`28bfedd0 00007ffc`c1c4fbbb     sqllang!ProcessMessages+0x2f17 000000c4`28bfee00 00007ffc`bdb53d4d     sqllang!process_commands+0x2b18 000000c4`28bfee30 00007ffc`bdb5ea9b     sqldk!SOS_Task::Param::Execute+0x2bd19 000000c4`28bff4e0 00007ffc`bdb5bc6f     sqldk!SOS_Scheduler::RunTask+0x1db1a 000000c4`28bff5a0 00007ffc`bdb43d13     sqldk!SOS_Scheduler::ProcessTasks+0x3ff1b 000000c4`28bff660 00007ffc`bdb3f937     sqldk!SchedulerManager::WorkerEntryPoint+0x2f31c 000000c4`28bff7c0 00007ffc`bdb3c848     sqldk!SystemThread::RunWorker+0x1471d 000000c4`28bff830 00007ffc`bdb42573     sqldk!SystemThreadDispatcher::ProcessWorker+0x4881e 000000c4`28bff940 00007ffc`ec8e55a0     sqldk!SchedulerManager::ThreadEntryPoint+0x2031f 000000c4`28bffab0 00007ffc`ed92485b     KERNEL32!BaseThreadInitThunk+0x1020 000000c4`28bffae0 00000000`00000000     ntdll!RtlUserThreadStart+0x2b

the behaviour is easily reproducible 

CREATE PROC PlanCacheProc 
AS 
SELECT * FROM sysindexes ORDER BY dpages DESC

EXEC PlanCacheProc 

SELECT * 
FROM sys.dm_exec_query_stats qs 
CROSS APPLY sys.dm_exec_sql_text(qs.sql_handle) AS qt  WHERE  qt.dbid = DB_ID('yourdb')


ALTER DATABASE  yourdb SET RECOVERY SIMPLE

SELECT * 
FROM sys.dm_exec_query_stats qs 
CROSS APPLY sys.dm_exec_sql_text(qs.sql_handle) AS qt  WHERE  qt.dbid = DB_ID('yourdb')
```