### PR TITLE
Update sql-server-2022-database-engine-events-and-errors-14000-14999.md

### DIFF
--- a/docs/relational-databases/errors-events/includes/sql-server-2016-database-engine-events-and-errors-14000-14999.md
+++ b/docs/relational-databases/errors-events/includes/sql-server-2016-database-engine-events-and-errors-14000-14999.md
@@ -586,7 +586,7 @@ ms.topic: include
 | 14849 | 16 | No | Attempted Migration failed. Remote insert failed to insert all the rows. Expected rows : %d, Actual remote rows inserted: %d. |
 | 14850 | 16 | No | Attempted Migration failed. Incrementation of the batch ID failed. Expected batch ID : %I64d, Current batch ID : %I64d. |
 | 14851 | 16 | No | Attempted Reconciliation failed. The new max remote batch IDs is not less than the initial. Initial: %I64d, New: %I64d |
-| 14852 | 16 | No | Cannot query table '%.\*ls' because data reconciliation is in progress. |
+| 14852 | 16 | No | Cannot query table '%.\*ls' because data reconciliation is in progress. This is part of the automatic recovery process for a remote data archive enabled table. You may check the status of this operation in sys.remote_data_archive_tables. |
 | 14853 | 16 | No | Function '%.\*ls' cannot be used as Stretch filter predicate because it does not meet necessary requirements. |
 | 14854 | 10 | No | The Remote Data Archive connection to the server '%ls' succeeded. |
 | 14855 | 16 | No | The Remote Data Archive connection to the server '%ls' failed. |

--- a/docs/relational-databases/errors-events/includes/sql-server-2017-database-engine-events-and-errors-14000-14999.md
+++ b/docs/relational-databases/errors-events/includes/sql-server-2017-database-engine-events-and-errors-14000-14999.md
@@ -587,7 +587,7 @@ ms.topic: include
 | 14849 | 16 | No | Attempted Migration failed. Remote insert failed to insert all the rows. Expected rows : %d, Actual remote rows inserted: %d. |
 | 14850 | 16 | No | Attempted Migration failed. Incrementation of the batch ID failed. Expected batch ID : %I64d, Current batch ID : %I64d. |
 | 14851 | 16 | No | Attempted Reconciliation failed. The new max remote batch IDs is not less than the initial. Initial: %I64d, New: %I64d |
-| 14852 | 16 | No | Cannot query table '%.\*ls' because data reconciliation is in progress. |
+| 14852 | 16 | No | Cannot query table '%.\*ls' because data reconciliation is in progress. This is part of the automatic recovery process for a remote data archive enabled table. You may check the status of this operation in sys.remote_data_archive_tables. |
 | 14853 | 16 | No | Function '%.\*ls' cannot be used as Stretch filter predicate because it does not meet necessary requirements. |
 | 14854 | 10 | No | The Remote Data Archive connection to the server '%ls' succeeded. |
 | 14855 | 16 | No | The Remote Data Archive connection to the server '%ls' failed. |

--- a/docs/relational-databases/errors-events/includes/sql-server-2019-database-engine-events-and-errors-14000-14999.md
+++ b/docs/relational-databases/errors-events/includes/sql-server-2019-database-engine-events-and-errors-14000-14999.md
@@ -587,7 +587,7 @@ ms.topic: include
 | 14849 | 16 | No | Attempted Migration failed. Remote insert failed to insert all the rows. Expected rows : %d, Actual remote rows inserted: %d. |
 | 14850 | 16 | No | Attempted Migration failed. Incrementation of the batch ID failed. Expected batch ID : %I64d, Current batch ID : %I64d. |
 | 14851 | 16 | No | Attempted Reconciliation failed. The new max remote batch IDs is not less than the initial. Initial: %I64d, New: %I64d |
-| 14852 | 16 | No | Cannot query table '%.\*ls' because data reconciliation is in progress. |
+| 14852 | 16 | No | Cannot query table '%.\*ls' because data reconciliation is in progress. This is part of the automatic recovery process for a remote data archive enabled table. You may check the status of this operation in sys.remote_data_archive_tables. |
 | 14853 | 16 | No | Function '%.\*ls' cannot be used as Stretch filter predicate because it does not meet necessary requirements. |
 | 14854 | 10 | No | The Remote Data Archive connection to the server '%ls' succeeded. |
 | 14855 | 16 | No | The Remote Data Archive connection to the server '%ls' failed. |

--- a/docs/relational-databases/errors-events/includes/sql-server-2022-database-engine-events-and-errors-14000-14999.md
+++ b/docs/relational-databases/errors-events/includes/sql-server-2022-database-engine-events-and-errors-14000-14999.md
@@ -587,7 +587,7 @@ ms.topic: include
 | 14849 | 16 | No | Attempted Migration failed. Remote insert failed to insert all the rows. Expected rows : %d, Actual remote rows inserted: %d. |
 | 14850 | 16 | No | Attempted Migration failed. Incrementation of the batch ID failed. Expected batch ID : %I64d, Current batch ID : %I64d. |
 | 14851 | 16 | No | Attempted Reconciliation failed. The new max remote batch IDs is not less than the initial. Initial: %I64d, New: %I64d |
-| 14852 | 16 | No | Cannot query table '%.\*ls' because data reconciliation is in progress. |
+| 14852 | 16 | No | Cannot query table '%.\*ls' because data reconciliation is in progress. This is part of the automatic recovery process for a remote data archive enabled table. You may check the status of this operation in sys.remote_data_archive_tables. |
 | 14853 | 16 | No | Function '%.\*ls' cannot be used as Stretch filter predicate because it does not meet necessary requirements. |
 | 14854 | 10 | No | The Remote Data Archive connection to the server '%ls' succeeded. |
 | 14855 | 16 | No | The Remote Data Archive connection to the server '%ls' failed. |


### PR DESCRIPTION
Hi SQL Server Docs Team,

I've fixed the incomplete Description for message_id 14852 so that it matches the text in sys.messages in SQL Server 2022-2016.

Thank you,

Vlad