### PR TITLE
added @variable and CTE to MERGE target table

### DIFF
--- a/docs/t-sql/statements/merge-transact-sql.md
+++ b/docs/t-sql/statements/merge-transact-sql.md
@@ -84,8 +84,9 @@ MERGE
   
 <target_table> ::=  
 {
-    [ database_name . schema_name . | schema_name . ]  
-  target_table  
+    [ database_name . schema_name . | schema_name . ]  target_table  
+    | @variable
+    | common_table_expression_name
 }  
   
 <merge_hint>::=  

--- a/docs/t-sql/statements/merge-transact-sql.md
+++ b/docs/t-sql/statements/merge-transact-sql.md
@@ -84,9 +84,9 @@ MERGE
   
 <target_table> ::=  
 {
-    [ database_name . schema_name . | schema_name . ]  target_table  
-    | @variable
-    | common_table_expression_name
+    [ database_name . schema_name . | schema_name . ] [ [ AS ] target_table ]
+    | @variable [ [ AS ] target_table ]
+    | common_table_expression_name [ [ AS ] target_table ]
 }  
   
 <merge_hint>::=  


### PR DESCRIPTION
Documentation does not clearly state that @variable or CTE can be used as target of MERGE statement, while SQL server allows it

```
select @@version

declare @demo table(id int)
merge into @demo
using @demo c on c.id=2
when matched then update set id = 1;
go


declare @demo table(id int);
with cte as (select * from @demo)
merge into cte
using cte c on c.id=2
when matched then update set id = 1;
go

```
```
Microsoft SQL Server 2016 (SP3-GDR) (KB5021129) - 13.0.6430.49 (X64) 
	Jan 22 2023 17:38:22 
	Copyright (c) Microsoft Corporation
	Developer Edition (64-bit) on Windows 10 Pro 10.0 <X64> (Build 19045: ) (Hypervisor)


(1 row affected)

(0 rows affected)


(0 rows affected)
```