### PR TITLE
Update virtual-machines-best-practices-vm-size.md

### DIFF
--- a/azure-sql/includes/virtual-machines-best-practices-vm-size.md
+++ b/azure-sql/includes/virtual-machines-best-practices-vm-size.md
@@ -16,5 +16,5 @@ ms.topic: include
 - Use [Azure Data Studio](/azure/dms/tutorial-sql-server-to-virtual-machine-online-ads) to migrate to Azure.
 
 > [!WARNING]
-Installing SQL Server to systems that exceed 64 cores per NUMA node is not currently supported, such as the Standard_M176s_3_v3 and Standard_M176s_4_v3 Azure Virtual Machine sizes within the Msv3 and Mdsv3 Medium Memory Series.
+> Installing SQL Server to systems that exceed 64 cores per NUMA node is not currently supported. This limitation currently applies to the Standard_M176s_3_v3 and Standard_M176s_4_v3 Azure Virtual Machine sizes within the Msv3 and Mdsv3 Medium Memory Series.
 > 

--- a/azure-sql/includes/virtual-machines-best-practices-vm-size.md
+++ b/azure-sql/includes/virtual-machines-best-practices-vm-size.md
@@ -16,5 +16,5 @@ ms.topic: include
 - Use [Azure Data Studio](/azure/dms/tutorial-sql-server-to-virtual-machine-online-ads) to migrate to Azure.
 
 > [!WARNING]
-SQL Server is not supported on machines with more than 64 cores per NUMA node. As a result, it will not be possible to provision SQL Server on systems that exceed 64 cores per NUMA node. Presently, this constraint only affects the Standard_M176s_3_v3 and Standard_M176s_4_v3 Azure Virtual Machine sizes within the Msv3 and Mdsv3 Medium Memory Series.
+Installing SQL Server to systems that exceed 64 cores per NUMA node is not currently supported, such as the Standard_M176s_3_v3 and Standard_M176s_4_v3 Azure Virtual Machine sizes within the Msv3 and Mdsv3 Medium Memory Series.
 > 

--- a/azure-sql/includes/virtual-machines-best-practices-vm-size.md
+++ b/azure-sql/includes/virtual-machines-best-practices-vm-size.md
@@ -15,3 +15,6 @@ ms.topic: include
 - Use the [Data Migration Assistant](https://www.microsoft.com/download/details.aspx?id=53595) and [SKU recommendation](/sql/dma/dma-sku-recommend-sql-db) tools to find the right VM size for your existing SQL Server workload.
 - Use [Azure Data Studio](/azure/dms/tutorial-sql-server-to-virtual-machine-online-ads) to migrate to Azure.
 
+> [!WARNING]
+SQL Server is not supported on machines with more than 64 cores per NUMA node. As a result, it will not be possible to provision SQL Server on systems that exceed 64 cores per NUMA node. Presently, this constraint only affects the Standard_M176s_3_v3 and Standard_M176s_4_v3 Azure Virtual Machine sizes within the Msv3 and Mdsv3 Medium Memory Series.
+> 


### PR DESCRIPTION
Adding a warning as it is not supported to install SQL Server on a system that has more than 64 cores per NUMA node. A recent update to SQL 2022 prevents SQL Server from starting, as a precautionary measure to ensure optimal performance and system stability. (https://learn.microsoft.com/en-us/troubleshoot/sql/releases/sqlserver-2022/cumulativeupdate11#2744933)