### PR TITLE
Update pre-post-deployment-scripts.md

### DIFF
--- a/docs/tools/sql-database-projects/concepts/pre-post-deployment-scripts.md
+++ b/docs/tools/sql-database-projects/concepts/pre-post-deployment-scripts.md
@@ -51,8 +51,8 @@ Those files should be excluded from the database model build by setting the `Bui
 ```xml
 ...
   <ItemGroup>
-    <None Include="scripts\script1.sql" />
-    <None Include="scripts\script2.sql" />
+    <Build Remove="scripts\script1.sql" />
+    <Build Remove="scripts\script2.sql" />
   </ItemGroup>
 </Project>
 ```


### PR DESCRIPTION
This pull request updates the documentation to reflect changes in how certain SQL scripts are excluded from the database model build.

Documentation updates:

* [`docs/tools/sql-database-projects/concepts/pre-post-deployment-scripts.md`](diffhunk://#diff-9b2d3aef5d71ff797d4707fd4e6cbfed284407e1a3ecf1d3c789cb00de521b23L54-R55): Changed the XML configuration to use the `Build` element with the `Remove` attribute instead of `None` to exclude `scripts\script1.sql` and `scripts\script2.sql` from the database model build.