### PR TITLE
Fix malformed HTML

### DIFF
--- a/docs/connect/sql-connection-libraries.md
+++ b/docs/connect/sql-connection-libraries.md
@@ -25,7 +25,7 @@ This article provides download links to connection modules or *drivers* that you
 
 The present article devotes separate sections to these two kinds of connection drivers.
 
-<a name="anchor-20-drivers-relational-access" />
+<a name="anchor-20-drivers-relational-access"></a>
 
 ## Drivers for relational access
 
@@ -40,7 +40,7 @@ The present article devotes separate sections to these two kinds of connection d
 | Python | [pyodbc, install instructions](./python/pyodbc/step-1-configure-development-environment-for-pyodbc-python-development.md)<br />[Download ODBC](./odbc/download-odbc-driver-for-sql-server.md) |
 | Ruby | [Ruby driver, install instructions](./ruby/step-1-configure-development-environment-for-ruby-development.md)<br />[Ruby download page](https://rubyinstaller.org/downloads/) |
 
-<a name="anchor-40-drivers-orm-access" />
+<a name="anchor-40-drivers-orm-access"></a>
 
 ## Drivers for ORM access
 


### PR DESCRIPTION
`<a />` is not valid HTML and so web-browsers interpret it as a `<a>` that wraps all subsequent content, so the table is rendered as a giant hyperlink (in Chrome 125 and Firefox 126).

![image](https://github.com/MicrosoftDocs/sql-docs/assets/1693078/d8543e87-971b-4733-83b4-3937af6237cf)
