### PR TITLE
Update sys-dm-os-volume-stats-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-os-volume-stats-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-os-volume-stats-transact-sql.md
@@ -83,7 +83,7 @@ CROSS APPLY sys.dm_os_volume_stats(f.database_id, f.file_id);
 ```sql  
 SELECT database_id, f.file_id, volume_mount_point, total_bytes, available_bytes  
 FROM sys.database_files AS f  
-CROSS APPLY sys.dm_os_volume_stats(DB_ID(f.name), f.file_id);  
+CROSS APPLY sys.dm_os_volume_stats(DB_ID(), f.file_id);  
 ```  
   
 ## See also  


### PR DESCRIPTION
The query for example B is incorrect

B. Return total space and available space for the current database

SELECT database_id, f.file_id, volume_mount_point, total_bytes, available_bytes   FROM sys.database_files AS f  
CROSS APPLY sys.dm_os_volume_stats(DB_ID(f.name), f.file_id) ;  


It should read

SELECT database_id, f.file_id, volume_mount_point, total_bytes, available_bytes   FROM sys.database_files AS f  
CROSS APPLY sys.dm_os_volume_stats(DB_ID(), f.file_id);  


There are a couple of issues with the original query:-

1) To get database_id all that is needed is
DB_ID().  The current parameter DB_ID(f.name) is incorrect

2) The return set also skips log files