### PR TITLE
Update use-the-system-health-session.md

### DIFF
--- a/docs/relational-databases/extended-events/use-the-system-health-session.md
+++ b/docs/relational-databases/extended-events/use-the-system-health-session.md
@@ -47,7 +47,7 @@ The session collects information that includes the following information:
 
 ## View the system_health session data
 
-The session uses both the ring buffer target and event file target to store the data. The event file target is configured with a maximum size of 5 MB and a file retention policy of 4 files.
+The session uses both the ring buffer target and event file target to store the data. The event file target is configured with a maximum size of 100 MB and a file retention policy of 10 files.
 
 To view the session data from the ring buffer target with the Extended Events user interface available in [!INCLUDE [ssManStudioFull](../../includes/ssmanstudiofull-md.md)], see [Advanced Viewing of Target Data from Extended Events in SQL Server - Watch live data](../../relational-databases/extended-events/advanced-viewing-of-target-data-from-extended-events-in-sql-server.md#watch-live-data).
 

--- a/docs/relational-databases/extended-events/use-the-system-health-session.md
+++ b/docs/relational-databases/extended-events/use-the-system-health-session.md
@@ -4,7 +4,7 @@ description: The system_health Extended Events session is included with SQL Serv
 author: WilliamDAssafMSFT
 ms.author: wiassaf
 ms.reviewer: randolphwest
-ms.date: 10/22/2023
+ms.date: 09/05/2024
 ms.service: sql
 ms.subservice: xevents
 ms.topic: tutorial
@@ -47,7 +47,7 @@ The session collects information that includes the following information:
 
 ## View the system_health session data
 
-The session uses both the ring buffer target and event file target to store the data. The event file target is configured with a maximum size of 100 MB and a file retention policy of 10 files.
+The session uses both the ring buffer target and event file target to store the data. The event file target is configured with a maximum size of 5 MB and a file retention policy of 4 files. In SQL Server Standard or Enterprise editions, the event file target has increased limits: a maximum size of 100 MB and a file retention policy of 10 files.
 
 To view the session data from the ring buffer target with the Extended Events user interface available in [!INCLUDE [ssManStudioFull](../../includes/ssmanstudiofull-md.md)], see [Advanced Viewing of Target Data from Extended Events in SQL Server - Watch live data](../../relational-databases/extended-events/advanced-viewing-of-target-data-from-extended-events-in-sql-server.md#watch-live-data).
 

--- a/docs/relational-databases/extended-events/use-the-system-health-session.md
+++ b/docs/relational-databases/extended-events/use-the-system-health-session.md
@@ -3,8 +3,8 @@ title: Use the system_health session
 description: The system_health Extended Events session is included with SQL Server. This session collects system data to troubleshoot database engine performance.
 author: WilliamDAssafMSFT
 ms.author: wiassaf
-ms.reviewer: randolphwest
-ms.date: 09/05/2024
+ms.reviewer: randolphwest, dimitri-furman
+ms.date: 07/16/2025
 ms.service: sql
 ms.subservice: xevents
 ms.topic: tutorial

--- a/docs/relational-databases/extended-events/use-the-system-health-session.md
+++ b/docs/relational-databases/extended-events/use-the-system-health-session.md
@@ -47,7 +47,7 @@ The session collects information that includes the following information:
 
 ## View the system_health session data
 
-The session uses both the ring buffer target and event file target to store the data. The event file target is configured with a maximum size of 5 MB and a file retention policy of 4 files. In SQL Server Standard or Enterprise editions, the event file target has increased limits: a maximum size of 100 MB and a file retention policy of 10 files.
+The session uses both the ring buffer target and event file target to store the data. The event file target is configured with a maximum size of 5 MB and a file retention policy of 4 files. In SQL Server Standard and Enterprise editions, the event file target has increased limits: a maximum size of 100 MB and a file retention policy of 10 files.
 
 To view the session data from the ring buffer target with the Extended Events user interface available in [!INCLUDE [ssManStudioFull](../../includes/ssmanstudiofull-md.md)], see [Advanced Viewing of Target Data from Extended Events in SQL Server - Watch live data](../../relational-databases/extended-events/advanced-viewing-of-target-data-from-extended-events-in-sql-server.md#watch-live-data).
 

--- a/docs/relational-databases/extended-events/use-the-system-health-session.md
+++ b/docs/relational-databases/extended-events/use-the-system-health-session.md
@@ -3,7 +3,7 @@ title: Use the system_health session
 description: The system_health Extended Events session is included with SQL Server. This session collects system data to troubleshoot database engine performance.
 author: WilliamDAssafMSFT
 ms.author: wiassaf
-ms.reviewer: randolphwest, dimitri-furman
+ms.reviewer: randolphwest, dfurman
 ms.date: 07/16/2025
 ms.service: sql
 ms.subservice: xevents


### PR DESCRIPTION
The system_health Extended Events session keeps ten files with a maximum size of 100 MB. You can confirm this by looking at GUI properties or scripting the definition.

`ADD TARGET package0.event_file(SET filename=N'system_health.xel',max_file_size=(100),max_rollover_files=(10)),`