### PR TITLE
Update accuracy for LTR backup roles on long-term-backup-retention-configure

### DIFF
--- a/azure-sql/database/long-term-backup-retention-configure.md
+++ b/azure-sql/database/long-term-backup-retention-configure.md
@@ -47,6 +47,7 @@ Prepare your environment for PowerShell.
 For `Get-AzSqlDatabaseLongTermRetentionBackup` and `Restore-AzSqlDatabase`, you need to be a member of one of the following roles:
 
 - Subscription Owner role or
+- Subscription Contributor role or
 - SQL Server Contributor role or
 - Custom role with the following permissions:
 
@@ -57,6 +58,7 @@ For `Get-AzSqlDatabaseLongTermRetentionBackup` and `Restore-AzSqlDatabase`, you 
 For `Remove-AzSqlDatabaseLongTermRetentionBackup`, you need to be a member of one of the following roles:
 
 - Subscription Owner role or
+- Subscription Contributor role or
 - Custom role with the following permission:
 
    `Microsoft.Sql/locations/longTermRetentionServers/longTermRetentionDatabases/longTermRetentionBackups/delete`
@@ -68,6 +70,7 @@ For `Remove-AzSqlDatabaseLongTermRetentionBackup`, you need to be a member of on
 To view and restore LTR backups, you need:
 
 - Subscription Owner role or
+- Subscription Contributor role or
 - SQL Server Contributor role or
 - Custom role with the following permissions:
 
@@ -78,6 +81,7 @@ To view and restore LTR backups, you need:
 To delete LTR backups, you need to be a member of one of the following roles:
 
 - Subscription Owner role or
+- Subscription Contributor role or
 - Custom role with the following permission:
 
    `Microsoft.Sql/locations/longTermRetentionServers/longTermRetentionDatabases/longTermRetentionBackups/delete`


### PR DESCRIPTION
The Contributor role is a commonly assigned role. 

The fact that this role is not included in this list (while SQL Server Contributor and Subscription Owner are) is misleading. It is possible to do everything on a LTR backup with a contributor role assignment.