### PR TITLE
Update dns-alias-overview.md

### DIFF
--- a/azure-sql/database/dns-alias-overview.md
+++ b/azure-sql/database/dns-alias-overview.md
@@ -100,10 +100,6 @@ Presently, a DNS alias has the following limitations:
 - *Delay of up to 2 minutes:* It takes up to 2 minutes for a DNS alias to be updated or removed.
   - Regardless of any brief delay, the alias immediately stops referring client connections to the legacy server.
 - *DNS lookup:* For now, the only authoritative way to check what server a given DNS alias refers to is by performing a [DNS lookup](/windows-server/administration/windows-commands/nslookup).
-- _Table auditing is not supported:_ You cannot use a DNS alias on a server that has *table auditing* enabled on a database.
-  - Table auditing is deprecated.
-  - We recommend that you move to [Blob Auditing](auditing-overview.md).
-  - We recommend that you move to [Blob Auditing](./auditing-overview.md).
 - DNS alias is subject to [naming restrictions](/azure/azure-resource-manager/management/resource-name-rules).
 
 ## Related resources


### PR DESCRIPTION
Table auditing was discontinued on October 1, 2017 in Azure SQL Database. And it is also dedicated on December 16, 2018 in SQL Pool (formerly SQL DW) .

The documentation appears to be out of date.