### PR TITLE
Update sys-extended-procedures-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-catalog-views/sys-extended-procedures-transact-sql.md
+++ b/docs/relational-databases/system-catalog-views/sys-extended-procedures-transact-sql.md
@@ -20,7 +20,7 @@ dev_langs:
 # sys.extended_procedures (Transact-SQL)
 [!INCLUDE [SQL Server](../../includes/applies-to-version/sqlserver.md)]
 
-  Contains a row for each object that is an extended stored procedure, with **sys.objects.type** = X. Because extended stored procedures are installed into the **master** database, they are only visible from that database context. Selecting from the **sys.extended_procedures** view in any other database context will return an empty result set.  
+  Contains a row for each object that is an extended stored procedure, with **sys.all_objects.type** = X. Because extended stored procedures are installed into the **master** database, they are only visible from that database context. Selecting from the **sys.extended_procedures** view in any other database context will return an empty result set.  
 
   
 |Column name|Data type|Description|  


### PR DESCRIPTION
Hi,

The correct table should be  sys.all_objects not sys.objects. the table sys.all_objects contains a column called "type" where "X" is associated with "EXTENDED_STORED_PROCEDURE".

Also, worth stating when you execute: 
SELECT * 
FROM master.sys.extended_procedures;
GO

NO rows are being returned back...I am using SQL Server 2022 release. I think this table is not being populated anymore.

Regards,
Emad