### PR TITLE
Update create-database-transact-sql.md: MAXSIZE warning

### DIFF
--- a/docs/t-sql/statements/create-database-transact-sql.md
+++ b/docs/t-sql/statements/create-database-transact-sql.md
@@ -1364,6 +1364,7 @@ CREATE DATABASE database_name [ COLLATE collation_name ]
 ```
 > [!IMPORTANT]
 > To add files or set containment for a database in a managed instance, use the [ALTER DATABASE](alter-database-transact-sql.md?tabs=sqldbmi) statement.
+> For managed instances, the initial MAXSIZE is implicitly set to the current disk size, and it doesn't change automatically when you extend the disk size from the Azure portal. After extending the disk, you should also extend MAXSIZE by [ALTER DATABASE](alter-database-transact-sql.md?tabs=sqldbmi) to avoid database file full errors.
 
 ## Arguments
 

--- a/docs/t-sql/statements/create-database-transact-sql.md
+++ b/docs/t-sql/statements/create-database-transact-sql.md
@@ -1364,7 +1364,8 @@ CREATE DATABASE database_name [ COLLATE collation_name ]
 ```
 > [!IMPORTANT]
 > To add files or set containment for a database in a managed instance, use the [ALTER DATABASE](alter-database-transact-sql.md?tabs=sqldbmi) statement.
-> For managed instances, the initial MAXSIZE is implicitly set to the current disk size, and it doesn't change automatically when you extend the disk size from the Azure portal. After extending the disk, you should also extend MAXSIZE by [ALTER DATABASE](alter-database-transact-sql.md?tabs=sqldbmi) to avoid database file full errors.
+>
+> For SQL managed instances, the initial MAXSIZE is implicitly set to the current disk size, and it doesn't change automatically when you extend the disk size from the Azure portal. After extending the disk, you should also extend MAXSIZE with [ALTER DATABASE](alter-database-transact-sql.md?tabs=sqldbmi) to avoid database file full errors.
 
 ## Arguments
 


### PR DESCRIPTION
My customer experienced 'file full error' even after she extended the disk from Azure portal. This was because she didn't notice the MAXSIZE was initially set to the previous disk size.