### PR TITLE
Fix wrong variable name in using-kerberos-integrated-authentication-t…

### DIFF
--- a/docs/connect/jdbc/using-kerberos-integrated-authentication-to-connect-to-sql-server.md
+++ b/docs/connect/jdbc/using-kerberos-integrated-authentication-to-connect-to-sql-server.md
@@ -225,7 +225,7 @@ Native platform GSS integration allows Java applications to use the native GSS-A
 GSSCredential credential = GSSManager.getInstance().createCredential(null, GSSCredential.DEFAULT_LIFETIME, new Oid("1.2.840.113554.1.2.2"), GSSCredential.ACCEPT_ONLY);
 
 SQLServerDataSource ds = new SQLServerDataSource();
-dataSource.setURL("jdbc:sqlserver://<server>;databaseName=<database>;integratedSecurity=true;authenticationScheme=JavaKerberos;");
+ds.setURL("jdbc:sqlserver://<server>;databaseName=<database>;integratedSecurity=true;authenticationScheme=JavaKerberos;");
 ds.setGSSCredentials(credential);
 ds.getConnection();
 


### PR DESCRIPTION
Wrong variable name in  sample code snippet. Check this link

https://learn.microsoft.com/en-us/sql/connect/jdbc/using-kerberos-integrated-authentication-to-connect-to-sql-server?view=sql-server-ver16#native-platform-gss-integration