### PR TITLE
add-a-secondary-replica-to-an-availability-group-sql-server.md : Remo…

### DIFF
--- a/docs/database-engine/availability-groups/windows/add-a-secondary-replica-to-an-availability-group-sql-server.md
+++ b/docs/database-engine/availability-groups/windows/add-a-secondary-replica-to-an-availability-group-sql-server.md
@@ -82,12 +82,12 @@ helpviewer_keywords:
     $availabilityMode = "AsynchronousCommit"  
     $secondaryReadMode = "AllowAllConnections"  
   
-    New-SqlAvailabilityReplica -Name SecondaryServer\Instance `   
-    -EndpointUrl $endpointURL `   
-    -FailoverMode $failoverMode `   
-    -AvailabilityMode $availabilityMode `   
-    -ConnectionModeInSecondaryRole $secondaryReadMode `   
-    -Path $agPath  
+    New-SqlAvailabilityReplica -Name SecondaryServer\Instance `
+    -EndpointUrl $endpointURL `
+    -FailoverMode $failoverMode `
+    -AvailabilityMode $availabilityMode `
+    -ConnectionModeInSecondaryRole $secondaryReadMode `
+    -Path $agPath
     ```  
   
     > [!NOTE]  


### PR DESCRIPTION
…ved spaces after backtick in PowerShell scripts

TL;DR: Removed the spaces after the backticks so the cmdlet does what's expected. 

Summary:
The backtick character (`) escapes the next character after it.

The purpose here is to escape the newline character so the cmdlet knows to check the next line for a parameter. If there are spaces after the backtick, then the space character gets escaped instead of the newline character.

This could lead to the cmdlet not working or even changing objects unexpectedly.