### PR TITLE
Correct FCI instance for Enterprise Edition

### DIFF
--- a/docs/sql-server/editions-and-components-of-sql-server-2019.md
+++ b/docs/sql-server/editions-and-components-of-sql-server-2019.md
@@ -162,7 +162,7 @@ The Developer edition continues to support only 1 client for [[!INCLUDE[ssNoVers
 
 <sup>3</sup> Witness only
 
-<sup>4</sup> On Enterprise edition, the number of nodes is the operating system maximum. On Standard edition there is support for two nodes.
+<sup>4</sup> On Enterprise edition, the number of nodes is 16. On Standard edition there is support for two nodes.
 
 <sup>5</sup> On Enterprise edition, provides support for up to 8 secondary replicas - including 5 synchronous secondary replicas.
 


### PR DESCRIPTION
Correcting the number of FCIs available in clustering for Enterprise Edition which is still 16 and has not changed.