### PR TITLE
Fix installing-the-microsoft-odbc-driver-for-sql-server.md: key verification debian 12

### DIFF
--- a/docs/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server.md
+++ b/docs/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server.md
@@ -60,7 +60,11 @@ sudo apk add --allow-untrusted mssql-tools18_18.3.1.1-1_$architecture.apk
 ### [Debian](#tab/debian18-install)
 
 ```bash
+#Debian 9-11
 curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc
+
+# Debian 12
+curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | sudo gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
 
 #Download appropriate package for the OS version
 #Choose only ONE of the following, corresponding to your OS version


### PR DESCRIPTION
apt changed the way it verified signature

thx to Philip Z (https://learn.microsoft.com/en-us/answers/questions/1328834/debian-12-public-key-is-not-available)