### PR TITLE
Update alter-database-scoped-configuration-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/alter-database-scoped-configuration-transact-sql.md
+++ b/docs/t-sql/statements/alter-database-scoped-configuration-transact-sql.md
@@ -453,7 +453,7 @@ Sets [!INCLUDE [tsql](../../includes/tsql-md.md)] and query processing behaviors
 
 #### EXEC_QUERY_STATS_FOR_SCALAR_FUNCTIONS = { ON | OFF }
 
-**Applies to:** (Starting with [!INCLUDE [sql-server-2022](../../includes/sssql22-md.md)]), [!INCLUDE [ssazure-sqldb](../../includes/ssazure-sqldb.md)] and [!INCLUDE [ssazuremi](../../includes/ssazuremi-md.md)]
+**Applies to:** [!INCLUDE [sql-server-2022](../../includes/sssql22-md.md)] and later versions, [!INCLUDE [ssazure-sqldb](../../includes/ssazure-sqldb.md)], and [!INCLUDE [ssazuremi](../../includes/ssazuremi-md.md)]
 
 Allows you to control whether execution statistics for scalar user-defined functions (UDF) appear in the [sys.dm_exec_function_stats](../../relational-databases/system-dynamic-management-views/sys-dm-exec-function-stats-transact-sql.md) system view. For some intensive workloads that are scalar UDF-heavy, collecting function execution statistics might cause a noticeable performance overhead. This can be avoided by setting the `EXEC_QUERY_STATS_FOR_SCALAR_FUNCTIONS` database-scoped configuration to `OFF`.  The default is **ON**. 
 

--- a/docs/t-sql/statements/alter-database-scoped-configuration-transact-sql.md
+++ b/docs/t-sql/statements/alter-database-scoped-configuration-transact-sql.md
@@ -453,7 +453,7 @@ Sets [!INCLUDE [tsql](../../includes/tsql-md.md)] and query processing behaviors
 
 #### EXEC_QUERY_STATS_FOR_SCALAR_FUNCTIONS = { ON | OFF }
 
-**Applies to:** [!INCLUDE [ssazure-sqldb](../../includes/ssazure-sqldb.md)] and [!INCLUDE [ssazuremi](../../includes/ssazuremi-md.md)]
+**Applies to:** (Starting with [!INCLUDE [sql-server-2022](../../includes/sssql22-md.md)]), [!INCLUDE [ssazure-sqldb](../../includes/ssazure-sqldb.md)] and [!INCLUDE [ssazuremi](../../includes/ssazuremi-md.md)]
 
 Allows you to control whether execution statistics for scalar user-defined functions (UDF) appear in the [sys.dm_exec_function_stats](../../relational-databases/system-dynamic-management-views/sys-dm-exec-function-stats-transact-sql.md) system view. For some intensive workloads that are scalar UDF-heavy, collecting function execution statistics might cause a noticeable performance overhead. This can be avoided by setting the `EXEC_QUERY_STATS_FOR_SCALAR_FUNCTIONS` database-scoped configuration to `OFF`.  The default is **ON**. 
 


### PR DESCRIPTION
I noted that EXEC_QUERY_STATS_FOR_SCALAR_FUNCTIONS is also supported in SQL 2022, and not only in the cloud offerings.