### PR TITLE
Update prereqs-restrictions-recommendations-always-on-availability.md

### DIFF
--- a/docs/database-engine/availability-groups/windows/prereqs-restrictions-recommendations-always-on-availability.md
+++ b/docs/database-engine/availability-groups/windows/prereqs-restrictions-recommendations-always-on-availability.md
@@ -57,6 +57,9 @@ To support the [!INCLUDE [ssHADR](../../../includes/sshadr-md.md)] feature, ensu
 
 - **Sufficient disk space:** Every computer on which a server instance hosts an availability replica must possess sufficient disk space for all the databases in the availability group. Keep in mind that as primary databases grow, their corresponding secondary databases grow the same amount.
 
+- ** Identical disk layout:** Every computer on which a server instance hosts an availability replica should have identical list of disks (with exact disk drive letters and sizes) to ensure database files (mdf,ldf) file paths are mirrored and synched without any complications. please refer to
+section for secondary replicas with different disk layout: Restrictions (availability databases)
+
 ### <a id="PermissionsWindows"></a> Permissions (Windows system)
 
 To administer a WSFC, the user must be a system administrator on every cluster node.


### PR DESCRIPTION
Hi,

Under: Recommendations for computers that host availability replicas (Windows system)

Identical disk layout: Every computer on which a server instance hosts an availability replica should have identical list of disks (with exact disk drive letters and sizes) to ensure database files (mdf,ldf) file paths are mirrored and synced without any complications. please refer to section for secondary replicas with different disk layout: Restrictions (availability databases)

*** Having identical disk layouts should be part of pre-requisite section to ensure correct and smooth deployment.