### PR TITLE
Correct spelling of "role"

### DIFF
--- a/docs/ssms/scripting/run-the-transact-sql-debugger.md
+++ b/docs/ssms/scripting/run-the-transact-sql-debugger.md
@@ -36,7 +36,7 @@ The requirements to start the [!INCLUDE[tsql](../../includes/tsql-md.md)] debugg
 
 - If your [!INCLUDE[ssDE](../../includes/ssde-md.md)] Query Editor is connected to an instance of the [!INCLUDE[ssDE](../../includes/ssde-md.md)] on another computer, you must have configured the debugger for remote debugging. For more information, see [Configure firewall rules before running the Transact-SQL debugger](./configure-firewall-rules-before-running-the-tsql-debugger.md).
   
-- SQL Server Management Studio must be running under a Windows account that is a member of the sysadmin fixed server roll.
+- SQL Server Management Studio must be running under a Windows account that is a member of the sysadmin fixed server role.
 
 - The [!INCLUDE[ssDE](../../includes/ssde-md.md)] Query Editor window must be connected by using either a Windows Authentication or [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] Authentication login that is a member of the sysadmin fixed server role.
   


### PR DESCRIPTION
The original used the word "roll" instead of "role".