### PR TITLE
Update winauth-azuread-setup-incoming-trust-based-flow.md

### DIFF
--- a/azure-sql/managed-instance/winauth-azuread-setup-incoming-trust-based-flow.md
+++ b/azure-sql/managed-instance/winauth-azuread-setup-incoming-trust-based-flow.md
@@ -153,7 +153,7 @@ Install-Module -Name AzureADHybridAuthenticationManagement -AllowClobber
     Run the [Set-AzureAdKerberosServer PowerShell cmdlet](/azure/active-directory/authentication/howto-authentication-passwordless-security-key-on-premises#create-a-kerberos-server-object) to add the Trusted Domain Object. Be sure to include `-SetupCloudTrust` parameter. If there's no Azure AD service account, this command creates a new Azure AD service account. This command will only create the requested Trusted Domain object if there's an Azure AD service account.
 
     ```powershell
-    Set-AzureADKerberosServer -Domain $domain -CloudCredential $cloudCred -DomainCredential $domainCred -SetupCloudTrust
+    Set-AzureADKerberosServer -Domain $domain -UserPrincipalName $cloudUserName -DomainCredential $domainCred -SetupCloudTrust
     ```
 
     > [!NOTE]  


### PR DESCRIPTION
Fix the Set-AzureAdKerberosServer cmdlet execution in the example as the variable name is not matching to the name of the variables

$cloudUserName is the name that was defined on the top and should be used with the parameter -UserPrincipalName