### PR TITLE
Update dbo-sysproxylogin-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-tables/dbo-sysproxylogin-transact-sql.md
+++ b/docs/relational-databases/system-tables/dbo-sysproxylogin-transact-sql.md
@@ -26,7 +26,6 @@ dev_langs:
 |-----------------|---------------|-----------------|  
 |**proxy_id**|**int**|ID of the [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] Agent proxy account. This value corresponds to the **proxy_id** column in the **sysproxies** table.|  
 |**sid**|**varbinary(85)**|Microsoft Windows *security_identifier* for the SQL Server login.|  
-|**principal_id**|**int**|ID of the user or group that has permission to use the proxy account for a specified subsystem step.|  
 |**flags**|**int**|Type of login:<br /><br /> **0** = Windows user or group, and [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] login.<br /><br /> **1** = [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] fixed system role<br /><br /> **2** = **msdb** database role|  
   
 ## Remarks  


### PR DESCRIPTION
Removed missing column principal_id.

Please have the developer expound a bit more on why the principal_id was originally included.

Also, does the flags column fully capture the essence of the sid column in place of what the principal_id does.