### PR TITLE
Update merge-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/merge-transact-sql.md
+++ b/docs/t-sql/statements/merge-transact-sql.md
@@ -91,7 +91,7 @@ MERGE
 <merge_hint>::=  
 {  
     { [ <table_hint_limited> [ ,...n ] ]  
-    [ [ , ] { INDEX ( index_val [ ,...n ] ) | INDEX =  index_val }]
+    [ [ , ] { INDEX ( index_val [ ,...n ] ) | INDEX = index_val }]
     }  
 }  
 

--- a/docs/t-sql/statements/merge-transact-sql.md
+++ b/docs/t-sql/statements/merge-transact-sql.md
@@ -91,7 +91,8 @@ MERGE
 <merge_hint>::=  
 {  
     { [ <table_hint_limited> [ ,...n ] ]  
-    [ [ , ] INDEX ( index_val [ ,...n ] ) ] }  
+    [ [ , ] { INDEX ( index_val [ ,...n ] ) | INDEX =  index_val }]
+    }  
 }  
 
 <merge_search_condition> ::=  


### PR DESCRIPTION
added missing index case "INDEX=index_val" for merge_hint clause

```
select @@version
merge into dbo.Area_t a
using dbo.Area_t b with(index=0) on a.AreaID= b.AreaID
when matched then update set AreaName=b.AreaName;

```


```
--------------------------------------------------------------------------------------------------------------------
Microsoft SQL Server 2016 (SP3-GDR) (KB5021129) - 13.0.6430.49 (X64) 
	Jan 22 2023 17:38:22 
	Copyright (c) Microsoft Corporation
	Developer Edition (64-bit) on Windows 10 Pro 10.0 <X64> (Build 19045: ) (Hypervisor)


(1 row affected)

(54 rows affected)

```