### PR TITLE
Fix SQL Syntax for ordered columnstore index

### DIFF
--- a/docs/t-sql/statements/create-columnstore-index-transact-sql.md
+++ b/docs/t-sql/statements/create-columnstore-index-transact-sql.md
@@ -52,8 +52,8 @@ Syntax for SQL Server and Azure SQL Database:
 -- Create a clustered columnstore index on disk-based table.
 CREATE CLUSTERED COLUMNSTORE INDEX index_name
     ON { database_name.schema_name.table_name | schema_name.table_name | table_name }
-    [ WITH ( <with_option> [ , ...n ] ) ]
     [ ORDER (column [ , ...n ] ) ]
+    [ WITH ( <with_option> [ , ...n ] ) ]
     [ ON <on_option> ]
 
 [ ; ]
@@ -130,7 +130,7 @@ Specifies the one-, two-, or three-part name of the table to be stored as a clus
 
 Use the `column_store_order_ordinal` column in [sys.index_columns](../../relational-databases/system-catalog-views/sys-index-columns-transact-sql.md) to determine the order of the column(s) for a clustered columnstore index. This aids with [segment elimination](../../relational-databases/indexes/columnstore-indexes-query-performance.md#segment-elimination), especially with string data. For more information, see [Performance tuning with ordered clustered columnstore index](/azure/synapse-analytics/sql-data-warehouse/performance-tuning-ordered-cci) and [Columnstore indexes design guidance](../../relational-databases/indexes/columnstore-indexes-design-guidance.md).
 
-To convert to an ordered clustered column store index, the existing index must be a clustered columnstore index. Use the `DROP_EXISTING` option.
+To convert to an ordered clustered columnstore index, the existing index must be a clustered columnstore index. Use the `DROP_EXISTING` option.
 
 LOB data types (the (max) length data types) can't be the key of an ordered clustered columnstore index.
 

--- a/docs/t-sql/statements/create-columnstore-index-transact-sql.md
+++ b/docs/t-sql/statements/create-columnstore-index-transact-sql.md
@@ -53,7 +53,8 @@ Syntax for SQL Server and Azure SQL Database:
 CREATE CLUSTERED COLUMNSTORE INDEX index_name
     ON { database_name.schema_name.table_name | schema_name.table_name | table_name }
     [ WITH ( <with_option> [ , ...n ] ) ]
-    [ ON <on_option> ] | [ ORDER <on_option> ]
+    [ ORDER (column [ , ...n ] ) ]
+    [ ON <on_option> ]
 
 [ ; ]
 


### PR DESCRIPTION
The syntax description contained wrong information about how to use the `ORDER` clause in the `CREATE CLUSTERED COLUMNSTORE INDEX` statement.

Here is some code to demonstrate the new version is correct:

```
SELECT @@VERSION;
GO
DROP TABLE IF EXISTS dbo.tbl3;
GO
IF EXISTS(SELECT 1 FROM sys.partition_schemes WHERE name = 'PS_dbo_tbl3') DROP PARTITION SCHEME PS_dbo_tbl3; IF EXISTS(SELECT 1 FROM sys.partition_functions WHERE name = 'PF_dbo_tbl3')DROP PARTITION FUNCTION PF_dbo_tbl3; GO
CREATE PARTITION FUNCTION PF_dbo_tbl3(INT) AS RANGE RIGHT FOR VALUES(1); GO
CREATE PARTITION SCHEME PS_dbo_tbl3 AS PARTITION PF_dbo_tbl3 ALL TO ('PRIMARY'); GO
CREATE TABLE dbo.tbl3(
 c1 INT,
 c2 INT,
 c3 INT,
 c4 INT,
 c5 INT,
 c6 INT,
 c7 INT,
 c8 INT,
 c9 INT,
 c10 INT
)
ON PS_dbo_tbl3(c5)
;
GO
CREATE CLUSTERED COLUMNSTORE INDEX tbl3_CCI
ON dbo.tbl3
ORDER (c2,c6,c4)
ON PS_dbo_tbl3(c5)
;
GO
SELECT I.name,C.name,index_column_id,partition_ordinal,column_store_order_ordinal
  FROM sys.index_columns IC 
  JOIN sys.columns C
    ON C.object_id = IC.object_id
   AND C.column_id = IC.column_id
  JOIN sys.indexes I
    ON I.object_id = IC.object_id
   AND I.index_id = IC.index_id
 WHERE C.object_id = OBJECT_ID('dbo.tbl3');
SELECT I.name,PS.name
  FROM sys.indexes I
  JOIN sys.partition_schemes PS 
    ON I.data_space_id = PS.data_space_id;
```