### PR TITLE
Update create-external-table-transact-sql.md - No support for nested …

### DIFF
--- a/docs/t-sql/statements/create-external-table-transact-sql.md
+++ b/docs/t-sql/statements/create-external-table-transact-sql.md
@@ -113,7 +113,7 @@ Specifies the folder or the file path and file name for the actual data in Hadoo
 
 In SQL Server, the CREATE EXTERNAL TABLE statement creates the path and folder if it doesn't already exist. You can then use INSERT INTO to export data from a local SQL Server table to the external data source. For more information, see [PolyBase Queries](../../relational-databases/polybase/polybase-queries.md).
 
-If you specify LOCATION to be a folder, a PolyBase query that selects from the external table will retrieve files from the folder and all of its subfolders. Just like Hadoop, PolyBase doesn't return hidden folders. It also doesn't return files for which the file name begins with an underline (_) or a period (.).
+If you specify LOCATION to be a folder, a PolyBase query that selects from the external table will retrieve files from the folder and all of its subfolders (Except for S3 where nested buckets are not supported). Just like Hadoop, PolyBase doesn't return hidden folders. It also doesn't return files for which the file name begins with an underline (_) or a period (.).
 
 In the following image example, if `LOCATION='/webdata/'`, a PolyBase query will return rows from `mydata.txt` and `mydata2.txt`. It won't return `mydata3.txt` because it's a file in a hidden subfolder. And it won't return `_hidden.txt` because it's a hidden file.
 


### PR DESCRIPTION
…buckets on S3

The documentation gives the reader the impression that subfolders / nested buckets are generally supported by polybase, however it seems that is not true for buckets that reside on s3. Therefore the documentation should be corrected.