### PR TITLE
Update dbcc-cleantable-transact-sql.md

### DIFF
--- a/docs/t-sql/database-console-commands/dbcc-cleantable-transact-sql.md
+++ b/docs/t-sql/database-console-commands/dbcc-cleantable-transact-sql.md
@@ -60,6 +60,7 @@ The table or indexed view to be cleaned.
 #### *batch_size*
 
 The number of rows processed per transaction. If not specified, the default value is `1000`. To avoid a long recovery period, `0` is not allowed.
+The behaviour of '0' is undefined but the statement will complete without error if attempted.
 
 #### WITH NO_INFOMSGS
 


### PR DESCRIPTION
Added additional information about the '0' is not allowed claim. I think the document should actually describe what really happens with '0' as there are internet posts around this but the MS docs are incomplete,