### PR TITLE
Avoid suggesting to run curl as superuser

### DIFF
--- a/docs/linux/includes/odbc-redhat.md
+++ b/docs/linux/includes/odbc-redhat.md
@@ -11,31 +11,19 @@ ms.custom:
 
 Use the following steps to install the **mssql-tools18** on Red Hat Enterprise Linux.
 
-1. Enter superuser mode.
-
-   ```bash
-   sudo su
-   ```
-
 1. Download the Microsoft Red Hat repository configuration file.
 
    - For Red Hat 8, use the following command:
 
      ```bash
-     curl https://packages.microsoft.com/config/rhel/8/prod.repo > /etc/yum.repos.d/mssql-release.repo
+     curl https://packages.microsoft.com/config/rhel/8/prod.repo | sudo tee /etc/yum.repos.d/mssql-release.repo
      ```
 
    - For Red Hat 7, use the following command:
 
      ```bash
-     curl https://packages.microsoft.com/config/rhel/7/prod.repo > /etc/yum.repos.d/mssql-release.repo
+     curl https://packages.microsoft.com/config/rhel/7/prod.repo | sudo tee /etc/yum.repos.d/mssql-release.repo
      ```
-
-1. Exit superuser mode.
-
-   ```bash
-   exit
-   ```
 
 1. If you had a previous version of **mssql-tools** installed, remove any older unixODBC packages.
 

--- a/docs/linux/includes/odbc-sles.md
+++ b/docs/linux/includes/odbc-sles.md
@@ -11,17 +11,11 @@ ms.custom:
 
 Use the following steps to install the **mssql-tools18** on SUSE Linux Enterprise Server.
 
-1. Enter superuser mode.
-
-   ```bash
-   sudo su
-   ```
-
 1. Import the Microsoft package signing key.
 
    ```bash
    curl -O https://packages.microsoft.com/keys/microsoft.asc
-   rpm --import microsoft.asc
+   sudo rpm --import microsoft.asc
    ```
 
 1. Add the [!INCLUDE [ssnoversion-md](../../includes/ssnoversion-md.md)] repository to Zypper.
@@ -29,33 +23,27 @@ Use the following steps to install the **mssql-tools18** on SUSE Linux Enterpris
    - For SLES 15, use the following command:
 
      ```bash
-     zypper ar https://packages.microsoft.com/config/sles/15/prod.repo
+     sudo zypper ar https://packages.microsoft.com/config/sles/15/prod.repo
      ```
 
    - For SLES 12, use the following command:
 
      ```bash
-     zypper ar https://packages.microsoft.com/config/sles/12/prod.repo
+     sudo zypper ar https://packages.microsoft.com/config/sles/12/prod.repo
      ```
-
-1. Exit superuser mode.
-
-   ```bash
-   exit
-   ```
 
 1. Install **mssql-tools18** with the unixODBC developer package.
 
    - For SLES 15, use the following command:
 
    ```bash
-   zypper install -y mssql-tools18 unixODBC-devel glibc-locale-base
+   sudo zypper install -y mssql-tools18 unixODBC-devel glibc-locale-base
    ```
 
    - For SLES 12, use the following command:
 
    ```bash
-   zypper install -y mssql-tools18 unixODBC-devel
+   sudo zypper install -y mssql-tools18 unixODBC-devel
    ```
 
    > [!NOTE]  

--- a/docs/linux/includes/odbc-ubuntu.md
+++ b/docs/linux/includes/odbc-ubuntu.md
@@ -16,12 +16,6 @@ Use the following steps to install the **mssql-tools18** on Ubuntu.
 > - Ubuntu 18.04 is supported starting with [!INCLUDE [sssql19-md](../../includes/sssql19-md.md)] CU 3.
 > - Ubuntu 20.04 is supported starting with [!INCLUDE [sssql19-md](../../includes/sssql19-md.md)] CU 10.
 
-1. Enter superuser mode.
-
-   ```bash
-   sudo su
-   ```
-
 1. Import the public repository GPG keys.
 
    ```bash
@@ -33,26 +27,20 @@ Use the following steps to install the **mssql-tools18** on Ubuntu.
    - For Ubuntu 20.04, use the following command:
 
      ```bash
-     curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
+     curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
      ```
 
    - For Ubuntu 18.04, use the following command:
 
      ```bash
-     curl https://packages.microsoft.com/config/ubuntu/18.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
+     curl https://packages.microsoft.com/config/ubuntu/18.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
      ```
 
    - For Ubuntu 16.04, use the following command:
 
      ```bash
-     curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
+     curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
      ```
-
-1. Exit superuser mode.
-
-   ```bash
-   exit
-   ```
 
 1. Update the sources list and run the installation command with the unixODBC developer package.
 


### PR DESCRIPTION
In this case, curl doesn’t need to be run as superuser. Superuser is only required for writing to the specified files.

With the suggestions, we also skip the steps to enter and exit superuser mode.