### PR TITLE
Update dbcc-show-statistics-transact-sql.md

### DIFF
--- a/docs/t-sql/database-console-commands/dbcc-show-statistics-transact-sql.md
+++ b/docs/t-sql/database-console-commands/dbcc-show-statistics-transact-sql.md
@@ -191,7 +191,7 @@ The following requirements exist for SELECT permissions to be sufficient to run 
 - Users must have permissions on all columns in the statistics object
 - Users must have permission on all columns in a filter condition (if one exists)
 - The table cannot have a row-level security policy.
-- If any of the columns within a statistics object is masked with Dynamic Data Masking rules, in addition to the `SELECT` permission, the user must have the `UNMASK` permission.
+- If any of the columns within a statistics object is masked with Dynamic Data Masking rules, in addition to the `SELECT` permission, the user must have the `UNMASK` permission , or db_ddladmin role.
 
 In versions before [!INCLUDE[ssSQL11](../../includes/sssql11-md.md)] Service Pack 1, the user must own the table or the user must be a member of the `sysadmin` fixed server role, the `db_owner` fixed database role, or the `db_ddladmin` fixed database role.
 


### PR DESCRIPTION
hi,

proposed addition:

If any of the columns within a statistics object is masked with Dynamic Data Masking rules, in addition to the SELECT permission, the user must have the UNMASK permission **, or db_ddladmin role.**

Also, This statement is confusing as this is still applicable for new versions 2016,2017,2019,2022. account being either granted sysadmin or db_owner or db_ddladmin roles [database-level] can execute the command DBCC SHOW_STATISTICS :

"In versions before SQL Server 2012 (11.x) Service Pack 1, the user must own the table or the user must be a member of the sysadmin fixed server role, the db_owner fixed database role, or the db_ddladmin fixed database role."




