### PR TITLE
Update xp-cmdshell-server-configuration-option.md

### DIFF
--- a/docs/database-engine/configure-windows/xp-cmdshell-server-configuration-option.md
+++ b/docs/database-engine/configure-windows/xp-cmdshell-server-configuration-option.md
@@ -42,6 +42,14 @@ GO
 -- To update the currently configured value for this feature.
 RECONFIGURE;
 GO
+
+-- To set "show advanced options" back to false
+EXECUTE sp_configure 'show advanced options', 0;
+GO
+
+-- To update the currently configured value for advanced options.
+RECONFIGURE;
+GO
 ```
 
 ## Next steps


### PR DESCRIPTION
Hi SQL Server Docs Team,
As a best practice, it is recommended to revert "show advanced options" back to 0 after changing the desired advanced option, so I've figured I can add the command to set it back to false after enabling xp_cmdshell.

Best regards,

Vlad Drumea