### PR TITLE
Update connectivity-settings.md

### DIFF
--- a/azure-sql/database/connectivity-settings.md
+++ b/azure-sql/database/connectivity-settings.md
@@ -6,7 +6,7 @@ author: rohitnayakmsft
 ms.author: rohitna
 ms.reviewer: wiassaf, mathoma, vanto
 ms.service: azure-sql-database
-ms.date: 09/13/2024
+ms.date: 10/24/2024
 ms.subservice: connect
 ms.topic: how-to
 ms.custom:
@@ -115,7 +115,7 @@ Ensure that **Public network access** is set to **Selected networks** to be able
 
 The minimum [Transport Layer Security (TLS)](https://support.microsoft.com/help/3135244/tls-1-2-support-for-microsoft-sql-server) version setting allows customers to choose which version of TLS their SQL database uses. It's possible to change the minimum TLS version by using the Azure portal, Azure PowerShell, and the Azure CLI.
 
-Currently, Azure SQL Database supports TLS 1.0, 1.1, 1.2, and 1.3. Setting a minimum TLS version ensures that newer TLS versions are supported. For example, choosing a TLS version 1.1 means only connections with TLS 1.1 and 1.2 are accepted, and connections with TLS 1.0 are rejected. After you test to confirm that your applications support it, we recommend setting the minimal TLS version to 1.2. This version includes fixes for vulnerabilities in previous versions and is the highest version of TLS that's supported in Azure SQL Database.
+Currently, Azure SQL Database and dedicated SQL pools (formerly SQL DW) support TLS 1.0, 1.1, 1.2, and 1.3. Starting November 2024, it will only support TLS 1.2 and 1.3. For more information, see [TLS 1.0 and 1.1 deprecation](https://azure.microsoft.com/en-us/updates/azure-support-tls-will-end-by-31-october-2024-2/). Setting a minimum TLS version ensures that newer TLS versions are supported. For example, choosing a TLS version 1.2 means only connections with TLS 1.2 and 1.3 are accepted, and connections with TLS 1.1 are rejected. After you test to confirm that your applications support it, we recommend setting the minimal TLS version to 1.2. This version includes fixes for vulnerabilities in previous versions and is the highest version of TLS that's supported in Azure SQL Database.
 
 ### Upcoming retirement changes 
 


### PR DESCRIPTION
I am suggesting these modifications to ensure maximum clarity regarding the end of support for TLS 1.0 and 1.1.  

The section "### Upcoming retirement changes" already mentions the end of support; however, the section "## Minimum TLS version" is the header, and it deserves emphasis on the end of support, as well as the removal of any references to the previous TLS versions.