### PR TITLE
Update sys-dm-os-out-of-memory-events.md

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-os-out-of-memory-events.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-os-out-of-memory-events.md
@@ -20,7 +20,7 @@ monikerRange: "=azuresqldb-current||=azuresqldb-mi-current"
 ---
 # sys.dm_os_out_of_memory_events
 
-[!INCLUDE [Azure SQL Database Azure SQL Managed Instance](../../includes/applies-to-version/asdb-asdbmi.md)]
+[!INCLUDE [SQL Server Azure SQL Database Azure SQL Managed Instance](../../includes/applies-to-version/sql-asdb-asdbmi.md)]
 
   Returns a log of out of memory (OOM) events.
 


### PR DESCRIPTION
dmv exists also on 2022 sql server engine, and actually we describe the permissions we need , in the paragraph "Permissions for SQL Server 2022 and later"

