### PR TITLE
Add tip about datetrunc use for start of month equivalent

### DIFF
--- a/docs/t-sql/functions/eomonth-transact-sql.md
+++ b/docs/t-sql/functions/eomonth-transact-sql.md
@@ -45,7 +45,9 @@ If the *month_to_add* argument has a value, then `EOMONTH` adds the specified nu
  **date**  
   
 ## Remarks  
-The `EOMONTH` function can remote to [!INCLUDE[ssSQL11](../../includes/sssql11-md.md)] servers and higher. It cannot be remote to servers with a version lower than [!INCLUDE[ssSQL11](../../includes/sssql11-md.md)].  
+The `EOMONTH` function can remote to [!INCLUDE[ssSQL11](../../includes/sssql11-md.md)] servers and higher. It cannot be remote to servers with a version lower than [!INCLUDE[ssSQL11](../../includes/sssql11-md.md)].
+
+Use `DATETRUNC(MONTH, @date)` to calculate start of month "SOMONTH". See [DATETRUNC](./datetrunc-transact-sql.md).
   
 ## Examples  
   


### PR DESCRIPTION
I was looking for the "start of month" equivalent to `eomonth` and came across a tip to use `datetrunc` on stackoverflow. Hopefully this will help others looking for the same.

Let me know if any changes are needed, feel free to make edits!