### PR TITLE
Update database-instant-file-initialization.md

### DIFF
--- a/docs/relational-databases/databases/database-instant-file-initialization.md
+++ b/docs/relational-databases/databases/database-instant-file-initialization.md
@@ -64,7 +64,7 @@ To grant an account the `Perform volume maintenance tasks` permission:
 
 1. In the right pane, double-click **Perform volume maintenance tasks**.
 
-1. Select **Add User or Group** and add the account that runs the [!INCLUDE [ssnoversion-md](../../includes/ssnoversion-md.md)] service.
+1. Select **Add User or Group** and add the [!INCLUDE [ssnoversion-md](../../includes/ssnoversion-md.md)] service account.
 
 1. Select **Apply**, and then close all **Local Security Policy** dialog boxes.
 


### PR DESCRIPTION
Add the "Perform volume maintenance tasks" right to the service account, as the setup.exe is doing it. Downside when using an AD account: Configuration manager will not show the setting, as it just looks for the StartName of the service. We wrote about the topic here: https://blog.ordix.de/instant-file-initialization-microsoft-sql-server-set-up-check