### PR TITLE
Added linux support information for SQL Managed Database backups

### DIFF
--- a/docs/relational-databases/backup-restore/sql-server-managed-backup-to-microsoft-azure.md
+++ b/docs/relational-databases/backup-restore/sql-server-managed-backup-to-microsoft-azure.md
@@ -118,6 +118,8 @@ ms.topic: conceptual
 -   [!INCLUDE[ss_smartbackup](../../includes/ss-smartbackup-md.md)] may have some limitations when it is configured with other technologies supporting backup, high availability, or disaster recovery.  
 
 -   Backups of databases in an Availability Group will be a [**copy_only** backup](../../relational-databases/backup-restore/copy-only-backups-sql-server.md).
+
+-  [!INCLUDE[ss_smartbackup](../../includes/ss-smartbackup-md.md)] is not supported for SQL Server on Linux due to SQL Server Agent limitations
   
 ## See Also  
 - [Enable SQL Server managed backup to Microsoft Azure](../../relational-databases/backup-restore/enable-sql-server-managed-backup-to-microsoft-azure.md)   


### PR DESCRIPTION
Added linux support information for SQL Managed Database backups. The feature is only supported in Windows. See reference at https://learn.microsoft.com/en-us/sql/linux/sql-server-linux-editions-and-components-2022?view=sql-server-ver16#unsupported-features-and-services