### PR TITLE
Correct Alpine's ODBC v17 downloads signature filename

### DIFF
--- a/docs/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server.md
+++ b/docs/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server.md
@@ -196,7 +196,7 @@ curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d
 curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/mssql-tools_17.10.1.1-1_amd64.sig
 
 curl https://packages.microsoft.com/keys/microsoft.asc  | gpg --import -
-gpg --verify msodbcsql17_17.10.1.1-1_amd64.sig msodbcsql17_17.10.4.1-1_amd64.apk
+gpg --verify msodbcsql17_17.10.4.1-1_amd64.sig msodbcsql17_17.10.4.1-1_amd64.apk
 gpg --verify mssql-tools_17.10.1.1-1_amd64.sig mssql-tools_17.10.1.1-1_amd64.apk
 
 #Install the package(s)


### PR DESCRIPTION
The verification will fail otherwise because the filename is not the same as what is downloaded above.