### PR TITLE
Removing incorrect owner info

### DIFF
--- a/docs/includes/msdb-execute-permissions.md
+++ b/docs/includes/msdb-execute-permissions.md
@@ -6,4 +6,4 @@ ms.service: sql
 ms.topic: include
 ms.custom: include file
 ---
-You can grant the `EXECUTE` permissions on this procedure, but these permissions may be overridden during a SQL Server upgrade.
+You can grant `EXECUTE` permissions on this procedure, but these permissions can be overridden during a SQL Server upgrade.

--- a/docs/includes/msdb-execute-permissions.md
+++ b/docs/includes/msdb-execute-permissions.md
@@ -6,4 +6,4 @@ ms.service: sql
 ms.topic: include
 ms.custom: include file
 ---
-This stored procedure is owned by the **db_owner** role. You can grant `EXECUTE` permissions for any user, but these permissions may be overridden during a SQL Server upgrade.
+You can grant the `EXECUTE` permissions on this procedure, but these permissions may be overridden during a SQL Server upgrade.


### PR DESCRIPTION
All SQL Agent procs except for the new "managed backup" and "smart admin" stuff are owned by the dbo. Not db_owner.  Also, I don't see why this needs to be documented at all, since this has no effect on the behavior/permissions. Hence, I suggest removing to simplify this