### PR TITLE
Adding information on how to start the trace on a read scale-out replica in Azure SQL Managed Instance

### DIFF
--- a/azure-sql/database/read-scale-out.md
+++ b/azure-sql/database/read-scale-out.md
@@ -114,7 +114,9 @@ The following views are commonly used for replica monitoring and troubleshooting
 
 An extended event session can't be created when connected to a read-only replica. However, in Azure SQL Database and Azure SQL Managed Instance, the definitions of database-scoped [Extended Event](xevent-db-diff-from-svr.md) sessions created and altered on the primary replica replicate to read-only replicas, including geo-replicas, and capture events on read-only replicas.
 
-In Azure SQL Database, an extended event session on a read-only replica that is based on a session definition from the primary replica can be started and stopped independently of the session on the primary replica. If you don't first start the trace on the primary replica, you receive the following error when attempting to start the trace on the read-only replica:
+In Azure SQL Database, an extended event session on a read-only replica that is based on a session definition from the primary replica can be started and stopped independently of the session on the primary replica.
+ 
+In Azure SQL Managed Instance, to start a trace on a read-only replica, you must first start the trace on the primary replica before you can start the trace on the read-only replica. If you do not first start the trace on the primary replica, you will receive the following error when attempting to start the trace on the read-only replica:
 
 > Msg 3906, Level 16, State 2, Line 1
 > Failed to update database "master" because the database is read-only.

--- a/azure-sql/database/read-scale-out.md
+++ b/azure-sql/database/read-scale-out.md
@@ -114,7 +114,7 @@ The following views are commonly used for replica monitoring and troubleshooting
 
 An extended event session can't be created when connected to a read-only replica. However, in Azure SQL Database and Azure SQL Managed Instance, the definitions of database-scoped [Extended Event](xevent-db-diff-from-svr.md) sessions created and altered on the primary replica replicate to read-only replicas, including geo-replicas, and capture events on read-only replicas.
 
-In Azure SQL Managed Instance, to start a trace on a read-only replica, you must first start the trace on the primary replica before you can start the trace on the read-only replica. If you do not first start the trace on the primary replica, you will receive the following error when attempting to start the trace on the read-only replica:
+In Azure SQL Database, an extended event session on a read-only replica that is based on a session definition from the primary replica can be started and stopped independently of the session on the primary replica. If you don't first start the trace on the primary replica, you receive the following error when attempting to start the trace on the read-only replica:
 
 > Msg 3906, Level 16, State 2, Line 1
 > Failed to update database "master" because the database is read-only.

--- a/azure-sql/database/read-scale-out.md
+++ b/azure-sql/database/read-scale-out.md
@@ -116,7 +116,7 @@ An extended event session can't be created when connected to a read-only replica
 
 In Azure SQL Database, an extended event session on a read-only replica that is based on a session definition from the primary replica can be started and stopped independently of the session on the primary replica.
  
-In Azure SQL Managed Instance, to start a trace on a read-only replica, you must first start the trace on the primary replica before you can start the trace on the read-only replica. If you do not first start the trace on the primary replica, you will receive the following error when attempting to start the trace on the read-only replica:
+In Azure SQL Managed Instance, to start a trace on a read-only replica, you must first start the trace on the primary replica before you can start the trace on the read-only replica. If you don't first start the trace on the primary replica, you receive the following error when attempting to start the trace on the read-only replica:
 
 > Msg 3906, Level 16, State 2, Line 1
 > Failed to update database "master" because the database is read-only.

--- a/azure-sql/database/read-scale-out.md
+++ b/azure-sql/database/read-scale-out.md
@@ -112,9 +112,14 @@ The following views are commonly used for replica monitoring and troubleshooting
 
 ### Monitor read-only replicas with Extended Events
 
-An extended event session can't be created when connected to a read-only replica. However, in Azure SQL Database, the definitions of database-scoped [Extended Event](xevent-db-diff-from-svr.md) sessions created and altered on the primary replica replicate to read-only replicas, including geo-replicas, and capture events on read-only replicas.
+An extended event session can't be created when connected to a read-only replica. However, in Azure SQL Database and Azure SQL Managed Instance, the definitions of database-scoped [Extended Event](xevent-db-diff-from-svr.md) sessions created and altered on the primary replica replicate to read-only replicas, including geo-replicas, and capture events on read-only replicas.
 
-An extended event session on a read-only replica that is based on a session definition from the primary replica can be started and stopped independently of the session on the primary replica.
+In Azure SQL Managed Instance, to start a trace on a read-only replica, you must first start the trace on the primary replica before you can start the trace on the secondary replica. If you do not first start the trace on the primary replica, you will receive the following error when starting the trace on the read-only replica:
+
+> Msg 3906, Level 16, State 2, Line 1
+> Failed to update database "master" because the database is read-only.
+
+After starting the trace first on the primary replica, then on the read-only replica, you may stop the trace on the primary replica.
 
 To drop an event session on a read-only replica, follow these steps:
 

--- a/azure-sql/database/read-scale-out.md
+++ b/azure-sql/database/read-scale-out.md
@@ -114,7 +114,7 @@ The following views are commonly used for replica monitoring and troubleshooting
 
 An extended event session can't be created when connected to a read-only replica. However, in Azure SQL Database and Azure SQL Managed Instance, the definitions of database-scoped [Extended Event](xevent-db-diff-from-svr.md) sessions created and altered on the primary replica replicate to read-only replicas, including geo-replicas, and capture events on read-only replicas.
 
-In Azure SQL Managed Instance, to start a trace on a read-only replica, you must first start the trace on the primary replica before you can start the trace on the secondary replica. If you do not first start the trace on the primary replica, you will receive the following error when starting the trace on the read-only replica:
+In Azure SQL Managed Instance, to start a trace on a read-only replica, you must first start the trace on the primary replica before you can start the trace on the read-only replica. If you do not first start the trace on the primary replica, you will receive the following error when attempting to start the trace on the read-only replica:
 
 > Msg 3906, Level 16, State 2, Line 1
 > Failed to update database "master" because the database is read-only.


### PR DESCRIPTION
I am not sure how this works with Azure SQL Database, but with Azure SQL Managed Instance I have not been able to start a trace on a read-scale out instance without first starting it on the replica where the trace was created.

It's super weird.