### PR TITLE
Update predict-transact-sql.md

### DIFF
--- a/docs/t-sql/queries/predict-transact-sql.md
+++ b/docs/t-sql/queries/predict-transact-sql.md
@@ -148,6 +148,9 @@ WITH ( <result_set_definition> )
 
 ::: moniker-end
 
+> [!IMPORTANT]
+> PREDIC is off by default in Azure Synapse Analytics. If you want to use it, you need to contact support
+
 ### Arguments
 
 **MODEL**


### PR DESCRIPTION
PREDICT is off by default in Azure Synapse Analytics Add annotation

The following syntax error occurs
 Incorrect syntax near '='.
![Untitled](https://github.com/MicrosoftDocs/sql-docs/assets/156894695/5a22b751-6c3a-4e47-909f-0c999a615c80)
