### PR TITLE
Update begin-transaction-transact-sql.md - Fix spelling error

### DIFF
--- a/docs/t-sql/language-elements/begin-transaction-transact-sql.md
+++ b/docs/t-sql/language-elements/begin-transaction-transact-sql.md
@@ -48,7 +48,7 @@ BEGIN { TRAN | TRANSACTION }
 ```  
  
 ```syntaxsql
---Applies to Synpase Data Warehouse in Microsoft Fabric, Azure Synapse Analytics and Parallel Data Warehouse
+--Applies to Synapse Data Warehouse in Microsoft Fabric, Azure Synapse Analytics and Parallel Data Warehouse
  
 BEGIN { TRAN | TRANSACTION }   
 [ ; ]  


### PR DESCRIPTION
There was a spelling error in BEGIN TRANSACTION (Transact-SQL) document where Synapse was written incorrectly, this pull request fixes that.