### PR TITLE
AUDIT_GUID - Availability Group scenario

### DIFF
--- a/docs/t-sql/statements/create-server-audit-transact-sql.md
+++ b/docs/t-sql/statements/create-server-audit-transact-sql.md
@@ -133,7 +133,7 @@ Database actions fail if they cause audited events. Actions, which don't cause a
 
 #### AUDIT_GUID = *uniqueidentifier*
 
-To support scenarios such as database mirroring, an audit needs a specific GUID that matches the GUID found in the mirrored database. The GUID can't be modified after the audit is created.
+To support scenarios such as database mirroring or where databases are participating in an Always On Availabiltiy Group, an audit needs a specific GUID that matches the GUID found in the mirrored database. The GUID can't be modified after the audit is created.
 
 #### OPERATOR_AUDIT
 

--- a/docs/t-sql/statements/create-server-audit-transact-sql.md
+++ b/docs/t-sql/statements/create-server-audit-transact-sql.md
@@ -133,7 +133,7 @@ Database actions fail if they cause audited events. Actions, which don't cause a
 
 #### AUDIT_GUID = *uniqueidentifier*
 
-To support scenarios such as database mirroring or where databases are participating in an Always On Availabiltiy Group, an audit needs a specific GUID that matches the GUID found in the mirrored database. The GUID can't be modified after the audit is created.
+To support scenarios such as database mirroring or databases participating in an Always On availability group, an audit needs a specific GUID that matches the GUID found in the mirrored database. The GUID can't be modified after the audit is created.
 
 #### OPERATOR_AUDIT
 


### PR DESCRIPTION
Whilst database mirroring is one of the underlying technologies used in Availability Groups, highlighting this for others that may not realise.