### PR TITLE
Update backup-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/backup-transact-sql.md
+++ b/docs/t-sql/statements/backup-transact-sql.md
@@ -811,7 +811,7 @@ Starting with [!INCLUDE [sql-server-2019](../../includes/sssql19-md.md)] CU5, se
 >
 > - When the database has multiple data files created, it uses `MAXTRANSFERSIZE` > 64K.
 > - When performing backup to URL to Azure Blob Storage, the default `MAXTRANSFERSIZE = 1048576` (1 MB).
-> - When perfomring backup to URL to S3-compatible object sotrage, the default `MAXTRANSFERSIZE = 10485760` (10 MB).
+> - When performing backup to URL to S3-compatible object storage, the default `MAXTRANSFERSIZE = 10485760` (10 MB).
 >
 > Even if one of these conditions applies, you must explicitly set `MAXTRANSFERSIZE` greater than 64K in your backup command in order to get the optimized backup compression algorithm, unless you are on [!INCLUDE [sql-server-2019](../../includes/sssql19-md.md)] CU5 or later.
 


### PR DESCRIPTION
Fix spelling mistakes.
- Change perfomring to performing.
- Change sotrage to storage.

I thought the 10 MB MaxTransferSize may have been a typo due to a 4 MB max mentioned earlier in the [article](https://learn.microsoft.com/en-us/sql/t-sql/statements/backup-transact-sql?view=sql-server-ver15#maxtransfersize---maxtransfersize---maxtransfersize_variable-), but [this article](https://learn.microsoft.com/en-us/sql/relational-databases/backup-restore/sql-server-backup-to-url-s3-compatible-object-storage?view=sql-server-ver16#part-numbers-and-file-size-limitations) confirms the 10 MB. Rewording the 4 MB max should be considered.