### PR TITLE
Update json-path-expressions-sql-server.md

### DIFF
--- a/docs/relational-databases/json/json-path-expressions-sql-server.md
+++ b/docs/relational-databases/json/json-path-expressions-sql-server.md
@@ -58,7 +58,7 @@ SELECT * FROM OPENJSON(@json, N'lax $.info');
   
 -   The property path is a set of path steps. Path steps can contain the following elements and operators.  
   
-    -   Key names. For example, `$.name` and `$."first name"`. If the key name starts with a dollar sign or contains special characters such as spaces, surround it with quotes.   
+    -   Key names. For example, `$.name` and `$."first name"`. If the key name starts with a dollar sign or contains special characters such as spaces or dot operators(`.`), surround it with quotes.   
   
     -   Array elements. For example, `$.product[3]`. Arrays are zero-based.  
   


### PR DESCRIPTION
Adding a note about escaping the dot operator (.) I ran into this scenario where there was a . in the column name but it wasn't obvious that it needed to be escaped as the column just returned null. if I used:` '$.content_access.event_date' `and it gave me a bit of trouble working out the correct syntax:  `'$."content_access.event_date"'` 