### PR TITLE
Update modify-or-rename-dml-triggers.md

### DIFF
--- a/docs/relational-databases/triggers/modify-or-rename-dml-triggers.md
+++ b/docs/relational-databases/triggers/modify-or-rename-dml-triggers.md
@@ -97,7 +97,7 @@ To alter a DML trigger requires `ALTER` permission on the table or view on which
       GO
       ```
 
-### Rename a trigger using DROP TRIGGER and ALTER TRIGGER
+### Rename a trigger using DROP TRIGGER and CREATE TRIGGER
 
 1. Connect to the [!INCLUDE [ssDE](../../includes/ssde-md.md)].
 


### PR DESCRIPTION
The heading **"Rename a trigger using DROP TRIGGER and ALTER TRIGGER"** was incorrect. Just proposing to replace **ALTER** with **CREATE**