### PR TITLE
Use correct default prefix

### DIFF
--- a/docs/sql-server/azure-arc/troubleshoot-assessment.md
+++ b/docs/sql-server/azure-arc/troubleshoot-assessment.md
@@ -81,7 +81,7 @@ If the error states that the Azure Monitor Agent (AMA) upload failed, verify tha
    2. AMA with required version should be successfully provisioned.
 1. The data collection rule (DCR) and data collection endpoint (DCE) must be in the same location as the Log Analytics workspace.
    1. Navigate to the Overview tab of the resource group to which the Log Analytics workspace belongs.
-   2. Under the list of resources, the **DCR** and the **DCE** can be identified by their prefixes, **sql-bpa-**.
+   2. Under the list of resources, the **DCR** and the **DCE** can be identified by their prefixes, **sqlbpa-**.
    3. Verify that the **DCR** and **DCE** are in the same location as the Log Analytics workspace.
 1. The data collection Rule (DCR) should be configured correctly.
    1. Navigate to The **Resources** tab under the relevant DCR. The Arc machine name should be present on the list.


### PR DESCRIPTION
When deploying the Azure Monitor Agent, it creates DCR (Data collection rule) and DCE (Data collection endpoint) objects in your Log Analytic workspace's resource group. Instead of "sql-bpa-" the correct default prefix naming is "sqlbpa-" for these objects.