### PR TITLE
Remove Azure SQL Database from applies-to list

### DIFF
--- a/docs/t-sql/spatial-geography/spatial-types-geography.md
+++ b/docs/t-sql/spatial-geography/spatial-types-geography.md
@@ -16,7 +16,7 @@ dev_langs:
   - "TSQL"
 ---
 # Spatial Types - geography
-[!INCLUDE [SQL Server Azure SQL Database Azure SQL Managed Instance](../../includes/applies-to-version/sql-asdb-asdbmi.md)]
+[!INCLUDE [SQL Server Azure SQL Managed Instance](../../includes/applies-to-version/sql-asdb-asdbmi.md)]
 
   The geography spatial data type, **geography**, is implemented as a .NET common language runtime (CLR) data type in [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)]. This type represents data in a round-earth coordinate system. The [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] **geography** data type stores ellipsoidal (round-earth) data, such as GPS latitude and longitude coordinates.  
   


### PR DESCRIPTION
Azure SQL Database supports the geography data type, but since it doesn't support CLR, the various functions like STGeomFromText do not work.