### PR TITLE
Fix example command for ExtractTarget

### DIFF
--- a/docs/tools/sqlpackage/sqlpackage-extract.md
+++ b/docs/tools/sqlpackage/sqlpackage-extract.md
@@ -33,7 +33,7 @@ SqlPackage /Action:Extract /TargetFile:{filename}.dacpac /DiagnosticsFile:{logFi
 
 # example extract to create a .sql file containing the schema definition of the database
 SqlPackage /Action:Extract /TargetFile:{filename}.dacpac /DiagnosticsFile:{logFile}.log /SourceServerName:{serverFQDN} \
-    /SourceDatabaseName:{databaseName} /SourceUser:{username} /SourcePassword:{password} /p:ExtractTarget:File
+    /SourceDatabaseName:{databaseName} /SourceUser:{username} /SourcePassword:{password} /p:ExtractTarget=File
 
 # example extract to create a .dacpac file with data connecting using SQL authentication
 SqlPackage /Action:Extract /TargetFile:{filename}.dacpac /DiagnosticsFile:{logFile}.log /p:ExtractAllTableData=true /p:VerifyExtraction=true \


### PR DESCRIPTION
When running the example, it returns an error:
```
*** 'ExtractTarget:File' is not a valid argument for the 'Extract' action.
*** The specified property 'ExtractTarget:File' is not valid.  Properties are specified as name=value.
```
This change fixes the command