### PR TITLE
Update sp-add-schedule-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-add-schedule-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-add-schedule-transact-sql.md
@@ -98,7 +98,7 @@ Specifies the units for *@freq_subday_interval*. *@freq_subday_type* is **int**,
 
 #### [ @freq_subday_interval = ] *freq_subday_interval*
 
-The number of *@freq_subday_type* periods to occur between each execution of a job. *@freq_subday_interval* is **int**, with a default of `0`. The interval should be longer than 10 seconds. *@freq_subday_interval* is ignored in those cases where *@freq_subday_type* is equal to `1`.
+The number of *@freq_subday_type* periods to occur between each execution of a job. *@freq_subday_interval* is **int**, with a default of `0`. The interval must be at least 10 seconds long. *@freq_subday_interval* is ignored in those cases where *@freq_subday_type* is equal to `1`.
 
 #### [ @freq_relative_interval = ] *freq_relative_interval*
 


### PR DESCRIPTION
Align with source code of msdb.dbo.sp_verify_schedule.

And here is the relevant code from msdb.dbo.sp_verify_schedule:
```
  IF ((@freq_subday_type <> 0x1) AND (@freq_subday_interval < 1)) -- FREQSUBTYPE_ONCE and less than 1 interval
     OR
     ((@freq_subday_type = 0x2) AND (@freq_subday_interval < 10)) -- FREQSUBTYPE_SECOND and less than 10 seconds (see MIN_SCHEDULE_GRANULARITY in SqlAgent source code)
  BEGIN
    SELECT @reason = FORMATMESSAGE(14200, '@freq_subday_interval')
    RAISERROR(14278, -1, -1, @reason)
    RETURN(1) -- Failure
  END
```

So 10 seconds is allowed, shorter periods raise an error. I'm not a native english speaker, so please adjust the wording as you like. I just think that "should" is not correct as it is just not possible and 10 seconds is a valid option.