### PR TITLE
ODBC Driver 17.10 is compartible with SQL 2022

### DIFF
--- a/docs/connect/odbc/windows/system-requirements-installation-and-driver-files.md
+++ b/docs/connect/odbc/windows/system-requirements-installation-and-driver-files.md
@@ -24,7 +24,7 @@ Compatibility indicates that a driver was tested for compatibility against exist
 |18.2 |Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|   |   |   |   |
 |18.1 |Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|   |   |   |   |
 |18.0 |Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|   |   |   |
-|17.10|Yes|Yes|Yes|   |Yes|Yes|Yes|Yes|Yes|   |   |   |
+|17.10|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|   |   |   |
 |17.9 |Yes|Yes|Yes|   |Yes|Yes|Yes|Yes|Yes|   |   |   |
 |17.8 |Yes|Yes|Yes|   |Yes|Yes|Yes|Yes|Yes|   |   |   |
 |17.7 |Yes|Yes|Yes|   |Yes|Yes|Yes|Yes|Yes|   |   |   |


### PR DESCRIPTION
ODBC Driver 17.10 is shipped with SQL Server 2022, so I check with PG, Jason Chou, it is supported, and this Docs needs to be updated.