### PR TITLE
Update sp-prepare-transact-sql.md - Make the sp_prepare handle example better

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-prepare-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-prepare-transact-sql.md
@@ -84,9 +84,9 @@ The following example prepares a statement in the [!INCLUDE [sssampledbobject-md
 
 ```sql
 -- Prepare query
-DECLARE @P1 INT;
+DECLARE @handle INT;
 
-EXEC sp_prepare @P1 OUTPUT,
+EXEC sp_prepare @handle OUTPUT,
     N'@Param INT',
     N'SELECT *
 FROM Sales.SalesOrderDetail AS sod
@@ -95,7 +95,7 @@ WHERE SalesOrderID = @Param
 ORDER BY Style DESC;';
 
 -- Return handle for calling application
-SELECT @P1;
+SELECT @handle;
 GO
 ```
 

--- a/docs/relational-databases/system-stored-procedures/sp-prepare-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-prepare-transact-sql.md
@@ -65,17 +65,17 @@ An optional parameter that returns a description of the cursor result set column
 The following example prepares and executes a basic Transact-SQL statement.
 
 ```sql
-DECLARE @P1 INT;
+DECLARE @handle INT;
 
-EXEC sp_prepare @P1 OUTPUT,
+EXEC sp_prepare @handle OUTPUT,
     N'@P1 NVARCHAR(128), @P2 NVARCHAR(100)',
     N'SELECT database_id, name FROM sys.databases WHERE name=@P1 AND state_desc = @P2';
 
-EXEC sp_execute @P1,
+EXEC sp_execute @handle,
     N'tempdb',
     N'ONLINE';
 
-EXEC sp_unprepare @P1;
+EXEC sp_unprepare @handle;
 ```
 
 ### B. Prepare and execute a statement using the handle


### PR DESCRIPTION
The first example provided in [sp_prepare](https://learn.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-prepare-transact-sql?view=sql-server-ver16#examples) page is little bit confusing. The handle variable name and the param name are same, and it took some time (although only a little), to realize the difference. 