### PR TITLE
update cmdlet from `Get-WmiObject` to `Get-CimInstance`

### DIFF
--- a/docs/sql-server/compute-capacity-limits-by-edition-of-sql-server.md
+++ b/docs/sql-server/compute-capacity-limits-by-edition-of-sql-server.md
@@ -84,7 +84,7 @@ You can reduce the logical core count per NUMA node in an [Azure Virtual Machine
 1. Check the number of logical cores. SMT is enabled if the ratio is 2:1 (the number of logical cores is twice the number of cores).
 
    ```powershell
-   Get-WmiObject -class win32_processor | Select-Object -Property "NumberOfCores", "NumberOfLogicalProcessors"
+   Get-CimInstance -ClassName Win32_Processor | Select-Object -Property "NumberOfCores", "NumberOfLogicalProcessors"
    ```
 
 1. Disable SMT with the following two registry changes, then reboot the VM.
@@ -97,7 +97,7 @@ You can reduce the logical core count per NUMA node in an [Azure Virtual Machine
 1. Check the number of logical cores once again. The number of logical cores should match the number of cores.
 
    ```powershell
-   Get-WmiObject -class win32_processor | Select-Object -Property "NumberOfCores", "NumberOfLogicalProcessors"
+   Get-CimInstance -ClassName Win32_Processor | Select-Object -Property "NumberOfCores", "NumberOfLogicalProcessors"
    ```
 
 ### Reduce logical core count on bare-metal instances


### PR DESCRIPTION
`Get-WmiObject` has been deprecated. using this cmdlet will give you an error in powershell core and powershell 7. Error below:

```
Get-WmiObject: The term 'Get-WmiObject' is not recognized as a name of a cmdlet, function, script file, or executable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.