### PR TITLE
Update char-and-varchar-transact-sql.md

### DIFF
--- a/docs/t-sql/data-types/char-and-varchar-transact-sql.md
+++ b/docs/t-sql/data-types/char-and-varchar-transact-sql.md
@@ -38,7 +38,7 @@ Fixed-size string data. *n* defines the string size in bytes and must be a value
 
 #### varchar [ ( *n* | max ) ]
 
-Variable-size string data. Use *n* to define the string size in bytes and can be a value from 1 through 8,000, or use **max** to indicate a column constraint size up to a maximum storage of 2^31-1 bytes (2 GB). For single-byte encoding character sets such as `Latin`, the storage size is *n* bytes + 2 bytes and the number of characters that can be stored is also *n*. For multibyte encoding character sets, the storage size is still *n* bytes + 2 bytes but the number of characters that can be stored may be smaller than *n*. The ISO synonyms for **varchar** are **charvarying** or **charactervarying**. For more information on character sets, see [Single-Byte and Multibyte Character Sets](/cpp/c-runtime-library/single-byte-and-multibyte-character-sets).
+Variable-size string data. Use *n* to define the string size in bytes and can be a value from 1 through 8,000, or use **max** to indicate a column constraint size up to a maximum storage of 2^31-1 bytes (2 GB). For single-byte encoding character sets such as `Latin`, the storage size is *n* bytes + 2 bytes and the number of characters that can be stored is also *n*. For multibyte encoding character sets, the storage size is still *n* bytes + 2 bytes but the number of characters that can be stored may be smaller than *n*. The ISO synonyms for **varchar** are **char varying** or **character varying**. For more information on character sets, see [Single-Byte and Multibyte Character Sets](/cpp/c-runtime-library/single-byte-and-multibyte-character-sets).
 
 ## Remarks
 


### PR DESCRIPTION
Fixing the character keyword to the correct spacing. 

https://learn.microsoft.com/en-us/openspecs/sql_standards/ms-tsqliso02/d92be736-953d-4182-a965-24d851de4118

The standard is:  

 <character string type> ::=
 CHARACTER [ <left paren> <character length> <right paren> ]
 | CHAR [ <left paren> <character length> <right paren> ]
 | CHARACTER VARYING <left paren> <character length> <right paren>
 | CHAR VARYING <left paren> <character length> <right paren>
 | VARCHAR <left paren> <character length> <right paren>
 | <character large object type>