### PR TITLE
Update winauth-azuread-setup-incoming-trust-based-flow.md Remove-AzureADKerberosServerTrustedDomainObject is the correct name of the cmdlet

### DIFF
--- a/azure-sql/managed-instance/winauth-azuread-setup-incoming-trust-based-flow.md
+++ b/azure-sql/managed-instance/winauth-azuread-setup-incoming-trust-based-flow.md
@@ -240,7 +240,7 @@ Set-AzureAdKerberosServer -Domain $domain `
 You can remove the added Trusted Domain Object using the following command:
 
 ```powershell
-Remove-AzureADKerberosTrustedDomainObject -Domain $domain `
+Remove-AzureADKerberosServerTrustedDomainObject -Domain $domain `
    -DomainCredential $domainCred `
    -UserPrincipalName $cloudUserName
 ```


### PR DESCRIPTION
Remove-AzureADKerberosServerTrustedDomainObject is the correct name of the cmdlet


PS C:\Users\Administrator> gcm -Module AzureADHybridAuthenticationManagement |  ? {$_.Name -imatch "trusted" }

CommandType     Name                                               Version    Source                                                                                                                        
-----------     ----                                               -------    ------                                                                                                                        
Cmdlet          Remove-AzureADKerberosServerTrustedDomainObject    2.1.1.0    AzureADHybridAuthenticationManagement                                                                                         
