### PR TITLE
Add docs about sys.dm_xe_database_session_targets:failed_buffer_count

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-xe-database-session-targets-azure-sql-database.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-xe-database-session-targets-azure-sql-database.md
@@ -27,6 +27,7 @@ Azure SQL Database supports only [database-scoped sessions](/azure/azure-sql/dat
 |execution_duration_ms|**bigint**|The total amount of time, in milliseconds, that the target has been executing. Is not nullable.|  
 |target_data|**nvarchar(max)**|The data that the target maintains, such as event aggregation information. Is nullable.| 
 |bytes_written|**bigint**|Number of bytes written to target. Is not nullable. |
+|failed_buffer_count| **bigint** | Number of buffers that have failed to be processed by the target (different from other cases of dropped buffers since other targets may have succeeded independently). Null if feature is not currently enabled for current instance. |
   
 ## Permissions  
 

--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-xe-database-sessions-azure-sql-database.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-xe-database-sessions-azure-sql-database.md
@@ -34,7 +34,7 @@ Azure SQL Database supports only [database-scoped sessions](/azure/azure-sql/dat
 | `flags` | **int** | A bitmap that indicates the flags that have been set on the session. Not nullable. |
 | `flag_desc` | **nvarchar(256)** | A description of the flags set on the session. Not nullable. `flag_desc` can be any combination of the following values:<br /><br />- Flush buffers on close<br />- Dedicated dispatcher<br />- Allow recursive events |
 | `dropped_event_count` | **int** | The number of events that were dropped when the buffers were full. This value is `0` if `buffer_policy_desc` is "Drop full buffer" or "Don't drop events". Not nullable. |
-| `dropped_buffer_count` | **int** | The number of buffers that were dropped when the buffers were full. This value is `0` if `buffer_policy_desc` is set to "Drop event" or "Don't drop events". Not nullable. |
+| `dropped_buffer_count` | **int** | The number of buffers that were dropped when the buffers were full. This value is `0` if `buffer_policy_desc` is set to "Drop event" or "Don't drop events". Not nullable. Even if a buffer is not dropped at the session level, individual targets may still fail to process a buffer for target specific reasons. |
 | `blocked_event_fire_time` | **int** | The length of time that event firings were blocked when buffers were full. This value is `0` if `buffer_policy_desc` is "Drop full buffer" or "Drop event". Not nullable. |
 | `create_time` | **datetime** | The time that the session was created (started). Not nullable. |
 | `largest_event_dropped_size` | **int** | The size of the largest event that didn't fit into the session buffer. Not nullable. |

--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-xe-sessions-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-xe-sessions-transact-sql.md
@@ -41,7 +41,7 @@ Azure SQL Database supports only database-scoped sessions. See [sys.dm_xe_databa
 | `flags` | **int** | A bitmap that indicates the flags that have been set on the session. Not nullable. |
 | `flag_desc` | **nvarchar(256)** | A description of the flags set on the session. Not nullable. `flag_desc` can be any combination of the following values:<br /><br />- Flush buffers on close<br />- Dedicated dispatcher<br />- Allow recursive events |
 | `dropped_event_count` | **int** | The number of events that were dropped when the buffers were full. This value is `0` if `buffer_policy_desc` is "Drop full buffer" or "Don't drop events". Not nullable. |
-| `dropped_buffer_count` | **int** | The number of buffers that were dropped when the buffers were full. This value is `0` if `buffer_policy_desc` is set to "Drop event" or "Don't drop events". Not nullable. |
+| `dropped_buffer_count` | **int** | The number of buffers that were dropped when the buffers were full. This value is `0` if `buffer_policy_desc` is set to "Drop event" or "Don't drop events". Not nullable. Even if a buffer is not dropped at the session level, individual targets may still fail to process a buffer for target specific reasons. |
 | `blocked_event_fire_time` | **int** | The length of time that event firings were blocked when buffers were full. This value is `0` if `buffer_policy_desc` is "Drop full buffer" or "Drop event". Not nullable. |
 | `create_time` | **datetime** | The time that the session was created (started). Not nullable. |
 | `largest_event_dropped_size` | **int** | The size of the largest event that didn't fit into the session buffer. Not nullable. |


### PR DESCRIPTION
This is a column we recently added to help track failures of individual targets. It is not yet present in SQL MI or box which is why the docs for sys.dm_xe_session_targets have not also been updated.