### PR TITLE
Add tip about datetrunc use for start of month equivalent

### DIFF
--- a/docs/t-sql/functions/eomonth-transact-sql.md
+++ b/docs/t-sql/functions/eomonth-transact-sql.md
@@ -56,6 +56,8 @@ If the *month_to_add* argument has a value, then `EOMONTH` adds the specified nu
 
 The `EOMONTH` function can remote to instances running [!INCLUDE [ssSQL11](../../includes/sssql11-md.md)] and later versions. It can't remote to instances with a version before [!INCLUDE [ssSQL11](../../includes/sssql11-md.md)].
 
+Use `DATETRUNC(MONTH, @date)` to calculate start of month "SOMONTH". See [DATETRUNC](./datetrunc-transact-sql.md).
+
 ## Examples
 
 ### A. EOMONTH with explicit datetime type


### PR DESCRIPTION
*Resubmitted using live branch - see #9470*

I was looking for the "start of month" equivalent to `eomonth` and came across a tip to use `datetrunc` on stackoverflow. Hopefully this will help others looking for the same.

Let me know if any changes are needed, feel free to make edits or close!