### PR TITLE
Update sp-serveroption-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-serveroption-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-serveroption-transact-sql.md
@@ -51,7 +51,7 @@ The option to set for the specified server. *option_name* is **varchar(35)**, wi
 | **data access** | Enables and disables a linked server for distributed query access. Can be used only for `sys.server` entries added through `sp_addlinkedserver`. |
 | **dist** | Distributor. |
 | **lazy schema validation** | Determines whether the schema of remote tables is checked.<br /><br />If **true**, skip schema checking of remote tables at the beginning of the query. |
-| **name** | Specifies the name of the linked server object.<br /><br />The name change is reflected in value returned by the `name` column of the `sys.servers` catalog view without affecting the value returned by the `data_source` column. |
+| **name** | Specifies the name of the linked server object.<br /><br />The name change is reflected in the value returned by the `name` column of the `sys.servers` catalog view without affecting the remote data source. |
 | **pub** | Publisher. |
 | **query timeout** | Time-out value for queries against a linked server.<br /><br />If **0**, use the `sp_configure` default. |
 | **rpc** | Enables RPC from the given server. |

--- a/docs/relational-databases/system-stored-procedures/sp-serveroption-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-serveroption-transact-sql.md
@@ -51,6 +51,7 @@ The option to set for the specified server. *option_name* is **varchar(35)**, wi
 | **data access** | Enables and disables a linked server for distributed query access. Can be used only for `sys.server` entries added through `sp_addlinkedserver`. |
 | **dist** | Distributor. |
 | **lazy schema validation** | Determines whether the schema of remote tables is checked.<br /><br />If **true**, skip schema checking of remote tables at the beginning of the query. |
+| **name** | Specifies the name of the linked server object.<br /><br />The name change is reflected in value returned by the `name` column of the `sys.servers` catalog view without affecting the value returned by the `data_source` column. |
 | **pub** | Publisher. |
 | **query timeout** | Time-out value for queries against a linked server.<br /><br />If **0**, use the `sp_configure` default. |
 | **rpc** | Enables RPC from the given server. |
@@ -62,9 +63,11 @@ The option to set for the specified server. *option_name* is **varchar(35)**, wi
 
 #### [ @optvalue = ] 'option_value'
 
-Specifies whether or not the *option_name* should be enabled (**true** or **on**) or disabled (**false** or **off**). *option_value* is **varchar(10)**, with no default.
+Specifies whether or not the *option_name* should be enabled (**true** or **on**) or disabled (**false** or **off**). *option_value* is **nvarchar(128)**, with no default.
 
 *option_value* may be a non-negative integer for the **connect timeout** and **query timeout** options. For the **collation name** option, *option_value* may be a collation name or NULL.
+
+*option_value* may be a string, representing the new name of the linked server connection, when using the the **name** option.
 
 ## Return code values
 
@@ -85,7 +88,16 @@ The following example configures a linked server corresponding to another instan
 ```sql
 USE master;
 GO
-EXEC sp_serveroption 'SEATTLE3', 'collation compatible', 'true';
+EXEC sp_serveroption N'SEATTLE3', 'collation compatible', N'true';
+GO
+```
+
+The following example renames the linked server connection from `PRODVM01\ProdSQL01` to `LinkToProdSQL01`.
+
+```sql
+USE master;
+GO
+EXEC sp_serveroption @server=N'PRODVM01\ProdSQL01', @optname='name', @optvalue=N'LinkToSQL2019';
 GO
 ```
 

--- a/docs/relational-databases/system-stored-procedures/sp-serveroption-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-serveroption-transact-sql.md
@@ -52,6 +52,7 @@ The option to set for the specified server. *option_name* is **varchar(35)**, wi
 | **dist** | Distributor. |
 | **lazy schema validation** | Determines whether the schema of remote tables is checked.<br /><br />If **true**, skip schema checking of remote tables at the beginning of the query. |
 | **name** | Specifies the name of the linked server object.<br /><br />The name change is reflected in the value returned by the `name` column of the `sys.servers` catalog view without affecting the remote data source. |
+| **provider string** | Specifies the OLEDB string that identifies the source of a linked server connection.<br /><br />The provider string change is reflected in the value returned by the `provider_string` column of the `sys.servers` catalog view |
 | **pub** | Publisher. |
 | **query timeout** | Time-out value for queries against a linked server.<br /><br />If **0**, use the `sp_configure` default. |
 | **rpc** | Enables RPC from the given server. |
@@ -67,7 +68,9 @@ Specifies whether or not the *option_name* should be enabled (**true** or **on**
 
 *option_value* may be a non-negative integer for the **connect timeout** and **query timeout** options. For the **collation name** option, *option_value* may be a collation name or NULL.
 
-*option_value* may be a string, representing the new name of the linked server connection, when using the the **name** option.
+*option_value* may be a string, representing the new name of the linked server connection, when using the **name** option.
+
+*option_value* may be a string or NULL, representing the new OLEDB source of the linked server connection, when using the **provider string** option.
 
 ## Return code values
 


### PR DESCRIPTION
Hi SQL Server Docs Team,

I've done the following changes:
- Added missing option `name`, and its description, for `@optname`. 
- Added code example of using `@optname='name'` to rename a linked server connection.
- Corrected the data type and size of the `@optvalue` parameter.

Best regards,

Vlad