### PR TITLE
Added that the IP resource needs to be offline and online to take effect the Probe port settings.

### DIFF
--- a/azure-sql/virtual-machines/windows/availability-group-vnn-azure-load-balancer-configure.md
+++ b/azure-sql/virtual-machines/windows/availability-group-vnn-azure-load-balancer-configure.md
@@ -163,6 +163,7 @@ The following table describes the values that you need to update:
 |`ProbePort`|The probe port that you configured in the health probe of the load balancer. Any unused TCP port is valid.|
 |`SubnetMask`| The subnet mask for the cluster parameter. It must be the TCP/IP broadcast address: `255.255.255.255`.| 
 
+The changes you made do not take effect until the IP address resource is taken offline and brought online again. Perform a failover of the availability group for this change to take effect.
 After you set the cluster probe, you can see all the cluster parameters in PowerShell. Run this script:
 
 ```powershell
@@ -194,6 +195,7 @@ The following table describes the values that you need to update:
 |`ProbePort`|The probe port that you configured in the health probe of the load balancer. Any unused TCP port is valid.|
 |`SubnetMask`| The subnet mask for the cluster parameter. It must be the TCP/IP broadcast address: `255.255.255.255`.| 
 
+The changes you made do not take effect until the IP address resource is taken offline and brought online again. Perform a failover of the availability group for this change to take effect.
 After you set the cluster probe, you can see all the cluster parameters in PowerShell. Run this script:
 
 ```powershell


### PR DESCRIPTION
The settings made with set-clusterparameter will take effect the next time the resource comes online. This was not explicitly stated in the public information, so I will add it.


![image](https://github.com/MicrosoftDocs/sql-docs/assets/84917396/aa01bfb9-25e7-4b8f-8e44-5cfab295ddfd)
Set-ClusterParameter output the following warning after setting.

WARNING: The properties were stored, but not all changes will take effect until IP Address [resource_name] is taken offline and then online again.