### PR TITLE
Update sys-dm-db-xtp-memory-consumers-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-db-xtp-memory-consumers-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-db-xtp-memory-consumers-transact-sql.md
@@ -42,7 +42,6 @@ monikerRange: ">=sql-server-2016||>=sql-server-linux-2017||=azuresqldb-mi-curren
 |min_sizeclass|**int**|Internal use only.|  
 |max_sizeclass|**int**|Internal use only.|  
 |memory_consumer_address|**varbinary**|Internal address of the consumer. For internal use only.|  
-|xtp_object_id|**bigint**|The [!INCLUDE[inmemory](../../includes/inmemory-md.md)] object ID that corresponds to the memory-optimized table.|  
   
 ## Remarks  
  In the output, the allocators at database levels refer to user tables, indexes, and system tables. VARHEAP with `object_id` = `NULL` refers to memory allocated to tables with variable length columns.  


### PR DESCRIPTION
Column xtp_object_id has been listed twice

Replaced by https://github.com/MicrosoftDocs/sql-docs-pr/pull/28122.