### PR TITLE
Update thread-and-task-architecture-guide.md

### DIFF
--- a/docs/relational-databases/thread-and-task-architecture-guide.md
+++ b/docs/relational-databases/thread-and-task-architecture-guide.md
@@ -223,7 +223,7 @@ Hot add CPU is the ability to dynamically add CPUs to a running system. Adding C
 Requirements for hot add CPU:
 
 - Requires hardware that supports hot add CPU.
-- Requires a supported version of Windows Server Datacenter or Enterprise edition.
+- Requires a supported version of Windows Server Datacenter or Enterprise edition (Starting on Windows 2012 also supported on Standard edition).
 - Requires [!INCLUDE[ssNoVersion](../includes/ssnoversion-md.md)] Enterprise edition.
 - [!INCLUDE[ssNoVersion](../includes/ssnoversion-md.md)] can't be configured to use soft NUMA. For more information about soft NUMA, see [Soft-NUMA (SQL Server)](../database-engine/configure-windows/soft-numa-sql-server.md).
 

--- a/docs/relational-databases/thread-and-task-architecture-guide.md
+++ b/docs/relational-databases/thread-and-task-architecture-guide.md
@@ -223,7 +223,7 @@ Hot add CPU is the ability to dynamically add CPUs to a running system. Adding C
 Requirements for hot add CPU:
 
 - Requires hardware that supports hot add CPU.
-- Requires a supported version of Windows Server Datacenter or Enterprise edition (Starting on Windows 2012 also supported on Standard edition).
+- Requires a supported version of Windows Server Datacenter or Enterprise edition. Starting with [!INCLUDE [winserver2012-md](../includes/winserver2012-md.md)], hot add is supported on Standard edition.
 - Requires [!INCLUDE[ssNoVersion](../includes/ssnoversion-md.md)] Enterprise edition.
 - [!INCLUDE[ssNoVersion](../includes/ssnoversion-md.md)] can't be configured to use soft NUMA. For more information about soft NUMA, see [Soft-NUMA (SQL Server)](../database-engine/configure-windows/soft-numa-sql-server.md).
 


### PR DESCRIPTION
The Windows edition requirement regarding the hot add CPU seems to be inaccurate. Found some articles indicating it started being supported on standard edition on Windows 2012

https://superuser.com/questions/1037712/does-windows-server-2012-r2-support-hot-add-cpus

