### PR TITLE
Update sqlcmd-utility.md

### DIFF
--- a/docs/tools/sqlcmd/sqlcmd-utility.md
+++ b/docs/tools/sqlcmd/sqlcmd-utility.md
@@ -49,7 +49,7 @@ There are two versions of **sqlcmd**:
 To determine the version you have installed, run the following statement at the command line:
 
 ```console
-sqlcmd "-?"
+sqlcmd -?
 ```
 
 ### [sqlcmd (ODBC)](#tab/odbc)


### PR DESCRIPTION
Hello SQL Server Docs Team,

There was a typo in the command suggested to check the version of sqlcmd
```console
sqlcmd "-?"
```
while using "-?" works in go-sqlcmd, it throws the following error in the ODBC-based sqlcmd:
```console
>sqlcmd "-?"
Sqlcmd: '-?': Unknown Option. Enter '-?' for help.
``` 
Removing the quotation marks and just running `sqlcmd -?` works in both flavors of sqlcmd.

Have a great weekend!