### PR TITLE
Update replication-log-reader-agent.md

### DIFF
--- a/docs/relational-databases/replication/agents/replication-log-reader-agent.md
+++ b/docs/relational-databases/replication/agents/replication-log-reader-agent.md
@@ -135,7 +135,7 @@ logread [-?]
 > **MaxCmdsInTran** was not designed to be always turned on. It exists to work around cases where someone accidentally performed a large number of DML operations in a single transaction (causing a delay in the distribution of commands until the entire transaction is in the distribution database, locks being held, etc.). If you routinely fall into this situation,review your applications and find ways to reduce the transaction size.  
 
 > [!WARNING]  
-> **MaxCmdsInTran** is not supported if the given publication database is enabled for both Change Data Capture and replication. Using **MaxCmdsInTran** in this configuration may lead to data loss in CDC change tables. It may also cause PK errors if the **MaxCmdsInTran** parameter is added and removed while replicating a large Transaction.
+> Primary key errors may occur if the **MaxCmdsInTran** parameter is added and removed while replicating a large Transaction. **MaxCmdsInTran** is not supported if the given publication database is enabled for both Change Data Capture and replication. Using **MaxCmdsInTran** in this configuration may lead to data loss in CDC change tables. 
   
  **-MessageInterval** _message_interval_  
  Is the time interval used for history logging. A history event is logged when the **MessageInterval** value is reached after the last history event is logged.  


### PR DESCRIPTION
Updating the "maxcmdsintran" warning to be clearer in that primary key errors can occur when modifying it under any circumstance, not just w/CDC.