### PR TITLE
Schema comparison: Add reference to Tools.SSDTNewSchemaComparison command

### DIFF
--- a/docs/ssdt/how-to-use-schema-compare-to-compare-different-database-definitions.md
+++ b/docs/ssdt/how-to-use-schema-compare-to-compare-different-database-definitions.md
@@ -106,3 +106,12 @@ To update the schema of the target, you have two choices. You can update the tar
   
 5.  Click the **Execute** button in the editing pane toolbar to run the script.  
   
+### Compare schemas by using the Visual Studio automation model
+
+1. Open the **View** menu, point to **Other Windows**, and select **Command Window**.
+
+1. In the Command Window, type the following command:
+
+    ```console
+    Tools.SSDTNewSchemaComparison
+    ```


### PR DESCRIPTION
The [data comparison page](https://learn.microsoft.com/en-us/sql/ssdt/how-to-compare-and-synchronize-the-data-of-two-databases) mentions how to use the Visual Studio automation commands to run data comparisons, but not the schema comparison page.