### PR TITLE
Update sp-getapplock-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-getapplock-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-getapplock-transact-sql.md
@@ -84,7 +84,7 @@ sp_getapplock [ @Resource = ] 'resource_name' ,
   
  Locks can be explicitly released with sp_releaseapplock. When an application calls sp_getapplock multiple times for the same lock resource, sp_releaseapplock must be called the same number of times to release the lock.  When a lock is opened with the `Transaction` lock owner, that lock is released when the transaction is committed or rolled back.
   
- If sp_getapplock is called multiple times for the same lock resource, but the lock mode that is specified in any of the requests is not the same as the existing mode, the effect on the resource is a union of the two lock modes. In most cases, this means the lock mode is promoted to the stronger of the lock modes, the existing mode, or the newly requested mode. This stronger lock mode is held until the lock is ultimately released even if lock release calls have occurred before that time. For example, in the following sequence of calls, the resource is held in `Exclusive` mode instead of in `Shared` mode.  
+ If sp_getapplock is called multiple times for the same lock resource, but the lock mode that is specified in any of the requests is not the same as the existing mode, the effect on the resource is a union of the two lock modes. In most cases, this means the lock mode is promoted to the stronger of the lock modes, the existing mode, or the newly requested mode. This stronger lock mode is held until the lock is ultimately released. For example, in the following sequence of calls, the resource is held in `Exclusive` mode instead of in `Shared` mode.  
   
 ```  
 USE AdventureWorks2022;  
@@ -95,7 +95,6 @@ EXEC @result = sp_getapplock @Resource = 'Form1',
                @LockMode = 'Shared';  
 EXEC @result = sp_getapplock @Resource = 'Form1',   
                @LockMode = 'Exclusive';  
-EXEC @result = sp_releaseapplock @Resource = 'Form1';  
 COMMIT TRANSACTION;  
 GO  
 ```  

--- a/docs/relational-databases/system-stored-procedures/sp-getapplock-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-getapplock-transact-sql.md
@@ -95,6 +95,7 @@ EXEC @result = sp_getapplock @Resource = 'Form1',
                @LockMode = 'Shared';  
 EXEC @result = sp_getapplock @Resource = 'Form1',   
                @LockMode = 'Exclusive';  
+EXEC @result = sp_releaseapplock @Resource = 'Form1';  
 COMMIT TRANSACTION;  
 GO  
 ```  


### PR DESCRIPTION
The original explanation contains some inaccuracies. It states, "This stronger lock mode is held until the lock is ultimately released even if lock release calls have occurred before that time." Let's break it down for clarity. The part "This stronger lock mode is held until the lock is ultimately released" is correct. In the original code, both "EXEC @result = sp_releaseapplock @Resource = 'Form1';" and "COMMIT TRANSACTION;" act to release the lock (if sp_releaseapplock has already released the lock, the commit operation won't affect the application lock since it no longer exists). However, the phrase "even if lock release calls have occurred before that time" seems to be misleading.

Consider this modification:

```
EXEC @result = sp_releaseapplock @Resource = 'Form1'; -- Newly added. Let's call it stmt1
EXEC @result = sp_releaseapplock @Resource = 'Form1';
COMMIT TRANSACTION;
```


In the phrase "before that time", "that time" refers to "the lock is ultimately released". If we insert stmt1 before the lock is ultimately released, would the lock still be held until it's finally released? No, it would be released by stmt1. Therefore, the original explanation is not entirely accurate. My suggested revision offers more clarity.

Moreover, manually releasing the application lock isn't necessary and isn't considered good practice. Observe the following code snippet:

```
EXEC @result = sp_releaseapplock @Resource = 'Form1';
-- <----- Other sessions can acquire the lock here, even though the transaction is still ongoing
COMMIT TRANSACTION;
```

Notice that once you've released the application lock with sp_releaseapplock, other sessions can acquire the lock, even while the transaction is still ongoing. However, the typical reason to use a transaction-level application lock is to maintain it for the duration of the entire transaction. There's no need to manually release it; the 'COMMIT TRANSACTION' statement will handle it for us. This revised version still communicates the same intent as the original example, but with greater precision and clarity.
