### PR TITLE
Azure database status is 'Online' when its 'Paused'

### DIFF
--- a/azure-sql/database/serverless-tier-overview.md
+++ b/azure-sql/database/serverless-tier-overview.md
@@ -118,7 +118,7 @@ In the Hyperscale service tier for both serverless and provisioned compute tiers
 
 Currently, serverless auto-pausing and auto-resuming are only supported in the General Purpose tier.
 
-### <a id="auto-pausing"></a> Auto-pause
+### <a id="auto-pausing"></a> ~~Auto-pause~~
 
 Auto-pausing is triggered if all of the following conditions are true during the auto-pause delay:
 


### PR DESCRIPTION
The changes in this PR are primarily to bring attention to the issue at hand.

The core problem appears to be related to Azure Status handling. I have a database 'TestDB' set with an auto-pause delay for testing different statuses. In the SQL Databases section, the status is shown as 'Paused'

![testDB](https://github.com/user-attachments/assets/e5b799ef-f640-450d-ba18-5be7a2e545da)

However, when querying the same database in Azure Resource Graph Explorer, the status is returned as 'Online', which is also the status reflected in my application. This discrepancy indicates some inconsistencies in how the status is being reported.

![ql](https://github.com/user-attachments/assets/0ebc47c1-57bc-415e-aeaa-402f2b8847df)

UPD: after a while (like 6-8 hours) status polled as paused
 