### PR TITLE
Remove CAST in example in sys-fn-xe-file-target-read-file-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-functions/sys-fn-xe-file-target-read-file-transact-sql.md
+++ b/docs/relational-databases/system-functions/sys-fn-xe-file-target-read-file-transact-sql.md
@@ -105,7 +105,7 @@ SELECT * FROM sys.fn_xe_file_target_read_file('*.xel', null, null, null)
 
 ```sql
 SELECT * FROM sys.fn_xe_file_target_read_file('system_health*.xel', null, null, null)
-WHERE cast(timestamp_utc as datetime2(7)) > dateadd(day, -1, GETUTCDATE())
+WHERE timestamp_utc > dateadd(day, -1, GETUTCDATE())
 ```
 
 


### PR DESCRIPTION
Remove `CAST` on `timestamp_utc` on the last example. The column is already a `datetime2(7)`, so the `CAST` is not required, and could be seen to imply that the column is a different data type.