### PR TITLE
Update sp-configure-automatic-tuning-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-configure-automatic-tuning-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-configure-automatic-tuning-transact-sql.md
@@ -97,7 +97,7 @@ For [!INCLUDE [ssSQL22](../../includes/sssql22-md.md)] CU 4 and later versions, 
 The following example shows how to configure automatic tuning to ignore a query if it's eligible for automatic plan forcing. This example uses a value of `422` as the `query_id` that was selected from the Query Store.
 
 ```sql
-EXECUTE sys.sp_configure_automatic_tuning 'FORCE_LAST_GOOD_PLAN', 'QUERY', 422, 'ON';
+EXECUTE sys.sp_configure_automatic_tuning 'FORCE_LAST_GOOD_PLAN', 'QUERY', 422, 'OFF';
 ```
 
 ### B. Configure the Automatic Tuning (Force Last Good Plan option) to ignore a specific query using named parameters


### PR DESCRIPTION
I believe that "OFF"=ignore and that this example is backwards. The example right below it uses OFF =ignore, so it's confusing that they are opposite.