### PR TITLE
Add support for url in sp_addsubscription backupdevicetype

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-addsubscription-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-addsubscription-transact-sql.md
@@ -278,7 +278,7 @@ Specifies the type of backup device used when initializing a Subscriber from a b
 | `logical` (default) | The backup device is a logical device |
 | `disk` | The backup device is disk drive |
 | `tape` | The backup device is a tape drive |
-| `url` | The backup device is a url |
+| `url` | The backup device is a URL |
 
 *@backupdevicetype* is only used when *@sync_method* is set to initialize_with_backup.
 

--- a/docs/relational-databases/system-stored-procedures/sp-addsubscription-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-addsubscription-transact-sql.md
@@ -278,6 +278,7 @@ Specifies the type of backup device used when initializing a Subscriber from a b
 | `logical` (default) | The backup device is a logical device |
 | `disk` | The backup device is disk drive |
 | `tape` | The backup device is a tape drive |
+| `url` | The backup device is a url |
 
 *@backupdevicetype* is only used when *@sync_method* is set to initialize_with_backup.
 


### PR DESCRIPTION
The stored procedure sp_addsubscription, when using @sync_type = "initialize with backup", supports setting @backupdevicetype to "url".

While migrating our backups to S3-compatible storage, we initially referred to the documentation, which seemed to indicate that the url type was unsupported, leading us to consider some workarounds. However, upon testing with @backupdevicetype = "url", the subscription functioned as expected.