### PR TITLE
added LOCAL/GLOBAL to SET @cursorVar = select ....

### DIFF
--- a/docs/t-sql/language-elements/set-local-variable-transact-sql.md
+++ b/docs/t-sql/language-elements/set-local-variable-transact-sql.md
@@ -41,7 +41,8 @@ SET
 |   
   { @cursor_variable =   
     { @cursor_variable | cursor_name   
-    | { CURSOR [ FORWARD_ONLY | SCROLL ]   
+    | { CURSOR [ LOCAL | GLOBAL ]
+        [ FORWARD_ONLY | SCROLL ]   
         [ STATIC | KEYSET | DYNAMIC | FAST_FORWARD ]   
         [ READ_ONLY | SCROLL_LOCKS | OPTIMISTIC ]   
         [ TYPE_WARNING ]   
@@ -168,7 +169,7 @@ After a variable is declared, it's initialized to NULL. Use the SET statement to
   
 You can use variables only in expressions, not instead of object names or keywords. To construct dynamic [!INCLUDE[tsql](../../includes/tsql-md.md)] statements, use EXECUTE.  
   
-The syntax rules for SET **@**_cursor_variable_ don't include the LOCAL and GLOBAL keywords. When you use the SET **@**_cursor_variable_ = CURSOR... syntax, the cursor is created as GLOBAL or LOCAL, depending on the setting of the default to local cursor database option.  
+Although syntax rules for SET **@**_cursor_variable_  include the LOCAL and GLOBAL keywords, when you use the SET **@**_cursor_variable_ = CURSOR... syntax, the cursor is created as GLOBAL or LOCAL, depending on the setting of the default to local cursor database option.  
   
 Cursor variables are always local, even if they reference a global cursor. When a cursor variable references a global cursor, the cursor has both a global and a local cursor reference. For more information, see [Example D, Using SET with a global cursor](#d-using-set-with-a-global-cursor).  
   


### PR DESCRIPTION
SQL Server 19 allows both LOCAL and GLOBAL specifiers to set @ var = cursor

```
select @@version
declare @var cursor
set @var = CURSOR LOCAL FOR select * from sys.columns
set @var = CURSOR GLOBAL FOR select * from sys.columns

```

Microsoft SQL Server 2019 (RTM-CU23) (KB5030333) - 15.0.4335.1 (X64) 
	Sep 21 2023 17:28:44 
	Copyright (C) 2019 Microsoft Corporation
	Developer Edition (64-bit) on Windows 10 Pro 10.0 <X64> (Build 22631: ) (Hypervisor)

![image](https://github.com/MicrosoftDocs/sql-docs/assets/26844170/3035b9c0-2cd1-46b9-be5d-ab38a70bddec)
