### PR TITLE
Update create-database-scoped-credential-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/create-database-scoped-credential-transact-sql.md
+++ b/docs/t-sql/statements/create-database-scoped-credential-transact-sql.md
@@ -131,7 +131,8 @@ CREATE DATABASE SCOPED CREDENTIAL AppCred WITH IDENTITY = 'Mary5',
 
 ### B. Creating a database scoped credential for a shared access signature
 
-The following example creates a database scoped credential that can be used to create an [external data source](../../t-sql/statements/create-external-data-source-transact-sql.md), which can do bulk operations, such as [BULK INSERT](../../t-sql/statements/bulk-insert-transact-sql.md) and [OPENROWSET](../../t-sql/functions/openrowset-transact-sql.md). Shared Access Signatures can be used with PolyBase in SQL Server, APS or Azure Synapse Analytics.
+The following example creates a database scoped credential that can be used to create an [external data source](../../t-sql/statements/create-external-data-source-transact-sql.md), which can do bulk operations, such as [BULK INSERT](../../t-sql/statements/bulk-insert-transact-sql.md) and [OPENROWSET](../../t-sql/functions/openrowset-transact-sql.md). 
+
 
 ```sql
 -- Create a db master key if one does not already exist, using your own password.

--- a/docs/t-sql/statements/create-database-scoped-credential-transact-sql.md
+++ b/docs/t-sql/statements/create-database-scoped-credential-transact-sql.md
@@ -3,7 +3,7 @@ title: "CREATE DATABASE SCOPED CREDENTIAL (Transact-SQL)"
 description: CREATE DATABASE SCOPED CREDENTIAL (Transact-SQL)
 author: VanMSFT
 ms.author: vanto
-ms.date: 01/18/2024
+ms.date: 07/11/2024
 ms.service: sql
 ms.subservice: t-sql
 ms.topic: reference

--- a/docs/t-sql/statements/create-database-scoped-credential-transact-sql.md
+++ b/docs/t-sql/statements/create-database-scoped-credential-transact-sql.md
@@ -131,7 +131,7 @@ CREATE DATABASE SCOPED CREDENTIAL AppCred WITH IDENTITY = 'Mary5',
 
 ### B. Creating a database scoped credential for a shared access signature
 
-The following example creates a database scoped credential that can be used to create an [external data source](../../t-sql/statements/create-external-data-source-transact-sql.md), which can do bulk operations, such as [BULK INSERT](../../t-sql/statements/bulk-insert-transact-sql.md) and [OPENROWSET](../../t-sql/functions/openrowset-transact-sql.md). Shared Access Signatures cannot be used with PolyBase in SQL Server, APS or Azure Synapse Analytics.
+The following example creates a database scoped credential that can be used to create an [external data source](../../t-sql/statements/create-external-data-source-transact-sql.md), which can do bulk operations, such as [BULK INSERT](../../t-sql/statements/bulk-insert-transact-sql.md) and [OPENROWSET](../../t-sql/functions/openrowset-transact-sql.md). Shared Access Signatures can be used with PolyBase in SQL Server, APS or Azure Synapse Analytics.
 
 ```sql
 -- Create a db master key if one does not already exist, using your own password.


### PR DESCRIPTION
typo in this document where it says, "Shared Access Signature cannot be used with Polybase." It should instead say, "Shared Access Signature can be used with Polybase."