### PR TITLE
Update alter-table-index-option-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/alter-table-index-option-transact-sql.md
+++ b/docs/t-sql/statements/alter-table-index-option-transact-sql.md
@@ -100,14 +100,21 @@ dev_langs:
  In backward compatible syntax, WITH IGNORE_DUP_KEY is equivalent to WITH IGNORE_DUP_KEY = ON.  
   
  STATISTICS_NORECOMPUTE **=** { ON | **OFF** }  
- Specifies whether statistics are recomputed. The default is OFF.  
+ Disable or enable the automatic statistics update option, AUTO_STATISTICS_UPDATE, for all index-related statistics on the table. The default is OFF.
   
  ON  
- Out-of-date statistics aren't automatically recomputed.  
+ Automatic statistics update will be disabled after the index is rebuilt.
   
  OFF  
- Automatic statistics updating are enabled.  
+ Automatic statistics update will be enabled after the index is rebuilt.  
   
+ To restore automatic statistics updating, set the `STATISTICS_NORECOMPUTE` to OFF, or execute `UPDATE STATISTICS` without the `NORECOMPUTE` clause.
+   
+ > [!IMPORTANT]  
+ > Disabling automatic updating of statistics may prevent the Query Optimizer from picking optimal execution plans for queries that involve the table. We recommend using this option sparingly, and then only by a qualified database administrator.
+   
+ **NOTE:** This setting does not prevent the automatic update with fullscan of the index-related statistics during the rebuild operation.
+   
  ALLOW_ROW_LOCKS **=** { **ON** | OFF }  
  **Applies to**: [!INCLUDE[sql2008-md](../../includes/sql2008-md.md)] and later.  
   


### PR DESCRIPTION
Better description of what STATISTICS_NORECOMPUTE actually does, also copied and reworded the warning that is provided for this option on the ALTER INDEX page.