### PR TITLE
Update select-over-clause-transact-sql.md

### DIFF
--- a/docs/t-sql/queries/select-over-clause-transact-sql.md
+++ b/docs/t-sql/queries/select-over-clause-transact-sql.md
@@ -278,7 +278,7 @@ BETWEEN <window frame bound > AND <window frame bound >
 > If ORDER BY is not specified entire partition is used for a window frame. This applies only to functions that do not require ORDER BY clause. If ROWS/RANGE is not specified but ORDER BY is specified, RANGE UNBOUNDED PRECEDING AND CURRENT ROW is used as default for window frame. This applies only to functions that have can accept optional ROWS/RANGE specification. For example, ranking functions cannot accept ROWS/RANGE, therefore this window frame is not applied even though ORDER BY is present and ROWS/RANGE is not.  
     
 ## Limitations and Restrictions  
- The OVER clause cannot be used with the CHECKSUM aggregate function.  
+ The OVER clause cannot be used with the DISTINCT aggregations.  
   
  RANGE cannot be used with \<unsigned value specification> PRECEDING or \<unsigned value specification> FOLLOWING.  
   


### PR DESCRIPTION
The listed restriction is incorrect. CHECKSUM is not an aggregate function at all. If CHECKSUM_AGG was meant, then it was still incorrect, because CHECKSUM_AGG can be used with OVER without errors. Example (AdventureWorks): SELECT p.ProductID,
       p.Name,
       p.ListPrice,
       p.ProductLine,
       CHECKSUM_AGG (p.DaysToManufacture) OVER (PARTITION BY p.ProductLine
                                                ORDER BY p.ListPrice
                                                ROWS BETWEEN 4 PRECEDING AND 2 FOLLOWING) AS MovingAverage
FROM   Production.Product AS p;

This only fails when you change it to CHECKSUM_AGG(DISTINCT p.DaysToManufacture). But the error you get in that case is the same that you also get for COUNT(DISTINCT p.DaysToManufacture) or even MAX(DISTINCT p.DaysToManufacture). So it is a restriction on DISTINCT, not on CHECKSUM_AGG (or on CHECKSUM)