### PR TITLE
Update tune-performance-with-the-query-store.md

### DIFF
--- a/docs/relational-databases/performance/tune-performance-with-the-query-store.md
+++ b/docs/relational-databases/performance/tune-performance-with-the-query-store.md
@@ -68,18 +68,25 @@ ORDER BY total_execution_count DESC;
 The number of queries with the longest average execution time within last hour:
 
 ```sql
-SELECT TOP 10 rs.avg_duration, qt.query_sql_text, q.query_id,
-    qt.query_text_id, p.plan_id, GETUTCDATE() AS CurrentUTCTime,
-    rs.last_execution_time
+SELECT TOP 10
+   AVG(rs.avg_duration) AS avg_duration,
+   SUM(rs.count_executions) AS total_execution_count,
+   qt.query_sql_text,
+   q.query_id,
+   qt.query_text_id,
+   p.plan_id,
+   GETUTCDATE() AS CurrentUTCTime,
+   MAX(rs.last_execution_time) AS last_execution_time
 FROM sys.query_store_query_text AS qt
-JOIN sys.query_store_query AS q
-    ON qt.query_text_id = q.query_text_id
-JOIN sys.query_store_plan AS p
-    ON q.query_id = p.query_id
-JOIN sys.query_store_runtime_stats AS rs
-    ON p.plan_id = rs.plan_id
-WHERE rs.last_execution_time > DATEADD(hour, -1, GETUTCDATE())
-ORDER BY rs.avg_duration DESC;
+JOIN sys.query_store_query AS q ON
+   qt.query_text_id = q.query_text_id
+JOIN sys.query_store_plan AS p ON
+   q.query_id = p.query_id
+JOIN sys.query_store_runtime_stats AS rs ON
+   p.plan_id = rs.plan_id
+WHERE rs.last_execution_time > DATEADD(HOUR, -1, GETUTCDATE())
+GROUP BY qt.query_sql_text, q.query_id, qt.query_text_id, p.plan_id
+ORDER BY AVG(rs.avg_duration) DESC;
 ```
 
 #### Biggest average physical I/O reads
@@ -105,7 +112,25 @@ ORDER BY rs.avg_physical_io_reads DESC;
 
 #### Queries with multiple plans
 
-These queries are especially interesting because they're candidates for regressions due to plan choice change. The following query identifies these queries along with all plans:
+These queries are especially interesting because they're candidates for regressions due to plan choice change. 
+
+The following query identifies the queries with the highest number of plans:
+
+```sql
+SELECT COUNT(*) AS cnt, q.query_id, object_name(object_id) AS ContainingObject,
+    MAX(p.last_compile_start_time) last_compile_start_time, 
+    MAX(p.last_execution_time) last_execution_time, STRING_AGG( plan_id,',') plan_ids
+FROM sys.query_store_query_text AS qt
+JOIN sys.query_store_query AS q
+    ON qt.query_text_id = q.query_text_id
+JOIN sys.query_store_plan AS p
+    ON p.query_id = q.query_id
+GROUP BY OBJECT_NAME(object_id), q.query_id
+HAVING COUNT(distinct plan_id) > 1
+ORDER BY cnt desc
+```
+
+The following query identifies these queries along with all plans:
 
 ```sql
 WITH Query_MultPlans
@@ -120,7 +145,6 @@ JOIN sys.query_store_plan AS p
 GROUP BY q.query_id
 HAVING COUNT(distinct plan_id) > 1
 )
-
 SELECT q.query_id, object_name(object_id) AS ContainingObject,
     query_sql_text, plan_id, p.query_plan AS plan_xml,
     p.last_compile_start_time, p.last_execution_time

--- a/docs/relational-databases/performance/tune-performance-with-the-query-store.md
+++ b/docs/relational-databases/performance/tune-performance-with-the-query-store.md
@@ -65,7 +65,7 @@ ORDER BY total_execution_count DESC;
 
 #### Longest average execution time
 
-The number of queries with the longest average execution time within last hour:
+The number of queries with the highest average duration within last hour:
 
 ```sql
 SELECT TOP 10
@@ -89,7 +89,7 @@ GROUP BY qt.query_sql_text, q.query_id, qt.query_text_id, p.plan_id
 ORDER BY AVG(rs.avg_duration) DESC;
 ```
 
-#### Biggest average physical I/O reads
+#### Highest average physical I/O reads
 
 The number of queries that had the biggest average physical I/O reads in last 24 hours, with corresponding average row count and execution count:
 
@@ -112,7 +112,7 @@ ORDER BY rs.avg_physical_io_reads DESC;
 
 #### Queries with multiple plans
 
-These queries are especially interesting because they're candidates for regressions due to plan choice change. 
+Queries with more than one plan are especially interesting, because they can be candidates for a regression in performance due to a change in plan choice.
 
 The following query identifies the queries with the highest number of plans:
 


### PR DESCRIPTION
1. Number of executions for each query - Edited to consolidate duplicates where the query id, plan id, and SQL text are the same and sum the execution counts.
2. Queries with multiple plans - A section has been added to identify queries with the highest number of plans