### PR TITLE
Update sys-fn-xe-file-target-read-file-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-functions/sys-fn-xe-file-target-read-file-transact-sql.md
+++ b/docs/relational-databases/system-functions/sys-fn-xe-file-target-read-file-transact-sql.md
@@ -117,7 +117,7 @@ In [!INCLUDE [sssql17](../../includes/sssql17-md.md)] and later versions, the fo
 ```sql
 SELECT *
 FROM sys.fn_xe_file_target_read_file('system_health*.xel', NULL, NULL, NULL)
-WHERE timestamp_utc > DATEADD(DAY, -1, GETUTCDATE());
+WHERE cast(timestamp_utc as datetime2(7)) > DATEADD(DAY, -1, GETUTCDATE());
 ```
 
 ## Related content

--- a/docs/relational-databases/system-functions/sys-fn-xe-file-target-read-file-transact-sql.md
+++ b/docs/relational-databases/system-functions/sys-fn-xe-file-target-read-file-transact-sql.md
@@ -117,7 +117,7 @@ In [!INCLUDE [sssql17](../../includes/sssql17-md.md)] and later versions, the fo
 ```sql
 SELECT *
 FROM sys.fn_xe_file_target_read_file('system_health*.xel', NULL, NULL, NULL)
-WHERE cast(timestamp_utc as datetime2(7)) > DATEADD(DAY, -1, GETUTCDATE());
+WHERE CAST(timestamp_utc AS DATETIME2(7)) > DATEADD(DAY, -1, GETUTCDATE());
 ```
 
 ## Related content


### PR DESCRIPTION
This CAST was erroneously removed in a previous PR.

It shouldn't be needed - but currently is for the reasons in this bug. (Perhaps should also have some explanatory text about _why_ it is needed)

https://feedback.azure.com/d365community/idea/5f8e52d6-f3d2-ec11-a81b-6045bd7ac9f9 

Also see https://dba.stackexchange.com/questions/323147/why-does-sys-fn-xe-file-target-read-file-require-an-explicit-cast-on-datetime2-c/323151#323151