### PR TITLE
2 typos, changing (x) to (X) for consistency 

### DIFF
--- a/docs/relational-databases/sql-server-transaction-locking-and-row-versioning-guide.md
+++ b/docs/relational-databases/sql-server-transaction-locking-and-row-versioning-guide.md
@@ -443,14 +443,14 @@ Data modification statements, such as INSERT, UPDATE, and DELETE combine both mo
 
 ### <a id="intent"></a> Intent locks
 
-The [!INCLUDE [ssDEnoversion](../includes/ssdenoversion-md.md)] uses intent locks to protect placing a shared (S) lock or exclusive (x) lock on a resource lower in the lock hierarchy. Intent locks are named "intent locks" because they're acquired before a lock at the lower level and, therefore, signal intent to place locks at a lower level.
+The [!INCLUDE [ssDEnoversion](../includes/ssdenoversion-md.md)] uses intent locks to protect placing a shared (S) lock or exclusive (X) lock on a resource lower in the lock hierarchy. Intent locks are named "intent locks" because they're acquired before a lock at the lower level and, therefore, signal intent to place locks at a lower level.
 
 Intent locks serve two purposes:
 
 - To prevent other transactions from modifying the higher-level resource in a way that would invalidate the lock at the lower level.
 - To improve the efficiency of the [!INCLUDE [ssDEnoversion](../includes/ssdenoversion-md.md)] in detecting lock conflicts at the higher level of granularity.
 
-For example, a shared intent lock is requested at the table level before shared (S) locks are requested on pages or rows within that table. Setting an intent lock at the table level prevents another transaction from subsequently acquiring an exclusive (x) lock on the table containing that page. Intent locks improve performance because the [!INCLUDE [ssDEnoversion](../includes/ssdenoversion-md.md)] examines intent locks only at the table level to determine if a transaction can safely acquire a lock on that table. This removes the requirement to examine every row or page lock on the table to determine if a transaction can lock the entire table.
+For example, a shared intent lock is requested at the table level before shared (S) locks are requested on pages or rows within that table. Setting an intent lock at the table level prevents another transaction from subsequently acquiring an exclusive (X) lock on the table containing that page. Intent locks improve performance because the [!INCLUDE [ssDEnoversion](../includes/ssdenoversion-md.md)] examines intent locks only at the table level to determine if a transaction can safely acquire a lock on that table. This removes the requirement to examine every row or page lock on the table to determine if a transaction can lock the entire table.
 
 <a name="lock_intent_table"></a> Intent locks include intent shared (IS), intent exclusive (IX), and shared with intent exclusive (SIX).
 


### PR DESCRIPTION
Just 2 typos in sql-server-transaction-locking-and-row-versioning-guide. Everywhere else you use (X) for Exclusive locks so for consistency change (x) to (X)