### PR TITLE
Update configure-sql-server-encryption.md

### DIFF
--- a/docs/database-engine/configure-windows/configure-sql-server-encryption.md
+++ b/docs/database-engine/configure-windows/configure-sql-server-encryption.md
@@ -155,7 +155,8 @@ USE [master];
 GO
 
 SELECT DISTINCT (encrypt_option)
-FROM sys.dm_exec_connections;
+FROM sys.dm_exec_connections
+WHERE net_transport <> 'Shared memory';
 GO
 ```
 


### PR DESCRIPTION
I think this SQL example needs to be qualified.  Shared Memory connections do not need to be encrypted.  Just the TCP connections usually.