### PR TITLE
Update sys-dm-database-backups-azure-sql-database.md

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-database-backups-azure-sql-database.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-database-backups-azure-sql-database.md
@@ -25,9 +25,6 @@ monikerRange: "=azuresqldb-current"
 
 Returns information about backups of a database in an [!INCLUDE [ssazure-sqldb](../../includes/ssazure-sqldb.md)] server.
 
-> [!NOTE]  
-> The `sys.dm_database_backups` DMV is currently in preview and is available for all Azure SQL Database service tiers except Hyperscale tier.
-
 | Column name | Data type | Description |
 | --- | --- | --- |
 | `backup_file_id` | **uniqueidentifier** | ID of the generated backup file. Not null. |


### PR DESCRIPTION
After some testing and investigations, the sys.dm_database_backups does exist in the Hyperscale Tier. 

![hs_001](https://github.com/MicrosoftDocs/sql-docs/assets/4842255/08d57111-99cf-4d70-942e-60c6197ed83e)

![hs_002](https://github.com/MicrosoftDocs/sql-docs/assets/4842255/834b9c58-2188-4984-b0da-7ddc5976c4c4)
