### PR TITLE
Added missing command to SQL Server command line tools install on Linux

### DIFF
--- a/docs/linux/includes/odbc-redhat.md
+++ b/docs/linux/includes/odbc-redhat.md
@@ -56,6 +56,7 @@ Use the following steps to install the **mssql-tools18** on Red Hat Enterprise L
 
    ```bash
    echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bash_profile
+   source ~/.bash_profile
    ```
 
    To make **sqlcmd** and **bcp** accessible from the bash shell for interactive/non-login sessions, modify the `PATH` in the `~/.bashrc` file with the following command:

--- a/docs/linux/includes/odbc-sles.md
+++ b/docs/linux/includes/odbc-sles.md
@@ -59,6 +59,7 @@ Use the following steps to install the **mssql-tools18** on SUSE Linux Enterpris
 
    ```bash
    echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bash_profile
+   source ~/.bash_profile
    ```
 
    To make **sqlcmd** or **bcp** accessible from the bash shell for interactive/non-login sessions, modify the `PATH` in the `~/.bashrc` file with the following command:

--- a/docs/linux/includes/odbc-ubuntu.md
+++ b/docs/linux/includes/odbc-ubuntu.md
@@ -68,6 +68,7 @@ Use the following steps to install the **mssql-tools18** on Ubuntu.
 
    ```bash
    echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bash_profile
+   source ~/.bash_profile
    ```
 
    To make **sqlcmd** and **bcp** accessible from the bash shell for interactive/non-login sessions, modify the `PATH` in the `~/.bashrc` file with the following command:


### PR DESCRIPTION
Hello SQL Server Docs Team,

With the current steps, sqlcmd and bcp still won't resolve until either the user reconnects to the server or .bash_profile is reloaded manually by running `source ~/.bash_profile`.

Thank you,

Vlad Drumea