### PR TITLE
Remove preview note for online defaults

### DIFF
--- a/docs/relational-databases/indexes/guidelines-for-online-index-operations.md
+++ b/docs/relational-databases/indexes/guidelines-for-online-index-operations.md
@@ -115,9 +115,6 @@ Generally, there is no difference in defragmentation quality between resumable a
 
 ## Online default options
 
-> [!IMPORTANT]
-> These options are in public preview for [!INCLUDE[ssNoVersion](../../includes/sssql19-md.md)].
-
 You can set default options for online or resumable at a database level by setting the ELEVATE_ONLINE or ELEVATE_RESUMABLE database scoped configuration options. With these default options, you can avoid accidentally performing an operation that takes your database table offline. Both options will cause the engine to automatically elevate certain operations to online or resumable execution.  
 You can set either option as FAIL_UNSUPPORTED, WHEN_SUPPORTED, or OFF using the [ALTER DATABASE SCOPED CONFIGURATION](../../t-sql/statements/alter-database-scoped-configuration-transact-sql.md) command. You can set different values for online and resumable.
 


### PR DESCRIPTION
The note explained that these items are in preview for SQL Server 2019. I believe they are no longer in preview and are fully supported in 2019, 2022, and Azure SQL DB and MI. 

If that is not the case, then an updated note explaining it remains in preview for higher versions and Azure SQL would be helpful.