### PR TITLE
Changed Ubuntu 24.04 instructions for installing-the-microsoft-odbc-driver-for-sql-server.md

### DIFF
--- a/docs/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server.md
+++ b/docs/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server.md
@@ -181,10 +181,16 @@ then
     exit;
 fi
 
+# Add the signature to trust the Microsoft repo
+# For Ubuntu versions < 24.04 
 curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc
+# For Ubuntu versions >= 24.04
+curl https://packages.microsoft.com/keys/microsoft.asc | sudo gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
 
+# Add repo to apt sources
 curl https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
 
+# Install the driver
 sudo apt-get update
 sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18
 # optional: for bcp and sqlcmd


### PR DESCRIPTION
Added instructions for installation on Ubuntu 24.04 since apt changed the way it verifies signatures.

Found this solution in a similar post and accepted PR for Debian. (https://learn.microsoft.com/en-us/answers/questions/1328834/debian-12-public-key-is-not-available)

Without the fix, the `apt-get update` step errors with `E: The repository 'https://packages.microsoft.com/ubuntu/24.04/prod noble InRelease' is not signed.`