### PR TITLE
Update alter-workload-group-transact-sql.md

### DIFF
--- a/docs/t-sql/includes/alter-workload-group.md
+++ b/docs/t-sql/includes/alter-workload-group.md
@@ -7,6 +7,9 @@ ms.topic: include
 ---
 Changes an existing Resource Governor workload group configuration, and optionally assigns it to a Resource Governor resource pool.
 
+> [!NOTE]  
+> For Azure SQL Managed Instance, you must be in the context of the `master` database to alter Resource Governor configuration.
+
 :::image type="icon" source="../../includes/media/topic-link-icon.svg" border="false"::: [Transact-SQL syntax conventions](../language-elements/transact-sql-syntax-conventions-transact-sql.md).
 
 ## Syntax

--- a/docs/t-sql/statements/alter-workload-group-transact-sql.md
+++ b/docs/t-sql/statements/alter-workload-group-transact-sql.md
@@ -60,8 +60,6 @@ monikerRange: ">=sql-server-2016||>=sql-server-linux-2017||=azure-sqldw-latest||
 
 ## SQL Server and SQL Managed Instance
 
-You must be in the context of the `master` database to alter Resource Governor configuration when using Azure SQL Managed Instance.
-
 [!INCLUDE [alter-workload-group](../includes/alter-workload-group.md)]
 
 ::: moniker-end

--- a/docs/t-sql/statements/alter-workload-group-transact-sql.md
+++ b/docs/t-sql/statements/alter-workload-group-transact-sql.md
@@ -60,6 +60,8 @@ monikerRange: ">=sql-server-2016||>=sql-server-linux-2017||=azure-sqldw-latest||
 
 ## SQL Server and SQL Managed Instance
 
+You must be in the context of the `master` database to alter Resource Governor configuration when using Azure SQL Managed Instance.
+
 [!INCLUDE [alter-workload-group](../includes/alter-workload-group.md)]
 
 ::: moniker-end


### PR DESCRIPTION
Adding note that to modify resource governor configuration in Azure SQL Managed instance, you must be in the context of the master database. 

If I attempt to run a resource governor command in the context of another database, I receive the message:

> Msg 40510, Level 16, State 2, Line 31
> Statement 'ALTER RESOURCE GOVERNOR' is not supported in this version of SQL Server.

But it works when I use master.

I think probably this note should be integrated into an include file in some way, but I couldn't manage to do this through the web UI and I wanted to submit this before I forgot. If it's easier to close this PR and make the change another way, totally understand. Thanks in advance!