### PR TITLE
Replace CONCAT_WS with CONCAT in syntax example for CONCAT

### DIFF
--- a/docs/t-sql/functions/concat-transact-sql.md
+++ b/docs/t-sql/functions/concat-transact-sql.md
@@ -31,7 +31,7 @@ This function returns a string resulting from the concatenation, or joining, of 
 ## Syntax
 
 ```syntaxsql
-CONCAT_WS ( argument1 , argument2 [ , argumentN ] ... )
+CONCAT ( argument1 , argument2 [ , argumentN ] ... )
 [ ; ]
 ```
 


### PR DESCRIPTION
The syntax example for `CONCAT` mistakenly uses the function name `CONCAT_WS`.
This corrects it to `CONCAT`.