### PR TITLE
Note about Automatic Backups Taken by Azure Service Are Only Available for Restore Operations and Cannot Be Downloaded or Accessed Directly by End Customers

### DIFF
--- a/azure-sql/database/automated-backups-overview.md
+++ b/azure-sql/database/automated-backups-overview.md
@@ -48,6 +48,8 @@ Azure SQL Database creates:
 
 The exact frequency of transaction log backups is based on the compute size and the amount of database activity. When you restore a database, the service determines which full, differential, and transaction log backups need to be restored.
 
+These automatic backups taken by the Azure service are not available for end customers to download or access directly; they can only be used for restore operations. 
+
 The Hyperscale architecture doesn't require full, differential, or log backups. To learn more, see [Hyperscale backups](hyperscale-automated-backups-overview.md). 
 
 


### PR DESCRIPTION
There is no note in the document which says those automatic backups taken by the Azure service are not available for end customers to download or access directly; they can only be used for restore operations. Which I have append in the document. 