### PR TITLE
move the block comment inside the stored proc.

### DIFF
--- a/docs/relational-databases/stored-procedures/create-a-stored-procedure.md
+++ b/docs/relational-databases/stored-procedures/create-a-stored-procedure.md
@@ -3,7 +3,7 @@ title: Create a stored procedure
 description: Learn how to create a Transact-SQL stored procedure by using SQL Server Management Studio and by using the Transact-SQL CREATE PROCEDURE statement.
 author: WilliamDAssafMSFT
 ms.author: wiassaf
-ms.date: 01/25/2024
+ms.date: 01/22/2025
 ms.service: sql
 ms.subservice: stored-procedures
 ms.topic: quickstart

--- a/docs/relational-databases/stored-procedures/create-a-stored-procedure.md
+++ b/docs/relational-databases/stored-procedures/create-a-stored-procedure.md
@@ -84,11 +84,7 @@ To create a stored procedure in SSMS:
    GO
    SET QUOTED_IDENTIFIER ON
    GO
-   -- =============================================
-   -- Author:      My Name
-   -- Create Date: 01/23/2024
-   -- Description: Returns the customer's company name.
-   -- =============================================
+ 
    CREATE PROCEDURE SalesLT.uspGetCustomerCompany
    (
        -- Add the parameters for the stored procedure here
@@ -96,6 +92,13 @@ To create a stored procedure in SSMS:
        @FirstName nvarchar(50) = NULL
    )
    AS
+   /*
+   -- =============================================
+   -- Author:      My Name
+   -- Create Date: 01/23/2024
+   -- Description: Returns the customer's company name.
+   -- =============================================
+   */
    BEGIN
        -- SET NOCOUNT ON added to prevent extra result sets from
        -- interfering with SELECT statements.


### PR DESCRIPTION
It is very tough to troubleshoot when the block comment is outside the stored procedure, especially when running it with DMV. We want to make sure that st.text gets the stored procedure name first before the comment block. If the comment is not placed inside, you have to expand the column to get to the stored procedure name, which complicates troubleshooting. Typically, you add a substring on st.text to get only a few characters of the text, and if the comment is placed before creating the stored procedure, it results in only showing the comments. Moving all comments inside the stored procedure ensures that the stored procedure name is retrieved first, making troubleshooting more efficient.

example:

```sql
SELECT SUBSTRING(st.text,1, 200)
FROM sys.dm_exec_query_stats wq
OUTER APPLY sys.dm_exec_query_plan(wq.plan_handle) AS qp
OUTER APPLY sys.dm_exec_sql_text(wq.plan_handle) AS st;
```