### PR TITLE
Fixed example code to use proper EXEC-syntax and removed unnecessary GO

### DIFF
--- a/docs/t-sql/statements/drop-rule-transact-sql.md
+++ b/docs/t-sql/statements/drop-rule-transact-sql.md
@@ -63,9 +63,8 @@ DROP RULE [ IF EXISTS ] { [ schema_name . ] rule_name } [ ,...n ] [ ; ]
  The following example unbinds and then drops the rule named `VendorID_rule`. 
   
 ```sql  
-sp_unbindrule 'Production.ProductVendor.VendorID'  
-DROP RULE VendorID_rule  
-GO  
+EXEC sp_unbindrule 'Production.ProductVendor.VendorID'  
+DROP RULE VendorID_rule
 ```  
   
 ## See Also  


### PR DESCRIPTION
The example code doesn't compile because EXEC is required to execute procedure in multi-statement batches. Also, i see no point of including a GO batch separator since it confuses from the matter at hand and is not really part of tsql