### PR TITLE
Update sql-machine-learning-services-windows-install-sql-2022.md

### DIFF
--- a/docs/machine-learning/install/sql-machine-learning-services-windows-install-sql-2022.md
+++ b/docs/machine-learning/install/sql-machine-learning-services-windows-install-sql-2022.md
@@ -143,7 +143,7 @@ Beginning with [!INCLUDE [sssql22-md](../../includes/sssql22-md.md)], runtimes f
 
 #### Install Python runtime
 
-1. Download the most recent version of [Python 3.10 for Windows](https://www.python.org/downloads/). Install it by using the following options:
+1. Download the most recent version of [Python 3.10 for Windows](https://www.python.org/downloads/release/python-31011/). Install it by using the following options:
     
     1. Open the Python Setup application and select **Customize installation**. 
     1. Verify that the **Install launcher for all users (recommended)** checkbox is selected.


### PR DESCRIPTION
Updating Python 3.10 link to link directly to the latest Python 3.10.11 release, instead of the python.org front page, as it's difficult for customers to find the correct downloadable and installable Python 3.10.