### PR TITLE
Added a consideration when taking managed backups on availability group secondary replica

### DIFF
--- a/docs/relational-databases/backup-restore/sql-server-managed-backup-to-microsoft-azure.md
+++ b/docs/relational-databases/backup-restore/sql-server-managed-backup-to-microsoft-azure.md
@@ -133,6 +133,8 @@ The following support limitations and considerations are specific to [!INCLUDE [
 
 - Backups of databases in an availability group are [copy-only backups](copy-only-backups-sql-server.md).
 
+- Backups of databases on secondary replica's in an availabiity group need to be readable in order to stripe to multiple files. 
+
 ## Related content
 
 - [Enable SQL Server managed backup to Azure](enable-sql-server-managed-backup-to-microsoft-azure.md)


### PR DESCRIPTION
In order for managed backup to be able to stripe to multiple files, it needs to query sys.dm_db_file_space_usage which is done at the database level. If the secondary replica does not allow read access, this query will fail and default to 1 stripe.

This should be added since it conflicts with what we say in our backup on secondary replica doc:
https://learn.microsoft.com/en-us/sql/database-engine/availability-groups/windows/configure-backup-on-availability-replicas-sql-server?view=sql-server-ver16#Prerequisites

"The secondary replica does not need to be readable to offload backups to it. Backups will still succeed on the secondary replica even if Readable Secondary is set to no."


IcM created to get PG approval for this: https://portal.microsofticm.com/imp/v3/incidents/incident/498983542/summary