### PR TITLE
fixed the mistake

### DIFF
--- a/docs/t-sql/statements/create-type-transact-sql.md
+++ b/docs/t-sql/statements/create-type-transact-sql.md
@@ -106,7 +106,7 @@ column_name AS computed_column_expression
 }  
 
 < table_index > ::=  
-  INDEX constraint_name  
+  INDEX index_name  
      [ CLUSTERED | NONCLUSTERED ] (column [ ASC | DESC ] [ ,... n ] )} }  
 ```  
   
@@ -148,7 +148,7 @@ column_name <data_type>
 }  
   
 < table_index > ::=  
-  INDEX constraint_name  
+  INDEX index_name  
 { [ NONCLUSTERED ] HASH (column [ ,... n ] ) WITH (BUCKET_COUNT = bucket_count) 
 	|  [ NONCLUSTERED ]  ( column [ ASC | DESC ] [ ,... n ] ) 
 }  

--- a/docs/t-sql/statements/create-type-transact-sql.md
+++ b/docs/t-sql/statements/create-type-transact-sql.md
@@ -143,8 +143,8 @@ column_name <data_type>
   
 <column_index> ::=  
   INDEX index_name  
-{ [ NONCLUSTERED ] HASH WITH ( BUCKET_COUNT = bucket_count ) 
-     | NONCLUSTERED 
+{ [ NONCLUSTERED ] HASH (column [ ,... n ] ) WITH ( BUCKET_COUNT = bucket_count ) 
+     | NONCLUSTERED ( column [ ASC | DESC ] [ ,... n ] )
 }  
   
 < table_index > ::=  

--- a/docs/t-sql/statements/create-type-transact-sql.md
+++ b/docs/t-sql/statements/create-type-transact-sql.md
@@ -106,7 +106,7 @@ column_name AS computed_column_expression
 }  
 
 < table_index > ::=  
-  INDEX index_name  
+  INDEX constraint_name  
      [ CLUSTERED | NONCLUSTERED ] (column [ ASC | DESC ] [ ,... n ] )} }  
 ```  
   
@@ -148,9 +148,9 @@ column_name <data_type>
 }  
   
 < table_index > ::=  
-  INDEX index_name  [ NONCLUSTERED ]
-{ HASH (column [ ,... n ] ) WITH (BUCKET_COUNT = bucket_count) 
-	| ( column [ ASC | DESC ] [ ,... n ] ) 
+  INDEX constraint_name
+{ [ NONCLUSTERED ] HASH (column [ ,... n ] ) WITH (BUCKET_COUNT = bucket_count)
+    | [ NONCLUSTERED ] ( column [ ASC | DESC ] [ ,... n ] )
 }  
   
 <table_option> ::=  

--- a/docs/t-sql/statements/create-type-transact-sql.md
+++ b/docs/t-sql/statements/create-type-transact-sql.md
@@ -148,9 +148,9 @@ column_name <data_type>
 }  
   
 < table_index > ::=  
-  INDEX index_name  
-{ [ NONCLUSTERED ] HASH (column [ ,... n ] ) WITH (BUCKET_COUNT = bucket_count) 
-	|  [ NONCLUSTERED ]  ( column [ ASC | DESC ] [ ,... n ] ) 
+  INDEX index_name  [ NONCLUSTERED ]
+{ HASH (column [ ,... n ] ) WITH (BUCKET_COUNT = bucket_count) 
+	| ( column [ ASC | DESC ] [ ,... n ] ) 
 }  
   
 <table_option> ::=  


### PR DESCRIPTION
I checked the behavior and find that i can throw this sintax to DB and it will create type with index.
script example:
```
CREATE TYPE type_idx_16 AS TABLE
(
	[Name] NVARCHAR(50) NOT NULL,
	SupplierId BIGINT NOT NULL INDEX idx_type_16 HASH (Price, SupplierId) WITH ( BUCKET_COUNT = 1 ),
	Price DECIMAL (18, 4) NULL  
	)
	with (MEMORY_OPTIMIZED=ON)
GO
```