### PR TITLE
Specified that the procedure must be in the dbo schema

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-procoption-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-procoption-transact-sql.md
@@ -45,7 +45,7 @@ sp_procoption [ @ProcName = ] 'procedure'
  0 (success) or error number (failure)  
   
 ## Remarks  
- Startup procedures must be in the **master** database and cannot contain INPUT or OUTPUT parameters. Execution of the stored procedures starts when all databases are recovered and the "Recovery is completed" message is logged at startup.  
+ Startup procedures must be in the **dbo** schema of the **master** database and cannot contain INPUT or OUTPUT parameters. Execution of the stored procedures starts when all databases are recovered and the "Recovery is completed" message is logged at startup.  
   
 ## Permissions  
  Requires membership in the **sysadmin** fixed server role.  


### PR DESCRIPTION
Hello SQL Server Docs Team,

I was playing around with sp_procoption as for a blog post, and I've noticed that, if the stored procedure is in any other schema than dbo, sp_procoption errors out despite the procedure being in the master database.

Testing:
```SQL
USE [master]
GO
/*create a schema*/
CREATE SCHEMA [test] AUTHORIZATION [dbo];
GO

/*create a sproc in that schema*/
CREATE PROCEDURE [test].[sp_test]
AS
  BEGIN
      CREATE TABLE ##TestTable
        (
           StartupTime DATETIME
        );

      INSERT INTO ##TestTable
                  (StartupTime)
      VALUES      (GETDATE());
  END; 
GO

/*try to make it a startup procedure*/
EXEC sp_procoption @ProcName = N'test.sp_test'   
    , @OptionName = 'startup'   
    , @OptionValue = 'on';
GO
```
The error message:
![image](https://github.com/MicrosoftDocs/sql-docs/assets/48413726/9ea99c15-ea41-4dba-ba33-3c03f2e003de)

Cleanup:
```SQL
USE [master]
GO
DROP PROCEDURE [test].[sp_test];
GO
DROP SCHEMA [test];
GO
```

Best regards and have a great rest of the week!

Vlad