### PR TITLE
Clarification for standalone DBs and line wrap

### DIFF
--- a/docs/relational-databases/system-functions/sys-fn-hadr-backup-is-preferred-replica-transact-sql.md
+++ b/docs/relational-databases/system-functions/sys-fn-hadr-backup-is-preferred-replica-transact-sql.md
@@ -38,6 +38,9 @@ sys.fn_hadr_backup_is_preferred_replica ( 'dbname' )
   
 ## Returns  
  Returns data type **bool**: 1 if the database on the current instance is on the preferred replica, otherwise 0.  
+
+> [!NOTE]  
+> For databases that are not part of an AG, this function alsways returns 1.
   
 ## Remarks  
  Use this function in a backup script to determine if the current database is on the replica that is preferred for backups. You can run a script on every availability replica. Each of these jobs looks at the same data to determine which job should run, so only one of the scheduled jobs actually proceeds to the backup stage. Sample code could be similar to the following.  
@@ -71,6 +74,7 @@ GO
  [Always On Availability Groups &#40;SQL Server&#41;](../../database-engine/availability-groups/windows/overview-of-always-on-availability-groups-sql-server.md)   
  [CREATE AVAILABILITY GROUP &#40;Transact-SQL&#41;](../../t-sql/statements/create-availability-group-transact-sql.md)   
  [ALTER AVAILABILITY GROUP &#40;Transact-SQL&#41;](../../t-sql/statements/alter-availability-group-transact-sql.md)   
- [Active Secondaries: Backup on Secondary Replicas &#40;Always On Availability Groups&#41;](../../database-engine/availability-groups/windows/active-secondaries-backup-on-secondary-replicas-always-on-availability-groups.md)    [Always On Availability Groups Catalog Views &#40;Transact-SQL&#41;](../../relational-databases/system-catalog-views/always-on-availability-groups-catalog-views-transact-sql.md)  
+ [Active Secondaries: Backup on Secondary Replicas &#40;Always On Availability Groups&#41;](../../database-engine/availability-groups/windows/active-secondaries-backup-on-secondary-replicas-always-on-availability-groups.md)    
+ [Always On Availability Groups Catalog Views &#40;Transact-SQL&#41;](../../relational-databases/system-catalog-views/always-on-availability-groups-catalog-views-transact-sql.md)  
   
   


### PR DESCRIPTION
I considered adding the note to point out that this also applies for contained AGs, but this I consider a bug and that means it probably does not belong here(?)