### PR TITLE
Update using-azure-active-directory.md

### DIFF
--- a/docs/connect/odbc/using-azure-active-directory.md
+++ b/docs/connect/odbc/using-azure-active-directory.md
@@ -29,7 +29,7 @@ The `Authentication` keyword can be used when connecting with a DSN or connectio
 
 |Name|Values|Default|Description|
 |-|-|-|-|
-|`Authentication`|(not set), (empty string), `SqlPassword`, `ActiveDirectoryPassword`, `ActiveDirectoryIntegrated`, `ActiveDirectoryInteractive`, `ActiveDirectoryMsi`, `ActiveDirectoryServicePrincipal` |(not set)|Controls the authentication mode.<table><tr><th>Value<th>Description<tr><td>(not set)<td>Authentication mode determined by other keywords (existing legacy connection options.)<tr><td>(empty string)<td>(Connection string only.) Override and unset an `Authentication` value set in the DSN.<tr><td>`SqlPassword`<td>Directly authenticate to SQL using a username and password.<tr><td>`ActiveDirectoryPassword`<td>Authenticate with a Microsoft Entra identity using a username and password.<tr><td>`ActiveDirectoryIntegrated`<td>_Windows, and Linux/Mac 17.6+, driver only_. Authenticate with a Windows credential federated through Microsoft Entra ID with integrated authentication.<tr><td>`ActiveDirectoryInteractive`<td>_Windows driver only_. Authenticate with a Microsoft Entra identity using interactive authentication.<tr><td>`ActiveDirectoryMsi`<td>Authenticate with a Microsoft Entra managed identity. For user-assigned identity, UID is set to the object ID of the user identity.<tr><td>`ActiveDirectoryServicePrincipal`<td>(17.7+) Authenticate with a Microsoft Entra  service principal. UID is set to the client ID of the service principal. PWD is set to the client secret.</table>|
+|`Authentication`|(not set), (empty string), `SqlPassword`, `ActiveDirectoryPassword`, `ActiveDirectoryIntegrated`, `ActiveDirectoryInteractive`, `ActiveDirectoryMsi`, `ActiveDirectoryServicePrincipal` |(not set)|Controls the authentication mode.<table><tr><th>Value<th>Description<tr><td>(not set)<td>Authentication mode determined by other keywords (existing legacy connection options.)<tr><td>(empty string)<td>(Connection string only.) Override and unset an `Authentication` value set in the DSN.<tr><td>`SqlPassword`<td>Directly authenticate to SQL using a username and password.<tr><td>`ActiveDirectoryPassword`<td>Authenticate with a Microsoft Entra identity using a username and password.<tr><td>`ActiveDirectoryIntegrated`<td>_Windows, and Linux/Mac 17.6+, driver only_. Authenticate with a Windows credential federated through Microsoft Entra ID with integrated authentication.<tr><td>`ActiveDirectoryInteractive`<td>_Windows driver only_. Authenticate with a Microsoft Entra identity using interactive authentication.<tr><td>`ActiveDirectoryMsi`<td>Authenticate with a Microsoft Entra managed identity. For user-assigned identity, UID is set to the object ID of the user identity. For system-assigned identity, UID is not required.<tr><td>`ActiveDirectoryServicePrincipal`<td>(17.7+) Authenticate with a Microsoft Entra  service principal. UID is set to the client ID of the service principal. PWD is set to the client secret.</table>|
 |`Encrypt`|(not set), `Yes`/`Mandatory`(18.0+), `No`/`Optional`(18.0+), `Strict`(18.0+)|(see description)|Controls encryption for a connection. If the pre-attribute value of the `Authentication` setting isn't _`none`_ in the DSN or connection string, the default is `Yes`. The default is also `Yes` in versions 18.0.1+. Otherwise, the default is `No`. If the attribute `SQL_COPT_SS_AUTHENTICATION` overrides the pre-attribute value of `Authentication`, explicitly set the value of Encryption in the DSN or connection string or connection attribute. The pre-attribute value of Encryption is `Yes` if the value is set to `Yes` in either the DSN or connection string.|
 
 ## New and/or Modified Connection Attributes
@@ -79,7 +79,7 @@ It's possible to use Microsoft Entra authentication options when creating or edi
 
 `Authentication=ActiveDirectoryMsi` for Microsoft Entra managed identity authentication
 
-![The DSN creation and editing screen with Managed Service Identity authentication selected.](windows/create-dsn-ad-msi.png)
+![The DSN creation and editing screen with Managed Service Identity authentication selected.](windows/create-dsn-ad-sys-msi.png)
 
 `Authentication=ActiveDirectoryServicePrincipal` for Microsoft Entra service principal authentication
 
@@ -127,7 +127,7 @@ These options correspond to the same six available in the DSN setup UI above.
 
    ![Windows Azure Authentication UI when using Active Directory Interactive authentication.](windows/WindowsAzureAuth.png)
 
-8. Microsoft Entra managed identity authentication uses a system-assigned or user-assigned managed identity for authentication to set up the connection. For a user-assigned identity, the UID is set to the object ID of the user identity.<br>
+8. Microsoft Entra managed identity authentication uses a system-assigned or user-assigned managed identity for authentication to set up the connection. For a system-assigned identity, the UID is not required. For a user-assigned identity, the UID is set to the object ID of the user identity.<br>
 
    For system-assigned identity:
 


### PR DESCRIPTION
When using MSI for authentication in ODBC driver:  For user assigned MSI, the UID should be set to the object id of the user assigned MSI.  For system assigned MSI, we don't have to set the UID, but if we set any value for UID, it also need to be the object id of the system assigned MSI.  The current document didn't make that clear enough, also the screenshot is a bit mis-leading by include a username in the UID field.