### PR TITLE
Fix mangled code blocks

### DIFF
--- a/docs/mdx/avg-mdx.md
+++ b/docs/mdx/avg-mdx.md
@@ -47,79 +47,49 @@ Avg( Set_Expression [ , Numeric_Expression ] )
 ## Examples  
  The following example returns the average for a measure over a specified set. Notice that the specified measure can be either the default measure for the members of the specified set or a specified measure.  
   
- `WITH SET [NW Region] AS`  
-  
- `{[Geography].[State-Province].[Washington]`  
-  
- `, [Geography].[State-Province].[Oregon]`  
-  
- `, [Geography].[State-Province].[Idaho]}`  
-  
- `MEMBER [Geography].[Geography].[NW Region Avg] AS`  
-  
- `AVG ([NW Region]`  
-  
- `--Uncomment the line below to get an average by Reseller Gross Profit Margin`  
-  
- `--otherwise the average will be by whatever the default measure is in the cube,`  
-  
- `--or whatever measure is specified in the query`  
-  
- `--, [Measures].[Reseller Gross Profit Margin]`  
-  
- `)`  
-  
- `SELECT [Date].[Calendar Year].[Calendar Year].Members ON 0`  
-  
- `FROM [Adventure Works]`  
-  
- `WHERE ([Geography].[Geography].[NW Region Avg])`  
+```  
+WITH SET [NW Region] AS  
+{[Geography].[State-Province].[Washington]  
+, [Geography].[State-Province].[Oregon]  
+, [Geography].[State-Province].[Idaho]}  
+MEMBER [Geography].[Geography].[NW Region Avg] AS  
+AVG ([NW Region]  
+--Uncomment the line below to get an average by Reseller Gross Profit Margin  
+--otherwise the average will be by whatever the default measure is in the cube,  
+--or whatever measure is specified in the query  
+--, [Measures].[Reseller Gross Profit Margin]  
+)  
+SELECT [Date].[Calendar Year].[Calendar Year].Members ON 0  
+FROM [Adventure Works]  
+WHERE ([Geography].[Geography].[NW Region Avg])  
+```  
   
  The following example returns the daily average of the `Measures.[Gross Profit Margin]` measure, calculated across the days of each month in the 2003 fiscal year, from the **Adventure Works** cube. The **Avg** function calculates the average from the set of days that are contained in each month of the `[Ship Date].[Fiscal Time]` hierarchy. The first version of the calculation shows the default behavior of Avg in excluding days that did not record any sales from the average, the second version shows how to include days with no sales in the average.  
   
- `WITH MEMBER Measures.[Avg Gross Profit Margin] AS`  
-  
- `Avg(`  
-  
- `Descendants(`  
-  
- `[Ship Date].[Fiscal].CurrentMember,`  
-  
- `[Ship Date].[Fiscal].[Date]`  
-  
- `),`  
-  
- `Measures.[Gross Profit Margin]`  
-  
- `), format_String='percent'`  
-  
- `MEMBER Measures.[Avg Gross Profit Margin Including Empty Days] AS`  
-  
- `Avg(`  
-  
- `Descendants(`  
-  
- `[Ship Date].[Fiscal].CurrentMember,`  
-  
- `[Ship Date].[Fiscal].[Date]`  
-  
- `),`  
-  
- `CoalesceEmpty(Measures.[Gross Profit Margin],0)`  
-  
- `), Format_String='percent'`  
-  
- `SELECT`  
-  
- `{Measures.[Avg Gross Profit Margin],Measures.[Avg Gross Profit Margin Including Empty Days]} ON COLUMNS,`  
-  
- `[Ship Date].[Fiscal].[Fiscal Year].Members ON ROWS`  
-  
- `FROM`  
-  
- `[Adventure Works]`  
-  
- `WHERE([Product].[Product Categories].[Product].&[344])`  
+```  
+WITH MEMBER Measures.[Avg Gross Profit Margin] AS  
+Avg(  
+Descendants(  
+[Ship Date].[Fiscal].CurrentMember,  
+[Ship Date].[Fiscal].[Date]  
+),  
+Measures.[Gross Profit Margin]  
+), format_String='percent'  
+MEMBER Measures.[Avg Gross Profit Margin Including Empty Days] AS  
+Avg(  
+Descendants(  
+[Ship Date].[Fiscal].CurrentMember,  
+[Ship Date].[Fiscal].[Date]  
+),  
+CoalesceEmpty(Measures.[Gross Profit Margin],0)  
+), Format_String='percent'  
+SELECT  
+{Measures.[Avg Gross Profit Margin],Measures.[Avg Gross Profit Margin Including Empty Days]} ON COLUMNS,  
+[Ship Date].[Fiscal].[Fiscal Year].Members ON ROWS  
+FROM  
+[Adventure Works]  
+WHERE([Product].[Product Categories].[Product].&[344])  
+```  
   
  The following example returns the daily average of the `Measures.[Gross Profit Margin]` measure, calculated across the days of each semester in the 2003 fiscal year, from the **Adventure Works** cube.  
   

--- a/docs/mdx/axis-mdx.md
+++ b/docs/mdx/axis-mdx.md
@@ -35,27 +35,23 @@ Axis(Axis_Number)
 ## Examples  
  The following example query shows how to use the Axis function:  
   
- `WITH MEMBER MEASURES.AXISDEMO AS`  
-  
- `SETTOSTR(AXIS(1))`  
-  
- `SELECT MEASURES.AXISDEMO ON 0,`  
-  
- `[Date].[Calendar Year].MEMBERS ON 1`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH MEMBER MEASURES.AXISDEMO AS  
+SETTOSTR(AXIS(1))  
+SELECT MEASURES.AXISDEMO ON 0,  
+[Date].[Calendar Year].MEMBERS ON 1  
+FROM [Adventure Works]  
+```  
   
  The following example shows the use of the Axis function inside a calculated member:  
   
- `WITH MEMBER MEASURES.AXISDEMO AS`  
-  
- `SUM(AXIS(1), [Measures].[Internet Sales Amount])`  
-  
- `SELECT {[Measures].[Internet Sales Amount],MEASURES.AXISDEMO} ON 0,`  
-  
- `{[Date].[Calendar Year].&[2003], [Date].[Calendar Year].&[2004]} ON 1`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH MEMBER MEASURES.AXISDEMO AS  
+SUM(AXIS(1), [Measures].[Internet Sales Amount])  
+SELECT {[Measures].[Internet Sales Amount],MEASURES.AXISDEMO} ON 0,  
+{[Date].[Calendar Year].&[2003], [Date].[Calendar Year].&[2004]} ON 1  
+FROM [Adventure Works]  
+```  
   
 ## See Also  
  [MDX Function Reference &#40;MDX&#41;](../mdx/mdx-function-reference-mdx.md)  

--- a/docs/mdx/bottomsum-mdx.md
+++ b/docs/mdx/bottomsum-mdx.md
@@ -41,23 +41,17 @@ BottomSum(Set_Expression, Value, Numeric_Expression)
 ## Examples  
  The following example returns, for the Bike category, the smallest set of members of the City level in the Geography hierarchy in the Geography dimension for fiscal year 2003, and whose cumulative total, using the Reseller Sales Amount measure, is at least the sum of 50,000 (beginning with the members of this set with the smallest number of sales):  
   
- `SELECT`  
-  
- `[Product].[Product Categories].Bikes ON 0,`  
-  
- `BottomSum`  
-  
- `({[Geography].[Geography].[City].Members}`  
-  
- `, 50000`  
-  
- `, ([Measures].[Reseller Sales Amount],[Product].[Product Categories].Bikes)`  
-  
- `) ON 1`  
-  
- `FROM [Adventure Works]`  
-  
- `WHERE([Measures].[Reseller Sales Amount],[Date].[Fiscal].[Fiscal Year].[FY 2003])`  
+```  
+SELECT  
+[Product].[Product Categories].Bikes ON 0,  
+BottomSum  
+({[Geography].[Geography].[City].Members}  
+, 50000  
+, ([Measures].[Reseller Sales Amount],[Product].[Product Categories].Bikes)  
+) ON 1  
+FROM [Adventure Works]  
+WHERE([Measures].[Reseller Sales Amount],[Date].[Fiscal].[Fiscal Year].[FY 2003])  
+```  
   
 ## See Also  
  [MDX Function Reference &#40;MDX&#41;](../mdx/mdx-function-reference-mdx.md)  

--- a/docs/mdx/crossjoin-mdx.md
+++ b/docs/mdx/crossjoin-mdx.md
@@ -46,45 +46,32 @@ Set_Expression1 * Set_Expression2 [* ...n]
 ## Examples  
  The following query shows simple examples of the use of the Crossjoin function on the Columns and Rows axis of a query:  
   
- `SELECT`  
-  
- `[Customer].[Country].Members *`  
-  
- `[Customer].[State-Province].Members`  
-  
- `ON 0,`  
-  
- `Crossjoin(`  
-  
- `[Date].[Calendar Year].Members,`  
-  
- `[Product].[Category].[Category].Members)`  
-  
- `ON 1`  
-  
- `FROM [Adventure Works]`  
-  
- `WHERE Measures.[Internet Sales Amount]`  
+```  
+SELECT  
+[Customer].[Country].Members *  
+[Customer].[State-Province].Members  
+ON 0,  
+Crossjoin(  
+[Date].[Calendar Year].Members,  
+[Product].[Category].[Category].Members)  
+ON 1  
+FROM [Adventure Works]  
+WHERE Measures.[Internet Sales Amount]  
+```  
   
  The following example shows the automatic filtering that takes place when different hierarchies from the same dimension are crossjoined:  
   
- `SELECT`  
-  
- `Measures.[Internet Sales Amount]`  
-  
- `ON 0,`  
-  
- `//Only the dates in Calendar Years 2003 and 2004 will be returned here`  
-  
- `Crossjoin(`  
-  
- `{[Date].[Calendar Year].&[2003], [Date].[Calendar Year].&[2004]},`  
-  
- `[Date].[Date].[Date].Members)`  
-  
- `ON 1`  
-  
- `FROM [Adventure Works]`  
+```  
+SELECT  
+Measures.[Internet Sales Amount]  
+ON 0,  
+//Only the dates in Calendar Years 2003 and 2004 will be returned here  
+Crossjoin(  
+{[Date].[Calendar Year].&[2003], [Date].[Calendar Year].&[2004]},  
+[Date].[Date].[Date].Members)  
+ON 1  
+FROM [Adventure Works]  
+```  
   
  The following three examples return the same results - the Internet Sales Amount by state for states within the United States. The first two use the two cross join syntaxes and the third demonstrates the use of the WHERE clause to return the same information.  
   

--- a/docs/mdx/current-mdx.md
+++ b/docs/mdx/current-mdx.md
@@ -37,29 +37,20 @@ Set_Expression.Current
 ## Examples  
  The following example shows how to use the **Current** function inside **Generate**:  
   
- `WITH`  
-  
- `//Creates a set of tuples consisting of all Calendar Years crossjoined with`  
-  
- `//all Product Categories`  
-  
- `SET MyTuples AS CROSSJOIN(`  
-  
- `[Date].[Calendar Year].[Calendar Year].MEMBERS,`  
-  
- `[Product].[Category].[Category].MEMBERS)`  
-  
- `//Iterates through each tuple in the set and returns the name of the Calendar`  
-  
- `//Year in each tuple`  
-  
- `MEMBER MEASURES.CURRENTDEMO AS`  
-  
- `GENERATE(MyTuples, MyTuples.CURRENT.ITEM(0).NAME, ", ")`  
-  
- `SELECT MEASURES.CURRENTDEMO ON 0`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH  
+//Creates a set of tuples consisting of all Calendar Years crossjoined with  
+//all Product Categories  
+SET MyTuples AS CROSSJOIN(  
+[Date].[Calendar Year].[Calendar Year].MEMBERS,  
+[Product].[Category].[Category].MEMBERS)  
+//Iterates through each tuple in the set and returns the name of the Calendar  
+//Year in each tuple  
+MEMBER MEASURES.CURRENTDEMO AS  
+GENERATE(MyTuples, MyTuples.CURRENT.ITEM(0).NAME, ", ")  
+SELECT MEASURES.CURRENTDEMO ON 0  
+FROM [Adventure Works]  
+```  
   
 ## See Also  
  [MDX Function Reference &#40;MDX&#41;](../mdx/mdx-function-reference-mdx.md)  

--- a/docs/mdx/currentordinal-mdx.md
+++ b/docs/mdx/currentordinal-mdx.md
@@ -32,15 +32,13 @@ Set_Expression.CurrentOrdinal
 ## Examples  
  The following simple example shows how **CurrentOrdinal** can be used with **Generate** to return a string containing the name of each item in a set along with its position in the set:  
   
- `WITH SET MySet AS [Customer].[Customer Geography].[Country].MEMBERS`  
-  
- `MEMBER MEASURES.CURRENTORDINALDEMO AS`  
-  
- `GENERATE(MySet, CSTR(MySet.CURRENTORDINAL) + ") " + MySet.CURRENT.ITEM(0).NAME, ", ")`  
-  
- `SELECT MEASURES.CURRENTORDINALDEMO ON 0`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH SET MySet AS [Customer].[Customer Geography].[Country].MEMBERS  
+MEMBER MEASURES.CURRENTORDINALDEMO AS  
+GENERATE(MySet, CSTR(MySet.CURRENTORDINAL) + ") " + MySet.CURRENT.ITEM(0).NAME, ", ")  
+SELECT MEASURES.CURRENTORDINALDEMO ON 0  
+FROM [Adventure Works]  
+```  
   
  The practical use of CurrentOrdinal is limited to very complex calculations. The following example returns the number of products in the set that are unique, using the **Order** function to order the non-empty tuples before utilizing the **Filter** function. The **CurrentOrdinal** function is used to compare and eliminate ties.  
   

--- a/docs/mdx/descendants-mdx.md
+++ b/docs/mdx/descendants-mdx.md
@@ -58,31 +58,25 @@ Descendants(Set_Expression [ , Distance [ ,Desc_Flag ] ] )
   
  If no level or distance is specified, the default value for the level used by the function is determined by calling the [Level](../mdx/level-mdx.md) function (<\<Member>>.Level) for the specified member (if a member is specified) or by calling the **Level** function for each member of the specified set (if a set is specified). If no level expression, distance or flags are specified, the function performs as if the following syntax were used:  
   
- `Descendants`  
-  
- `(`  
-  
- `Member_Expression ,`  
-  
- `Member_Expression.Level ,`  
-  
- `SELF_BEFORE_AFTER`  
-  
- `)`  
+```  
+Descendants  
+(  
+Member_Expression ,  
+Member_Expression.Level ,  
+SELF_BEFORE_AFTER  
+)  
+```  
   
  If a level is specified and a description flag is not specified, the function performs as if the following syntax were used.  
   
- `Descendants`  
-  
- `(`  
-  
- `Member_Expression ,`  
-  
- `Level_Expression,`  
-  
- `SELF`  
-  
- `)`  
+```  
+Descendants  
+(  
+Member_Expression ,  
+Level_Expression,  
+SELF  
+)  
+```  
   
  By changing the value of the description flag, you can include or exclude descendants at the specified level or distance, the children before or after the specified level or distance (until the leaf node), and the leaf children regardless of the specified level or distance. The following table describes the flags allowed in the *Desc_Flag* argument.  
   

--- a/docs/mdx/distinct-mdx.md
+++ b/docs/mdx/distinct-mdx.md
@@ -32,27 +32,19 @@ Distinct(Set_Expression)
 ## Examples  
  The following example query shows how to use the Distinct function with a named set, as well as how to use it with the Count function to find the number of distinct tuples in a set:  
   
- `WITH SET MySet AS`  
-  
- `{[Customer].[Customer Geography].[Country].&[Australia],[Customer].[Customer Geography].[Country].&[Australia],`  
-  
- `[Customer].[Customer Geography].[Country].&[Canada],[Customer].[Customer Geography].[Country].&[France],`  
-  
- `[Customer].[Customer Geography].[Country].&[United Kingdom],[Customer].[Customer Geography].[Country].&[United Kingdom]}`  
-  
- `MEMBER MEASURES.SETCOUNT AS`  
-  
- `COUNT(MySet)`  
-  
- `MEMBER MEASURES.SETDISTINCTCOUNT AS`  
-  
- `COUNT(DISTINCT(MySet))`  
-  
- `SELECT {MEASURES.SETCOUNT, MEASURES.SETDISTINCTCOUNT} ON 0,`  
-  
- `DISTINCT(MySet) ON 1`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH SET MySet AS  
+{[Customer].[Customer Geography].[Country].&[Australia],[Customer].[Customer Geography].[Country].&[Australia],  
+[Customer].[Customer Geography].[Country].&[Canada],[Customer].[Customer Geography].[Country].&[France],  
+[Customer].[Customer Geography].[Country].&[United Kingdom],[Customer].[Customer Geography].[Country].&[United Kingdom]}  
+MEMBER MEASURES.SETCOUNT AS  
+COUNT(MySet)  
+MEMBER MEASURES.SETDISTINCTCOUNT AS  
+COUNT(DISTINCT(MySet))  
+SELECT {MEASURES.SETCOUNT, MEASURES.SETDISTINCTCOUNT} ON 0,  
+DISTINCT(MySet) ON 1  
+FROM [Adventure Works]  
+```  
   
 ## See Also  
  [MDX Function Reference &#40;MDX&#41;](../mdx/mdx-function-reference-mdx.md)  

--- a/docs/mdx/divide-mdx-operator-reference.md
+++ b/docs/mdx/divide-mdx-operator-reference.md
@@ -59,39 +59,25 @@ WHERE
   
  Dividing a non-zero or non-null value by zero or null will return the value Infinity, which is displayed in query results as the value "1.#INF". In most cases, you should check for division by zero to avoid this situation. The following example shows you how:  
   
- `//Returns 1.#INF when Internet Sales Amount is zero or null`  
-  
- `Member [Measures].[Reseller to Internet Ratio] AS`  
-  
- `[Measures].[Reseller Sales Amount]`  
-  
- `/`  
-  
- `[Measures].[Internet Sales Amount]`  
-  
- `//Traps the division by zero scenario and returns null instead of 1.#INF`  
-  
- `Member [Measures].[Reseller to Internet Ratio With Error Handling] AS`  
-  
- `IIF([Measures].[Internet Sales Amount]=0, NULL,`  
-  
- `[Measures].[Reseller Sales Amount]`  
-  
- `/`  
-  
- `[Measures].[Internet Sales Amount])`  
-  
- `SELECT`  
-  
- `{[Measures].[Reseller to Internet Ratio],[Measures].[Reseller to Internet Ratio With Error Handling]} ON 0,`  
-  
- `[Product].[Category].[Category].Members ON 1`  
-  
- `FROM`  
-  
- `[Adventure Works]`  
-  
- `WHERE([Date].[Calendar].[Calendar Year].&[2001])`  
+```  
+//Returns 1.#INF when Internet Sales Amount is zero or null  
+Member [Measures].[Reseller to Internet Ratio] AS  
+[Measures].[Reseller Sales Amount]  
+/  
+[Measures].[Internet Sales Amount]  
+//Traps the division by zero scenario and returns null instead of 1.#INF  
+Member [Measures].[Reseller to Internet Ratio With Error Handling] AS  
+IIF([Measures].[Internet Sales Amount]=0, NULL,  
+[Measures].[Reseller Sales Amount]  
+/  
+[Measures].[Internet Sales Amount])  
+SELECT  
+{[Measures].[Reseller to Internet Ratio],[Measures].[Reseller to Internet Ratio With Error Handling]} ON 0,  
+[Product].[Category].[Category].Members ON 1  
+FROM  
+[Adventure Works]  
+WHERE([Date].[Calendar].[Calendar Year].&[2001])  
+```  
   
 ## See Also  
  [IIf &#40;MDX&#41;](../mdx/iif-mdx.md)   

--- a/docs/mdx/equal-to-mdx.md
+++ b/docs/mdx/equal-to-mdx.md
@@ -41,33 +41,22 @@ MDX_Expression = MDX_Expression
 ## Examples  
  The following query shows examples of these conditions:  
   
- `With`  
-  
- `--Returns true`  
-  
- `Member [Measures].bool1 as 1=1`  
-  
- `--Returns false`  
-  
- `Member [Measures].bool2 as 1=0`  
-  
- `--Returns true`  
-  
- `Member [Measures].bool3 as null=null`  
-  
- `--Returns true`  
-  
- `Member [Measures].bool4 as 0=null`  
-  
- `--Returns false`  
-  
- `Member [Measures].bool5 as 1=null`  
-  
- `Select {[Measures].bool1,[Measures].bool2,[Measures].bool3,[Measures].bool4,[Measures].bool5}`  
-  
- `On 0`  
-  
- `From [Adventure Works]`  
+```  
+With  
+--Returns true  
+Member [Measures].bool1 as 1=1  
+--Returns false  
+Member [Measures].bool2 as 1=0  
+--Returns true  
+Member [Measures].bool3 as null=null  
+--Returns true  
+Member [Measures].bool4 as 0=null  
+--Returns false  
+Member [Measures].bool5 as 1=null  
+Select {[Measures].bool1,[Measures].bool2,[Measures].bool3,[Measures].bool4,[Measures].bool5}  
+On 0  
+From [Adventure Works]  
+```  
   
 ## See Also  
  [MDX Operator Reference &#40;MDX&#41;](../mdx/mdx-operator-reference-mdx.md)  

--- a/docs/mdx/error-mdx.md
+++ b/docs/mdx/error-mdx.md
@@ -29,13 +29,12 @@ Error( [ Error_Text ] )
 ## Examples  
  The following query shows how to use the **Error** function inside a calculated measure:  
   
- `WITH MEMBER MEASURES.ERRORDEMO AS ERROR("THIS IS AN ERROR")`  
-  
- `SELECT`  
-  
- `MEASURES.ERRORDEMO ON 0`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH MEMBER MEASURES.ERRORDEMO AS ERROR("THIS IS AN ERROR")  
+SELECT  
+MEASURES.ERRORDEMO ON 0  
+FROM [Adventure Works]  
+```  
   
 ## See Also  
  [MDX Function Reference &#40;MDX&#41;](../mdx/mdx-function-reference-mdx.md)  

--- a/docs/mdx/extract-mdx.md
+++ b/docs/mdx/extract-mdx.md
@@ -40,37 +40,24 @@ Extract(Set_Expression, Hierarchy_Expression1 [,Hierarchy_Expression2, ...n] )
 ## Examples  
  The following query shows how to use the **Extract** function on a set of tuples returned by the **NonEmpty** function:  
   
- `SELECT [Measures].[Internet Sales Amount] ON 0,`  
-  
- `//Returns the distinct combinations of Customer and Date for all purchases`  
-  
- `//of Bike Racks or Bike Stands`  
-  
- `EXTRACT(`  
-  
- `NONEMPTY(`  
-  
- `[Customer].[Customer].[Customer].MEMBERS`  
-  
- `*`  
-  
- `[Date].[Date].[Date].MEMBERS`  
-  
- `*`  
-  
- `{[Product].[Product Categories].[Subcategory].&[26],[Product].[Product Categories].[Subcategory].&[27]}`  
-  
- `*`  
-  
- `{[Measures].[Internet Sales Amount]}`  
-  
- `)`  
-  
- `,  [Customer].[Customer], [Date].[Date])`  
-  
- `ON 1`  
-  
- `FROM [Adventure Works]`  
+```  
+SELECT [Measures].[Internet Sales Amount] ON 0,  
+//Returns the distinct combinations of Customer and Date for all purchases  
+//of Bike Racks or Bike Stands  
+EXTRACT(  
+NONEMPTY(  
+[Customer].[Customer].[Customer].MEMBERS  
+*  
+[Date].[Date].[Date].MEMBERS  
+*  
+{[Product].[Product Categories].[Subcategory].&[26],[Product].[Product Categories].[Subcategory].&[27]}  
+*  
+{[Measures].[Internet Sales Amount]}  
+)  
+,  [Customer].[Customer], [Date].[Date])  
+ON 1  
+FROM [Adventure Works]  
+```  
   
 ## See Also  
  [MDX Function Reference &#40;MDX&#41;](../mdx/mdx-function-reference-mdx.md)  

--- a/docs/mdx/filter-mdx.md
+++ b/docs/mdx/filter-mdx.md
@@ -37,19 +37,15 @@ Filter(Set_Expression, Logical_Expression )
 ## Examples  
  The following example shows the use of the Filter function on the Rows axis of a query, to return only the Dates where Internet Sales Amount is greater than $10000:  
   
- `SELECT [Measures].[Internet Sales Amount] ON 0,`  
-  
- `FILTER(`  
-  
- `[Date].[Date].[Date].MEMBERS`  
-  
- `,  [Measures].[Internet Sales Amount]>10000)`  
-  
- `ON 1`  
-  
- `FROM`  
-  
- `[Adventure Works]`  
+```  
+SELECT [Measures].[Internet Sales Amount] ON 0,  
+FILTER(  
+[Date].[Date].[Date].MEMBERS  
+,  [Measures].[Internet Sales Amount]>10000)  
+ON 1  
+FROM  
+[Adventure Works]  
+```  
   
  The Filter function can also be using inside calculated member definitions. The following example returns the sum of the `Measures.[Order Quantity]` member, aggregated over the first nine months of 2003 contained in the `Date` dimension, from the **Adventure Works** cube. The **PeriodsToDate** function defines the tuples in the set over which the **Aggregate** function operates. The **Filter** function limits those tuples being returned to those with lower values for the Reseller Sales Amount measure for the previous time period.  
   

--- a/docs/mdx/hierarchy-mdx.md
+++ b/docs/mdx/hierarchy-mdx.md
@@ -36,17 +36,14 @@ Level_Expression.Hierarchy
 ### Examples  
  The following example returns the name of the Calendar hierarchy in the Date dimension in the AdventureWorks cube.  
   
- `WITH`  
-  
- `MEMBER Measures.HierarchyName as`  
-  
- `[Date].[Calendar].Currentmember.Hierarchy.Name`  
-  
- `SELECT {Measures.HierarchyName}  ON 0,`  
-  
- `{[Date].[Calendar].[All Periods]} ON 1`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH  
+MEMBER Measures.HierarchyName as  
+[Date].[Calendar].Currentmember.Hierarchy.Name  
+SELECT {Measures.HierarchyName}  ON 0,  
+{[Date].[Calendar].[All Periods]} ON 1  
+FROM [Adventure Works]  
+```  
   
 ## See Also  
  [MDX Function Reference &#40;MDX&#41;](../mdx/mdx-function-reference-mdx.md)  

--- a/docs/mdx/identifiers-mdx.md
+++ b/docs/mdx/identifiers-mdx.md
@@ -46,23 +46,21 @@ ms.custom: mdx
 ### Examples of Regular Identifiers  
  In the following MDX statement, the identifiers, `Measures`, `Product`, and `Style`, comply with the formatting rules for regular identifiers. These regular identifiers do not need delimiters.  
   
- `SELECT Measures.MEMBERS ON COLUMNS,`  
+```  
+SELECT Measures.MEMBERS ON COLUMNS,  
+Product.Style.CHILDREN ON ROWS  
+FROM [Adventure Works]  
   
- `Product.Style.CHILDREN ON ROWS`  
-  
- `FROM [Adventure Works]`  
-  
- ``  
+```  
   
  Although not required, you could also use delimiters with regular identifiers. In the following MDX statement, the `Measures`, `Product`, and `Style` regular identifiers have been correctly delimited by using brackets.  
   
- `SELECT [Measures].MEMBERS ON COLUMNS,`  
+```  
+SELECT [Measures].MEMBERS ON COLUMNS,  
+[Product].[Style].CHILDREN ON ROWS  
+FROM [Adventure Works]  
   
- `[Product].[Style].CHILDREN ON ROWS`  
-  
- `FROM [Adventure Works]`  
-  
- ``  
+```  
   
 ## Using Delimited Identifiers  
  An identifier that does not comply with the formatting rules for regular identifiers must always be delimited by using brackets ([]).  
@@ -90,15 +88,13 @@ ms.custom: mdx
 ### Examples of Delimited Identifiers  
  In the following hypothetical MDX statement, `Sales Volume`, `Sales Cube`, and `select` are delimited identifiers:  
   
- `-- The [Sales Volume] and [Sales Cube] identifiers contain a space.`  
-  
- `SELECT Measures.[Sales Volume]`  
-  
- `FROM [Sales Cube]`  
-  
- `WHERE Product.[select]`  
-  
- `-- The [select] identifier is a reserved keyword.`  
+```  
+-- The [Sales Volume] and [Sales Cube] identifiers contain a space.  
+SELECT Measures.[Sales Volume]  
+FROM [Sales Cube]  
+WHERE Product.[select]  
+-- The [select] identifier is a reserved keyword.  
+```  
   
  In this next example, the name of an object is `Total Profit [Domestic]`. To reference this object, you must use the following delimited identifier:  
   

--- a/docs/mdx/iif-mdx.md
+++ b/docs/mdx/iif-mdx.md
@@ -63,113 +63,74 @@ IIf(Logical_Expression, Expression1 [HINT <hints>], Expression2 [HINT <hints>])
 ## Examples  
  The following query shows a simple use of **IIF** inside a calculated measure to return one of two different string values when the measure Internet Sales Amount is greater or less than $10000:  
   
- `WITH MEMBER MEASURES.IIFDEMO AS`  
-  
- `IIF([Measures].[Internet Sales Amount]>10000`  
-  
- `, "Sales Are High", "Sales Are Low")`  
-  
- `SELECT {[Measures].[Internet Sales Amount],MEASURES.IIFDEMO} ON 0,`  
-  
- `[Date].[Date].[Date].MEMBERS ON 1`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH MEMBER MEASURES.IIFDEMO AS  
+IIF([Measures].[Internet Sales Amount]>10000  
+, "Sales Are High", "Sales Are Low")  
+SELECT {[Measures].[Internet Sales Amount],MEASURES.IIFDEMO} ON 0,  
+[Date].[Date].[Date].MEMBERS ON 1  
+FROM [Adventure Works]  
+```  
   
  A very common use of IIF is to handle 'division by zero'  errors within calculated measures, as in the following example:  
   
- `WITH`  
-  
- `//Returns 1.#INF when the previous period contains no value`  
-  
- `//but the current period does`  
-  
- `MEMBER MEASURES.[Previous Period Growth With Errors] AS`  
-  
- `([Measures].[Internet Sales Amount]-([Measures].[Internet Sales Amount], [Date].[Date].CURRENTMEMBER.PREVMEMBER))`  
-  
- `/`  
-  
- `([Measures].[Internet Sales Amount], [Date].[Date].CURRENTMEMBER.PREVMEMBER)`  
-  
- `,FORMAT_STRING='PERCENT'`  
-  
- `//Traps division by zero and returns null when the previous period contains`  
-  
- `//no value but the current period does`  
-  
- `MEMBER MEASURES.[Previous Period Growth] AS`  
-  
- `IIF(([Measures].[Internet Sales Amount], [Date].[Date].CURRENTMEMBER.PREVMEMBER)=0,`  
-  
- `NULL,`  
-  
- `([Measures].[Internet Sales Amount]-([Measures].[Internet Sales Amount], [Date].[Date].CURRENTMEMBER.PREVMEMBER))`  
-  
- `/`  
-  
- `([Measures].[Internet Sales Amount], [Date].[Date].CURRENTMEMBER.PREVMEMBER)`  
-  
- `),FORMAT_STRING='PERCENT'`  
-  
- `SELECT {[Measures].[Internet Sales Amount],MEASURES.[Previous Period Growth With Errors], MEASURES.[Previous Period Growth]} ON 0,`  
-  
- `DESCENDANTS(`  
-  
- `[Date].[Calendar].[Calendar Year].&[2004],`  
-  
- `[Date].[Calendar].[Date])`  
-  
- `ON 1`  
-  
- `FROM [Adventure Works]`  
-  
- `WHERE([Product].[Product Categories].[Subcategory].&[26])`  
+```  
+WITH  
+//Returns 1.#INF when the previous period contains no value  
+//but the current period does  
+MEMBER MEASURES.[Previous Period Growth With Errors] AS  
+([Measures].[Internet Sales Amount]-([Measures].[Internet Sales Amount], [Date].[Date].CURRENTMEMBER.PREVMEMBER))  
+/  
+([Measures].[Internet Sales Amount], [Date].[Date].CURRENTMEMBER.PREVMEMBER)  
+,FORMAT_STRING='PERCENT'  
+//Traps division by zero and returns null when the previous period contains  
+//no value but the current period does  
+MEMBER MEASURES.[Previous Period Growth] AS  
+IIF(([Measures].[Internet Sales Amount], [Date].[Date].CURRENTMEMBER.PREVMEMBER)=0,  
+NULL,  
+([Measures].[Internet Sales Amount]-([Measures].[Internet Sales Amount], [Date].[Date].CURRENTMEMBER.PREVMEMBER))  
+/  
+([Measures].[Internet Sales Amount], [Date].[Date].CURRENTMEMBER.PREVMEMBER)  
+),FORMAT_STRING='PERCENT'  
+SELECT {[Measures].[Internet Sales Amount],MEASURES.[Previous Period Growth With Errors], MEASURES.[Previous Period Growth]} ON 0,  
+DESCENDANTS(  
+[Date].[Calendar].[Calendar Year].&[2004],  
+[Date].[Calendar].[Date])  
+ON 1  
+FROM [Adventure Works]  
+WHERE([Product].[Product Categories].[Subcategory].&[26])  
+```  
   
  The following is an example of **IIF** returning one of two sets inside the Generate function to create a complex set of tuples on Rows:  
   
- `SELECT {[Measures].[Internet Sales Amount]} ON 0,`  
-  
- `//If Internet Sales Amount is zero or null`  
-  
- `//returns the current year and the All Customers member`  
-  
- `//else returns the current year broken down by Country`  
-  
- `GENERATE(`  
-  
- `[Date].[Calendar Year].[Calendar Year].MEMBERS`  
-  
- `, IIF([Measures].[Internet Sales Amount]=0,`  
-  
- `{([Date].[Calendar Year].CURRENTMEMBER, [Customer].[Country].[All Customers])}`  
-  
- `, {{[Date].[Calendar Year].CURRENTMEMBER} * [Customer].[Country].[Country].MEMBERS}`  
-  
- `))`  
-  
- `ON 1`  
-  
- `FROM [Adventure Works]`  
-  
- `WHERE([Product].[Product Categories].[Subcategory].&[26])`  
+```  
+SELECT {[Measures].[Internet Sales Amount]} ON 0,  
+//If Internet Sales Amount is zero or null  
+//returns the current year and the All Customers member  
+//else returns the current year broken down by Country  
+GENERATE(  
+[Date].[Calendar Year].[Calendar Year].MEMBERS  
+, IIF([Measures].[Internet Sales Amount]=0,  
+{([Date].[Calendar Year].CURRENTMEMBER, [Customer].[Country].[All Customers])}  
+, {{[Date].[Calendar Year].CURRENTMEMBER} * [Customer].[Country].[Country].MEMBERS}  
+))  
+ON 1  
+FROM [Adventure Works]  
+WHERE([Product].[Product Categories].[Subcategory].&[26])  
+```  
   
  Lastly, this example shows how to use Plan Hints:  
   
- `WITH MEMBER MEASURES.X AS`  
-  
- `IIF(`  
-  
- `[Measures].[Internet Sales Amount]=0`  
-  
- `, NULL`  
-  
- `, (1/[Measures].[Internet Sales Amount]) HINT EAGER)`  
-  
- `SELECT {[Measures].x} ON 0,`  
-  
- `[Customer].[Customer Geography].[Country].MEMBERS ON 1`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH MEMBER MEASURES.X AS  
+IIF(  
+[Measures].[Internet Sales Amount]=0  
+, NULL  
+, (1/[Measures].[Internet Sales Amount]) HINT EAGER)  
+SELECT {[Measures].x} ON 0,  
+[Customer].[Customer Geography].[Country].MEMBERS ON 1  
+FROM [Adventure Works]  
+```  
   
 ## See Also  
  [MDX Function Reference &#40;MDX&#41;](../mdx/mdx-function-reference-mdx.md)  

--- a/docs/mdx/intersect-mdx.md
+++ b/docs/mdx/intersect-mdx.md
@@ -37,35 +37,27 @@ Intersect(Set_Expression1 , Set_Expression2 [ , ALL ] )
 ## Example  
  The following query returns the Years 2003 and 2004, the two members that appear in both the sets specified:  
   
- `SELECT`  
-  
- `INTERSECT(`  
-  
- `{[Date].[Calendar Year].&[2001], [Date].[Calendar Year].&[2002],[Date].[Calendar Year].&[2003]}`  
-  
- `, {[Date].[Calendar Year].&[2002],[Date].[Calendar Year].&[2003], [Date].[Calendar Year].&[2004]})`  
-  
- `ON 0`  
-  
- `FROM`  
-  
- `[Adventure Works]`  
+```  
+SELECT  
+INTERSECT(  
+{[Date].[Calendar Year].&[2001], [Date].[Calendar Year].&[2002],[Date].[Calendar Year].&[2003]}  
+, {[Date].[Calendar Year].&[2002],[Date].[Calendar Year].&[2003], [Date].[Calendar Year].&[2004]})  
+ON 0  
+FROM  
+[Adventure Works]  
+```  
   
  The following query fails because the two sets specified contain members from different hierarchies:  
   
- `SELECT`  
-  
- `INTERSECT(`  
-  
- `{[Date].[Calendar Year].&[2001]}`  
-  
- `, {[Customer].[City].&[Abingdon]&[ENG]})`  
-  
- `ON 0`  
-  
- `FROM`  
-  
- `[Adventure Works]`  
+```  
+SELECT  
+INTERSECT(  
+{[Date].[Calendar Year].&[2001]}  
+, {[Customer].[City].&[Abingdon]&[ENG]})  
+ON 0  
+FROM  
+[Adventure Works]  
+```  
   
 ## See Also  
  [MDX Function Reference &#40;MDX&#41;](../mdx/mdx-function-reference-mdx.md)  

--- a/docs/mdx/is-mdx.md
+++ b/docs/mdx/is-mdx.md
@@ -38,23 +38,17 @@ Expression1 IS ( Expression2 | NULL )
 ## Examples  
  The following example shows how to use the **IS** operator to check if the current member on an axis is a specific member:  
   
- `With`  
-  
- `//Returns TRUE if the currentmember is Bikes`  
-  
- `Member [Measures].[IsBikes?] AS`  
-  
- `[Product].[Category].CurrentMember IS [Product].[Category].&[1]`  
-  
- `SELECT`  
-  
- `{[Measures].[IsBikes?]} ON 0,`  
-  
- `[Product].[Category].[Category].Members ON 1`  
-  
- `FROM`  
-  
- `[Adventure Works]`  
+```  
+With  
+//Returns TRUE if the currentmember is Bikes  
+Member [Measures].[IsBikes?] AS  
+[Product].[Category].CurrentMember IS [Product].[Category].&[1]  
+SELECT  
+{[Measures].[IsBikes?]} ON 0,  
+[Product].[Category].[Category].Members ON 1  
+FROM  
+[Adventure Works]  
+```  
   
 ## See Also  
  [MDX Operator Reference &#40;MDX&#41;](../mdx/mdx-operator-reference-mdx.md)  

--- a/docs/mdx/isancestor-mdx.md
+++ b/docs/mdx/isancestor-mdx.md
@@ -35,15 +35,13 @@ IsAncestor(Member_Expression1, Member_Expression2)
 ## Example  
  The following example returns **true** if [Date].[Fiscal].CurrentMember is an ancestor of January 2003:  
   
- `WITH MEMBER MEASURES.ISANCESTORDEMO AS`  
-  
- `IsAncestor([Date].[Fiscal].CurrentMember, [Date].[Fiscal].[Month].&[2003]&[1])`  
-  
- `SELECT MEASURES.ISANCESTORDEMO ON 0,`  
-  
- `[Date].[Fiscal].MEMBERS ON 1`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH MEMBER MEASURES.ISANCESTORDEMO AS  
+IsAncestor([Date].[Fiscal].CurrentMember, [Date].[Fiscal].[Month].&[2003]&[1])  
+SELECT MEASURES.ISANCESTORDEMO ON 0,  
+[Date].[Fiscal].MEMBERS ON 1  
+FROM [Adventure Works]  
+```  
   
 ## See Also  
  [Ancestor &#40;MDX&#41;](../mdx/ancestor-mdx.md)   

--- a/docs/mdx/isempty-mdx.md
+++ b/docs/mdx/isempty-mdx.md
@@ -42,15 +42,13 @@ IsEmpty(Value_Expression)
 ## Example  
  The following example returns TRUE if the Internet Sales Amount for the current member on the Fiscal hierarchy of the Date dimension returns an empty cell:  
   
- `WITH MEMBER MEASURES.ISEMPTYDEMO AS`  
-  
- `IsEmpty([Measures].[Internet Sales Amount])`  
-  
- `SELECT {[Measures].[Internet Sales Amount],MEASURES.ISEMPTYDEMO} ON 0,`  
-  
- `[Date].[Fiscal].MEMBERS ON 1`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH MEMBER MEASURES.ISEMPTYDEMO AS  
+IsEmpty([Measures].[Internet Sales Amount])  
+SELECT {[Measures].[Internet Sales Amount],MEASURES.ISEMPTYDEMO} ON 0,  
+[Date].[Fiscal].MEMBERS ON 1  
+FROM [Adventure Works]  
+```  
   
 ## See Also  
  [Working with Empty Values](../mdx/working-with-empty-values.md)   

--- a/docs/mdx/isgeneration-mdx.md
+++ b/docs/mdx/isgeneration-mdx.md
@@ -37,15 +37,13 @@ IsGeneration(Member_Expression, Generation_Number)
 ## Example  
  The following example returns TRUE if [Date].[Fiscal].CurrentMember is part of the second generation:  
   
- `WITH MEMBER MEASURES.ISGENERATIONDEMO AS`  
-  
- `IsGeneration([Date].[Fiscal].CURRENTMEMBER, 2)`  
-  
- `SELECT {MEASURES.ISGENERATIONDEMO} ON 0,`  
-  
- `[Date].[Fiscal].MEMBERS ON 1`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH MEMBER MEASURES.ISGENERATIONDEMO AS  
+IsGeneration([Date].[Fiscal].CURRENTMEMBER, 2)  
+SELECT {MEASURES.ISGENERATIONDEMO} ON 0,  
+[Date].[Fiscal].MEMBERS ON 1  
+FROM [Adventure Works]  
+```  
   
 ## See Also  
  [MDX Function Reference &#40;MDX&#41;](../mdx/mdx-function-reference-mdx.md)  

--- a/docs/mdx/isleaf-mdx.md
+++ b/docs/mdx/isleaf-mdx.md
@@ -32,15 +32,13 @@ IsLeaf(Member_Expression)
 ## Example  
  The following example returns TRUE if [Date].[Fiscal].CurrentMember is a leaf member:  
   
- `WITH MEMBER MEASURES.ISLEAFDEMO AS`  
-  
- `IsLeaf([Date].[Fiscal].CURRENTMEMBER)`  
-  
- `SELECT {MEASURES.ISLEAFDEMO} ON 0,`  
-  
- `[Date].[Fiscal].MEMBERS ON 1`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH MEMBER MEASURES.ISLEAFDEMO AS  
+IsLeaf([Date].[Fiscal].CURRENTMEMBER)  
+SELECT {MEASURES.ISLEAFDEMO} ON 0,  
+[Date].[Fiscal].MEMBERS ON 1  
+FROM [Adventure Works]  
+```  
   
 ## See Also  
  [MDX Function Reference &#40;MDX&#41;](../mdx/mdx-function-reference-mdx.md)  

--- a/docs/mdx/issibling-mdx.md
+++ b/docs/mdx/issibling-mdx.md
@@ -35,15 +35,13 @@ IsSibling(Member_Expression1, Member_Expression2)
 ## Example  
  The following example returns TRUE if the current member on the Fiscal hierarchy of the Date dimension is a sibling of July 2002:  
   
- `WITH MEMBER MEASURES.ISSIBLINGDEMO AS`  
-  
- `IsSibling([Date].[Fiscal].CURRENTMEMBER, [Date].[Fiscal].[Month].&[2002]&[7])`  
-  
- `SELECT {MEASURES.ISSIBLINGDEMO} ON 0,`  
-  
- `[Date].[Fiscal].MEMBERS ON 1`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH MEMBER MEASURES.ISSIBLINGDEMO AS  
+IsSibling([Date].[Fiscal].CURRENTMEMBER, [Date].[Fiscal].[Month].&[2002]&[7])  
+SELECT {MEASURES.ISSIBLINGDEMO} ON 0,  
+[Date].[Fiscal].MEMBERS ON 1  
+FROM [Adventure Works]  
+```  
   
 ## See Also  
  [MDX Function Reference &#40;MDX&#41;](../mdx/mdx-function-reference-mdx.md)  

--- a/docs/mdx/item-member-mdx.md
+++ b/docs/mdx/item-member-mdx.md
@@ -35,13 +35,12 @@ Tuple_Expression.Item( Index )
 ## Example  
  The following example returns the member `[2003]` - the first item in the tuple `[Date].[Calendar Year].&[2003], [Measures].[Internet Sales Amount] ).` - on columns :  
   
- `SELECT`  
-  
- `{( [Date].[Calendar Year].&[2003], [Measures].[Internet Sales Amount] ).Item(0)} ON 0`  
-  
- `,{[Measures].[Reseller Sales Amount]} ON 1`  
-  
- `FROM [Adventure Works]`  
+```  
+SELECT  
+{( [Date].[Calendar Year].&[2003], [Measures].[Internet Sales Amount] ).Item(0)} ON 0  
+,{[Measures].[Reseller Sales Amount]} ON 1  
+FROM [Adventure Works]  
+```  
   
 ## See Also  
  [MDX Function Reference &#40;MDX&#41;](../mdx/mdx-function-reference-mdx.md)  

--- a/docs/mdx/lookupcube-mdx.md
+++ b/docs/mdx/lookupcube-mdx.md
@@ -51,13 +51,12 @@ LookupCube(Cube_Name, String_Expression )
 ## Examples  
  The following query demonstrates the use of LookupCube:  
   
- `WITH MEMBER MEASURES.LOOKUPCUBEDEMO AS`  
-  
- `LOOKUPCUBE("Adventure Works", "[Measures].[In" + "ternet Sales Amount]")`  
-  
- `SELECT MEASURES.LOOKUPCUBEDEMO  ON 0`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH MEMBER MEASURES.LOOKUPCUBEDEMO AS  
+LOOKUPCUBE("Adventure Works", "[Measures].[In" + "ternet Sales Amount]")  
+SELECT MEASURES.LOOKUPCUBEDEMO  ON 0  
+FROM [Adventure Works]  
+```  
   
 ## See Also  
  [MDX Function Reference &#40;MDX&#41;](../mdx/mdx-function-reference-mdx.md)  

--- a/docs/mdx/mdx-data-definition-create-subcube.md
+++ b/docs/mdx/mdx-data-definition-create-subcube.md
@@ -64,23 +64,21 @@ SELECT [Geography].[Country].[Country].MEMBERS ON 0
   
  The following example creates a subcube that restricts the apparent cube space to {Accessories, Clothing} members in Products.Category and {[Value Added Reseller], [Warehouse]} in Resellers.[Business Type].  
   
- `CREATE SUBCUBE [Adventure Works] AS`  
-  
- `Select {[Category].Accessories, [Category].Clothing} on 0,`  
-  
- `{[Business Type].[Value Added Reseller], [Business Type].[Warehouse]} on 1`  
-  
- `from [Adventure Works]`  
+```  
+CREATE SUBCUBE [Adventure Works] AS  
+Select {[Category].Accessories, [Category].Clothing} on 0,  
+{[Business Type].[Value Added Reseller], [Business Type].[Warehouse]} on 1  
+from [Adventure Works]  
+```  
   
  Querying the subcube for all members in Products.Category and Resellers.[Business Type] with the following MDX:  
   
- `select [Category].members on 0,`  
-  
- `[Business Type].members on 1`  
-  
- `from [Adventure Works]`  
-  
- `where [Measures].[Reseller Sales Amount]`  
+```  
+select [Category].members on 0,  
+[Business Type].members on 1  
+from [Adventure Works]  
+where [Measures].[Reseller Sales Amount]  
+```  
   
  Yields the following results:  
   
@@ -92,23 +90,21 @@ SELECT [Geography].[Country].[Country].MEMBERS ON 0
   
  Dropping and recreating the subcube using the NON VISUAL clause will create a subcube that keeps the true totals for all members in Products.Category and Resellers.[Business Type], whether they are visible or not in the subcube.  
   
- `CREATE SUBCUBE [Adventure Works] AS`  
-  
- `NON VISUAL (Select {[Category].Accessories, [Category].Clothing} on 0,`  
-  
- `{[Business Type].[Value Added Reseller], [Business Type].[Warehouse]} on 1`  
-  
- `from [Adventure Works])`  
+```  
+CREATE SUBCUBE [Adventure Works] AS  
+NON VISUAL (Select {[Category].Accessories, [Category].Clothing} on 0,  
+{[Business Type].[Value Added Reseller], [Business Type].[Warehouse]} on 1  
+from [Adventure Works])  
+```  
   
  Issuing the same MDX query from above:  
   
- `select [Category].members on 0,`  
-  
- `[Business Type].members on 1`  
-  
- `from [Adventure Works]`  
-  
- `where [Measures].[Reseller Sales Amount]`  
+```  
+select [Category].members on 0,  
+[Business Type].members on 1  
+from [Adventure Works]  
+where [Measures].[Reseller Sales Amount]  
+```  
   
  Yields the following different results:  
   

--- a/docs/mdx/mdx-data-manipulation-select.md
+++ b/docs/mdx/mdx-data-manipulation-select.md
@@ -116,41 +116,26 @@ FROM
 ## Autoexists  
  When two or more attributes of the dimension are used in a SELECT statement, Analysis Services evaluates the attributes' expressions to make sure that the members of those attributes are properly confined to meet the criteria of all other attributes. For example, suppose you are working with attributes from the Geography dimension. If you have one expression that returns all members from the City attribute, and another expression that confines members from the Country attribute to all countries/regions in Europe, then this will result in the City members being confined to only those cities that belong to countries/regions in Europe. This characteristic of Analysis Services is called Autoexists and applies only to attributes in the same dimension. Autoexists only applies to attributes from the same dimension because it tries to prevent the dimension records excluded in one attribute expression from being included by the other attribute expressions. Autoexists can also be understood as the resulting intersection of the different attributes expressions over the dimension records. See the following examples below:  
   
- `//Obtain the Top 10 best reseller selling products by Name`  
-  
- `with member [Measures].[PCT Discount] AS '[Measures].[Discount Amount]/[Measures].[Reseller Sales Amount]', FORMAT_STRING = 'Percent'`  
-  
- `set Top10SellingProducts as 'topcount([Product].[Model Name].children, 10, [Measures].[Reseller Sales Amount])'`  
-  
- `set Preferred10Products as '`  
-  
- `{[Product].[Model Name].&[Mountain-200],`  
-  
- `[Product].[Model Name].&[Road-250],`  
-  
- `[Product].[Model Name].&[Mountain-100],`  
-  
- `[Product].[Model Name].&[Road-650],`  
-  
- `[Product].[Model Name].&[Touring-1000],`  
-  
- `[Product].[Model Name].&[Road-550-W],`  
-  
- `[Product].[Model Name].&[Road-350-W],`  
-  
- `[Product].[Model Name].&[HL Mountain Frame],`  
-  
- `[Product].[Model Name].&[Road-150],`  
-  
- `[Product].[Model Name].&[Touring-3000]`  
-  
- `}'`  
-  
- `select {[Measures].[Reseller Sales Amount], [Measures].[Discount Amount], [Measures].[PCT Discount]} on 0,`  
-  
- `Top10SellingProducts on 1`  
-  
- `from [Adventure Works]`  
+```  
+//Obtain the Top 10 best reseller selling products by Name  
+with member [Measures].[PCT Discount] AS '[Measures].[Discount Amount]/[Measures].[Reseller Sales Amount]', FORMAT_STRING = 'Percent'  
+set Top10SellingProducts as 'topcount([Product].[Model Name].children, 10, [Measures].[Reseller Sales Amount])'  
+set Preferred10Products as '  
+{[Product].[Model Name].&[Mountain-200],  
+[Product].[Model Name].&[Road-250],  
+[Product].[Model Name].&[Mountain-100],  
+[Product].[Model Name].&[Road-650],  
+[Product].[Model Name].&[Touring-1000],  
+[Product].[Model Name].&[Road-550-W],  
+[Product].[Model Name].&[Road-350-W],  
+[Product].[Model Name].&[HL Mountain Frame],  
+[Product].[Model Name].&[Road-150],  
+[Product].[Model Name].&[Touring-3000]  
+}'  
+select {[Measures].[Reseller Sales Amount], [Measures].[Discount Amount], [Measures].[PCT Discount]} on 0,  
+Top10SellingProducts on 1  
+from [Adventure Works]  
+```  
   
  The obtained result set is:  
   
@@ -169,39 +154,25 @@ FROM
   
  The obtained set of products seems to be the same as Preferred10Products; so, verifying the Preferred10Products set:  
   
- `with member [Measures].[PCT Discount] AS '[Measures].[Discount Amount]/[Measures].[Reseller Sales Amount]', FORMAT_STRING = 'Percent'`  
-  
- `set Top10SellingProducts as 'topcount([Product].[Model Name].children, 10, [Measures].[Reseller Sales Amount])'`  
-  
- `set Preferred10Products as '`  
-  
- `{[Product].[Model Name].&[Mountain-200],`  
-  
- `[Product].[Model Name].&[Road-250],`  
-  
- `[Product].[Model Name].&[Mountain-100],`  
-  
- `[Product].[Model Name].&[Road-650],`  
-  
- `[Product].[Model Name].&[Touring-1000],`  
-  
- `[Product].[Model Name].&[Road-550-W],`  
-  
- `[Product].[Model Name].&[Road-350-W],`  
-  
- `[Product].[Model Name].&[HL Mountain Frame],`  
-  
- `[Product].[Model Name].&[Road-150],`  
-  
- `[Product].[Model Name].&[Touring-3000]`  
-  
- `}'`  
-  
- `select {[Measures].[Reseller Sales Amount], [Measures].[Discount Amount], [Measures].[PCT Discount]} on 0,`  
-  
- `Preferred10Products on 1`  
-  
- `from [Adventure Works]`  
+```  
+with member [Measures].[PCT Discount] AS '[Measures].[Discount Amount]/[Measures].[Reseller Sales Amount]', FORMAT_STRING = 'Percent'  
+set Top10SellingProducts as 'topcount([Product].[Model Name].children, 10, [Measures].[Reseller Sales Amount])'  
+set Preferred10Products as '  
+{[Product].[Model Name].&[Mountain-200],  
+[Product].[Model Name].&[Road-250],  
+[Product].[Model Name].&[Mountain-100],  
+[Product].[Model Name].&[Road-650],  
+[Product].[Model Name].&[Touring-1000],  
+[Product].[Model Name].&[Road-550-W],  
+[Product].[Model Name].&[Road-350-W],  
+[Product].[Model Name].&[HL Mountain Frame],  
+[Product].[Model Name].&[Road-150],  
+[Product].[Model Name].&[Touring-3000]  
+}'  
+select {[Measures].[Reseller Sales Amount], [Measures].[Discount Amount], [Measures].[PCT Discount]} on 0,  
+Preferred10Products on 1  
+from [Adventure Works]  
+```  
   
  As per the following results, both sets (Top10SellingProducts, Preferred10Products) are the same  
   
@@ -222,19 +193,15 @@ FROM
   
  Autoexists can be applied deep or shallow to the expressions. The default  setting is deep. The following example will illustrate the concept of deep Autoexists. In the example we are filtering Top10SellingProducts by [Product].[Product Line] attribute for those in [Mountain] group. Note that both attributes (slicer and axis) belong to the same dimension, [Product].  
   
- `with member [Measures].[PCT Discount] AS '[Measures].[Discount Amount]/[Measures].[Reseller Sales Amount]', FORMAT_STRING = 'Percent'`  
-  
- `set Top10SellingProducts as 'topcount([Product].[Model Name].children, 10, [Measures].[Reseller Sales Amount])'`  
-  
- `// Preferred10Products set removed for clarity`  
-  
- `select {[Measures].[Reseller Sales Amount], [Measures].[Discount Amount], [Measures].[PCT Discount]} on 0,`  
-  
- `Top10SellingProducts on 1`  
-  
- `from [Adventure Works]`  
-  
- `where [Product].[Product Line].[Mountain]`  
+```  
+with member [Measures].[PCT Discount] AS '[Measures].[Discount Amount]/[Measures].[Reseller Sales Amount]', FORMAT_STRING = 'Percent'  
+set Top10SellingProducts as 'topcount([Product].[Model Name].children, 10, [Measures].[Reseller Sales Amount])'  
+// Preferred10Products set removed for clarity  
+select {[Measures].[Reseller Sales Amount], [Measures].[Discount Amount], [Measures].[PCT Discount]} on 0,  
+Top10SellingProducts on 1  
+from [Adventure Works]  
+where [Product].[Product Line].[Mountain]  
+```  
   
  Produces the following result set:  
   
@@ -257,41 +224,26 @@ FROM
   
  However, one might want to be able to do the analysis over the Top10SellingProducts as equivalent to Preferred10Products, as in the following example:  
   
- `with member [Measures].[PCT Discount] AS '[Measures].[Discount Amount]/[Measures].[Reseller Sales Amount]', FORMAT_STRING = 'Percent'`  
-  
- `set Top10SellingProducts as 'topcount([Product].[Model Name].children, 10, [Measures].[Reseller Sales Amount])'`  
-  
- `set Preferred10Products as '`  
-  
- `{[Product].[Model Name].&[Mountain-200],`  
-  
- `[Product].[Model Name].&[Road-250],`  
-  
- `[Product].[Model Name].&[Mountain-100],`  
-  
- `[Product].[Model Name].&[Road-650],`  
-  
- `[Product].[Model Name].&[Touring-1000],`  
-  
- `[Product].[Model Name].&[Road-550-W],`  
-  
- `[Product].[Model Name].&[Road-350-W],`  
-  
- `[Product].[Model Name].&[HL Mountain Frame],`  
-  
- `[Product].[Model Name].&[Road-150],`  
-  
- `[Product].[Model Name].&[Touring-3000]`  
-  
- `}'`  
-  
- `select {[Measures].[Reseller Sales Amount], [Measures].[Discount Amount], [Measures].[PCT Discount]} on 0,`  
-  
- `Preferred10Products on 1`  
-  
- `from [Adventure Works]`  
-  
- `where [Product].[Product Line].[Mountain]`  
+```  
+with member [Measures].[PCT Discount] AS '[Measures].[Discount Amount]/[Measures].[Reseller Sales Amount]', FORMAT_STRING = 'Percent'  
+set Top10SellingProducts as 'topcount([Product].[Model Name].children, 10, [Measures].[Reseller Sales Amount])'  
+set Preferred10Products as '  
+{[Product].[Model Name].&[Mountain-200],  
+[Product].[Model Name].&[Road-250],  
+[Product].[Model Name].&[Mountain-100],  
+[Product].[Model Name].&[Road-650],  
+[Product].[Model Name].&[Touring-1000],  
+[Product].[Model Name].&[Road-550-W],  
+[Product].[Model Name].&[Road-350-W],  
+[Product].[Model Name].&[HL Mountain Frame],  
+[Product].[Model Name].&[Road-150],  
+[Product].[Model Name].&[Touring-3000]  
+}'  
+select {[Measures].[Reseller Sales Amount], [Measures].[Discount Amount], [Measures].[PCT Discount]} on 0,  
+Preferred10Products on 1  
+from [Adventure Works]  
+where [Product].[Product Line].[Mountain]  
+```  
   
  Produces the following result set:  
   
@@ -307,19 +259,15 @@ FROM
   
  Autoexists behavior can be modified at the session level using the **Autoexists** connection string property. The following example begins by opening a new session and adding the *Autoexists=3* property to the connection string. You must open a new connection in order to do the example. Once the connection is established with the Autoexist setting it will remain in effect until that connection is finished.  
   
- `with member [Measures].[PCT Discount] AS '[Measures].[Discount Amount]/[Measures].[Reseller Sales Amount]', FORMAT_STRING = 'Percent'`  
-  
- `set Top10SellingProducts as 'topcount([Product].[Model Name].children, 10, [Measures].[Reseller Sales Amount])'`  
-  
- `//Preferred10Products set removed for clarity`  
-  
- `select {[Measures].[Reseller Sales Amount], [Measures].[Discount Amount], [Measures].[PCT Discount]} on 0,`  
-  
- `Top10SellingProducts on 1`  
-  
- `from [Adventure Works]`  
-  
- `where [Product].[Product Line].[Mountain]`  
+```  
+with member [Measures].[PCT Discount] AS '[Measures].[Discount Amount]/[Measures].[Reseller Sales Amount]', FORMAT_STRING = 'Percent'  
+set Top10SellingProducts as 'topcount([Product].[Model Name].children, 10, [Measures].[Reseller Sales Amount])'  
+//Preferred10Products set removed for clarity  
+select {[Measures].[Reseller Sales Amount], [Measures].[Discount Amount], [Measures].[PCT Discount]} on 0,  
+Top10SellingProducts on 1  
+from [Adventure Works]  
+where [Product].[Product Line].[Mountain]  
+```  
   
  The following result set now shows the shallow behavior of Autoexists.  
   
@@ -355,13 +303,12 @@ WHERE
   
  The following SELECT statement:  
   
- `select [Category].members on 0,`  
-  
- `[Business Type].members on 1`  
-  
- `from [Adventure Works]`  
-  
- `where [Measures].[Reseller Sales Amount]`  
+```  
+select [Category].members on 0,  
+[Business Type].members on 1  
+from [Adventure Works]  
+where [Measures].[Reseller Sales Amount]  
+```  
   
  Produces the following results:  
   
@@ -374,17 +321,14 @@ WHERE
   
  To produce a table with data only for theAccessories and Clothing products, the Value Added Reseller and Warehouse resellers,  yet keeping the overall totals could be written as follows using NON VISUAL:  
   
- `select [Category].members on 0,`  
-  
- `[Business Type].members on 1`  
-  
- `from NON VISUAL (Select {[Category].Accessories, [Category].Clothing} on 0,`  
-  
- `{[Business Type].[Value Added Reseller], [Business Type].[Warehouse]} on 1`  
-  
- `from [Adventure Works])`  
-  
- `where [Measures].[Reseller Sales Amount]`  
+```  
+select [Category].members on 0,  
+[Business Type].members on 1  
+from NON VISUAL (Select {[Category].Accessories, [Category].Clothing} on 0,  
+{[Business Type].[Value Added Reseller], [Business Type].[Warehouse]} on 1  
+from [Adventure Works])  
+where [Measures].[Reseller Sales Amount]  
+```  
   
  Produces the following results:  
   
@@ -396,19 +340,15 @@ WHERE
   
  To produce a table that visually totals the columns but for row totals brings the true total of all [Category], the following query should be issued:  
   
- `select [Category].members on 0,`  
-  
- `[Business Type].members on 1`  
-  
- `from NON VISUAL (Select {[Category].Accessories, [Category].Clothing} on 0`  
-  
- `from ( Select {[Business Type].[Value Added Reseller], [Business Type].[Warehouse]} on 0`  
-  
- `from [Adventure Works])`  
-  
- `)`  
-  
- `where [Measures].[Reseller Sales Amount]`  
+```  
+select [Category].members on 0,  
+[Business Type].members on 1  
+from NON VISUAL (Select {[Category].Accessories, [Category].Clothing} on 0  
+from ( Select {[Business Type].[Value Added Reseller], [Business Type].[Warehouse]} on 0  
+from [Adventure Works])  
+)  
+where [Measures].[Reseller Sales Amount]  
+```  
   
  Note how NON VISUAL is only applied to [Category].  
   
@@ -424,23 +364,17 @@ WHERE
   
  The following example demonstrates how to use calculated members in subselects to filter on them. To be able to reproduce this sample, the connection must be established using the connection string parameter *subqueries=1*.  
   
- `select Measures.allmembers on 0`  
-  
- `from (`  
-  
- `Select { [Measures].[Reseller Sales Amount]`  
-  
- `, [Measures].[Reseller Total Product Cost]`  
-  
- `, [Measures].[Reseller Gross Profit]`  
-  
- `, [Measures].[Reseller Gross Profit Margin]`  
-  
- `} on 0`  
-  
- `from [Adventure Works]`  
-  
- `)`  
+```  
+select Measures.allmembers on 0  
+from (  
+Select { [Measures].[Reseller Sales Amount]  
+, [Measures].[Reseller Total Product Cost]  
+, [Measures].[Reseller Gross Profit]  
+, [Measures].[Reseller Gross Profit Margin]  
+} on 0  
+from [Adventure Works]  
+)  
+```  
   
  The above query produces the following results:  
   

--- a/docs/mdx/mdx-scripting-if.md
+++ b/docs/mdx/mdx-scripting-if.md
@@ -35,9 +35,10 @@ IF expression THEN assignment END IF
 ## Examples  
  In the following example, the scope is restricted to the Country level of the Customers Geography hierarchy in the Customers dimension. If the current measure is Internet Sales Amount, then the Internet Sales Amount is set to 10:  
   
- `SCOPE ([Customer].[Customer Geography].[Country].MEMBERS);`  
-  
- `IF Measures.CurrentMember IS [Measures].[Internet Sales Amount] THEN this = 10 END IF;`  
+```  
+SCOPE ([Customer].[Customer Geography].[Country].MEMBERS);  
+IF Measures.CurrentMember IS [Measures].[Internet Sales Amount] THEN this = 10 END IF;  
+```  
   
  `END SCOPE`;  
   

--- a/docs/mdx/membertostr-mdx.md
+++ b/docs/mdx/membertostr-mdx.md
@@ -32,13 +32,12 @@ MemberToStr(Member_Expression)
 ## Example  
  The following example returns the string [Geography].[Geography].[Country].&[United States] :  
   
- `WITH MEMBER Measures.x AS MemberToStr`  
-  
- `([Geography].[Geography].[Country].[United States])`  
-  
- `SELECT Measures.x ON 0`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH MEMBER Measures.x AS MemberToStr  
+([Geography].[Geography].[Country].[United States])  
+SELECT Measures.x ON 0  
+FROM [Adventure Works]  
+```  
   
 ## See Also  
  [MDX Function Reference &#40;MDX&#41;](../mdx/mdx-function-reference-mdx.md)  

--- a/docs/mdx/nonempty-mdx.md
+++ b/docs/mdx/nonempty-mdx.md
@@ -41,45 +41,32 @@ NONEMPTY(set_expression1 [,set_expression2])
 ## Examples  
  The following query shows a simple example of **NonEmpty**, returning all the Customers who had a non-null value for Internet Sales Amount on July 1st 2001:  
   
- `SELECT [Measures].[Internet Sales Amount] ON 0,`  
-  
- `NONEMPTY(`  
-  
- `[Customer].[Customer].[Customer].MEMBERS`  
-  
- `, {([Date].[Calendar].[Date].&[20010701], [Measures].[Internet Sales Amount])}`  
-  
- `)`  
-  
- `ON 1`  
-  
- `FROM [Adventure Works]`  
+```  
+SELECT [Measures].[Internet Sales Amount] ON 0,  
+NONEMPTY(  
+[Customer].[Customer].[Customer].MEMBERS  
+, {([Date].[Calendar].[Date].&[20010701], [Measures].[Internet Sales Amount])}  
+)  
+ON 1  
+FROM [Adventure Works]  
+```  
   
  The following example returns the set of tuples containing customers and purchase dates, using the **Filter** function and the **NonEmpty** functions to find the last date that each customer made a purchase:  
   
- `WITH SET MYROWS AS FILTER`  
-  
- `(NONEMPTY`  
-  
- `([Customer].[Customer Geography].[Customer].MEMBERS`  
-  
- `* [Date].[Date].[Date].MEMBERS`  
-  
- `, [Measures].[Internet Sales Amount]`  
-  
- `) AS MYSET`  
-  
- `, NOT(MYSET.CURRENT.ITEM(0)`  
-  
- `IS MYSET.ITEM(RANK(MYSET.CURRENT, MYSET)).ITEM(0))`  
-  
- `)`  
-  
- `SELECT [Measures].[Internet Sales Amount] ON 0,`  
-  
- `MYROWS ON 1`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH SET MYROWS AS FILTER  
+(NONEMPTY  
+([Customer].[Customer Geography].[Customer].MEMBERS  
+* [Date].[Date].[Date].MEMBERS  
+, [Measures].[Internet Sales Amount]  
+) AS MYSET  
+, NOT(MYSET.CURRENT.ITEM(0)  
+IS MYSET.ITEM(RANK(MYSET.CURRENT, MYSET)).ITEM(0))  
+)  
+SELECT [Measures].[Internet Sales Amount] ON 0,  
+MYROWS ON 1  
+FROM [Adventure Works]  
+```  
   
 ## See Also  
  [DefaultMember &#40;MDX&#41;](../mdx/defaultmember-mdx.md)   

--- a/docs/mdx/prevmember-mdx.md
+++ b/docs/mdx/prevmember-mdx.md
@@ -32,15 +32,13 @@ Member_Expression.PrevMember
 ## Example  
  The following example shows a simple query that uses the **PrevMember** function to display the name of the member immediately before the current member on the rows axis:  
   
- `WITH MEMBER MEASURES.PREVMEMBERDEMO AS`  
-  
- `[Date].[Calendar].CURRENTMEMBER.PREVMEMBER.NAME`  
-  
- `SELECT MEASURES.PREVMEMBERDEMO ON 0,`  
-  
- `[Date].[Calendar].MEMBERS ON 1`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH MEMBER MEASURES.PREVMEMBERDEMO AS  
+[Date].[Calendar].CURRENTMEMBER.PREVMEMBER.NAME  
+SELECT MEASURES.PREVMEMBERDEMO ON 0,  
+[Date].[Calendar].MEMBERS ON 1  
+FROM [Adventure Works]  
+```  
   
  The following example returns the count of the resellers whose sales have declined over the previous time period, based on user-selected State-Province member values evaluated using the Aggregate function. The **Hierarchize** and **DrillDownLevel** functions are used to return values for declining sales for product categories in the Product dimension. The **PrevMember** function is used to compare the current time period with the previous time period.  
   

--- a/docs/mdx/sum-mdx.md
+++ b/docs/mdx/sum-mdx.md
@@ -77,15 +77,13 @@ FROM [Adventure Works]
   
  Often, the **SUM** function is used with the **CURRENTMEMBER** function or functions like **YTD** that return a set that varies depending on the currentmember of a hierarchy. For example, the following query returns the sum of the Internet Sales Amount measure for all dates from the beginning of the calendar year to the date displayed on the Rows axis:  
   
- `WITH MEMBER MEASURES.YTDSUM AS`  
-  
- `SUM(YTD(), [Measures].[Internet Sales Amount])`  
-  
- `SELECT {[Measures].[Internet Sales Amount], MEASURES.YTDSUM} ON 0,`  
-  
- `[Date].[Calendar].MEMBERS ON 1`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH MEMBER MEASURES.YTDSUM AS  
+SUM(YTD(), [Measures].[Internet Sales Amount])  
+SELECT {[Measures].[Internet Sales Amount], MEASURES.YTDSUM} ON 0,  
+[Date].[Calendar].MEMBERS ON 1  
+FROM [Adventure Works]  
+```  
   
 ## See Also  
  [MDX Function Reference &#40;MDX&#41;](../mdx/mdx-function-reference-mdx.md)  

--- a/docs/mdx/this-mdx.md
+++ b/docs/mdx/this-mdx.md
@@ -28,45 +28,28 @@ This
 ## Examples  
  The following MDX Script fragment shows how the This keyword can be used with SCOPE statements to make assignments to subcubes:  
   
- `Scope`  
-  
- `(`  
-  
- `[Date].[Fiscal Year].&[2005],`  
-  
- `[Date].[Fiscal].[Fiscal Quarter].Members,`  
-  
- `[Measures].[Sales Amount Quota]`  
-  
- `) ;`  
-  
- `This = ParallelPeriod`  
-  
- `(`  
-  
- `[Date].[Fiscal].[Fiscal Year], 1,`  
-  
- `[Date].[Fiscal].CurrentMember`  
-  
- `) * 1.35 ;`  
-  
- `/*-- Allocate equally to months in FY 2002 -----------------------------*/`  
-  
- `Scope`  
-  
- `(`  
-  
- `[Date].[Fiscal Year].&[2002],`  
-  
- `[Date].[Fiscal].[Month].Members`  
-  
- `) ;`  
-  
- `This = [Date].[Fiscal].CurrentMember.Parent / 3 ;`  
-  
- `End Scope ;`  
-  
- `End Scope;`  
+```  
+Scope  
+(  
+[Date].[Fiscal Year].&[2005],  
+[Date].[Fiscal].[Fiscal Quarter].Members,  
+[Measures].[Sales Amount Quota]  
+) ;  
+This = ParallelPeriod  
+(  
+[Date].[Fiscal].[Fiscal Year], 1,  
+[Date].[Fiscal].CurrentMember  
+) * 1.35 ;  
+/*-- Allocate equally to months in FY 2002 -----------------------------*/  
+Scope  
+(  
+[Date].[Fiscal Year].&[2002],  
+[Date].[Fiscal].[Month].Members  
+) ;  
+This = [Date].[Fiscal].CurrentMember.Parent / 3 ;  
+End Scope ;  
+End Scope;  
+```  
   
 ## See Also  
  [MDX Function Reference &#40;MDX&#41;](../mdx/mdx-function-reference-mdx.md)   

--- a/docs/mdx/topcount-mdx.md
+++ b/docs/mdx/topcount-mdx.md
@@ -43,13 +43,12 @@ TopCount(Set_Expression,Count [ ,Numeric_Expression ] )
 ## Examples  
  The following example returns the top 10 dates by Internet Sales Amount:  
   
- `SELECT [Measures].[Internet Sales Amount] ON 0,`  
-  
- `TOPCOUNT([Date].[Date].[Date].MEMBERS, 10, [Measures].[Internet Sales Amount])`  
-  
- `ON 1`  
-  
- `FROM [Adventure Works]`  
+```  
+SELECT [Measures].[Internet Sales Amount] ON 0,  
+TOPCOUNT([Date].[Date].[Date].MEMBERS, 10, [Measures].[Internet Sales Amount])  
+ON 1  
+FROM [Adventure Works]  
+```  
   
  The following example returns, for the Bike category, the first five members in the set containing all combinations of members of the City level in the Geography hierarchy in the Geography dimension and all fiscal years from the Fiscal hierarchy of the Date dimension, ordered by the Reseller Sales Amount measure (beginning with the members of this set with the largest number of sales).  
   

--- a/docs/mdx/using-cube-and-subcube-expressions.md
+++ b/docs/mdx/using-cube-and-subcube-expressions.md
@@ -22,9 +22,10 @@ ms.custom: mdx
   
  Cube expressions may appear in several places. In an MDX SELECT statement they specify the cube from which data is to be retrieved. In the following example query, the expression [Adventure Works] refers to the cube of that name:  
   
- `SELECT [Measures].[Internet Sales Amount] ON COLUMNS`  
-  
- `FROM [Adventure Works]`  
+```  
+SELECT [Measures].[Internet Sales Amount] ON COLUMNS  
+FROM [Adventure Works]  
+```  
   
  In the CREATE MEMBER statement, the cube expression specifies which cube the calculated member you are creating is to appear on. In the following example, the statement creates a calculated measure on the Measures dimension of the Adventure Works cube:  
   
@@ -39,27 +40,24 @@ ms.custom: mdx
 ## SubCube Expressions  
  A subcube expression can contain a subcube identifier or an MDX statement that returns a subcube. If the subcube expression contains a subcube identifier, it will be a simple expression. If it contains an MDX statement that returns a subcube, it is a complex statement. The MDX SELECT statement, for example, returns a subcube and can be used where subcube expressions are allowed, as shown in the following example:  
   
- `SELECT [Measures].MEMBERS ON COLUMNS,`  
-  
- `[Date].[Calendar Year].MEMBERS ON ROWS`  
-  
- `FROM`  
-  
- `(SELECT [Measures].[Internet Sales Amount] ON COLUMNS,`  
-  
- `[Date].[Calendar Year].&[2004] ON ROWS`  
-  
- `FROM [Adventure Works])`  
+```  
+SELECT [Measures].MEMBERS ON COLUMNS,  
+[Date].[Calendar Year].MEMBERS ON ROWS  
+FROM  
+(SELECT [Measures].[Internet Sales Amount] ON COLUMNS,  
+[Date].[Calendar Year].&[2004] ON ROWS  
+FROM [Adventure Works])  
+```  
   
  This use of a SELECT statement in the FROM clause is also referred to as a subselect.  
   
  Another common scenario where subcube expressions are encountered is when making scoped assignments in an MDX Script. In the following example, the SCOPE statement is used to limit an assignment to a subcube consisting of [Measures].[Internet Sales Amount]:  
   
- `SCOPE([Measures].[Internet Sales Amount]);`  
-  
- `This=1;`  
-  
- `END SCOPE;`  
+```  
+SCOPE([Measures].[Internet Sales Amount]);  
+This=1;  
+END SCOPE;  
+```  
   
  A subcube identifier appears as *Subcube_Name*. in BNF notation descriptions of MDX statements.  
   

--- a/docs/mdx/using-dimension-expressions.md
+++ b/docs/mdx/using-dimension-expressions.md
@@ -24,34 +24,32 @@ ms.custom: mdx
   
  The following example shows a calculated member that uses the expression [Measures] along with the .Members and Count() functions to return the number of members on the Measures dimension:  
   
- `WITH MEMBER [Measures].[MeasureCount] AS`  
-  
- `COUNT([Measures].MEMBERS)`  
-  
- `SELECT [Measures].[MeasureCount] ON 0`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH MEMBER [Measures].[MeasureCount] AS  
+COUNT([Measures].MEMBERS)  
+SELECT [Measures].[MeasureCount] ON 0  
+FROM [Adventure Works]  
+```  
   
  A dimension identifier appears as *Dimension_Name* in the BNF notation used to describe MDX statements.  
   
 ## Hierarchy Expressions  
  Similarly, a hierarchy expression contains either a hierarchy identifier or a hierarchy function. The following example shows the use of the hierarchy expression [Date].[Calendar], along with the .Levels and .Count functions, to return the number of levels in the Calendar hierarchy of the Date dimension:  
   
- `WITH MEMBER [Measures].[CalendarLevelCount] AS`  
-  
- `[Date].[Calendar].Levels.Count`  
-  
- `SELECT [Measures].[CalendarLevelCount] ON 0`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH MEMBER [Measures].[CalendarLevelCount] AS  
+[Date].[Calendar].Levels.Count  
+SELECT [Measures].[CalendarLevelCount] ON 0  
+FROM [Adventure Works]  
+```  
   
  The most common scenario where hierarchy expressions are used is in conjunction with the .Members function, to return all the members on a hierarchy. The following example returns all the members of [Date].[Calendar] on the rows axis:  
   
- `SELECT [Measures].[Internet Sales Amount] ON 0,`  
-  
- `[Date].[Calendar].MEMBERS ON 1`  
-  
- `FROM [Adventure Works]`  
+```  
+SELECT [Measures].[Internet Sales Amount] ON 0,  
+[Date].[Calendar].MEMBERS ON 1  
+FROM [Adventure Works]  
+```  
   
  A hierarchy identifier appears as *Dimension_Name.Hierarchy_Name* in the BNF notation used to describe MDX statements.  
   

--- a/docs/mdx/using-dimension-hierarchy-and-level-functions.md
+++ b/docs/mdx/using-dimension-hierarchy-and-level-functions.md
@@ -17,25 +17,18 @@ ms.custom: mdx
   
  The following example shows how to use the **.Dimension**, **.Hierarchy**, and **.Level** functions:  
   
- `WITH`  
-  
- `MEMBER MEASURES.DIMENSIONNAME AS [Date].[Calendar].CURRENTMEMBER.DIMENSION.NAME`  
-  
- `MEMBER MEASURES.HIERARCHYNAME AS [Date].[Calendar].CURRENTMEMBER.HIERARCHY.NAME`  
-  
- `MEMBER MEASURES.LEVELNAME AS [Date].[Calendar].LEVEL.NAME`  
-  
- `SELECT`  
-  
- `{MEASURES.DIMENSIONNAME, MEASURES.HIERARCHYNAME, MEASURES.LEVELNAME}`  
-  
- `ON Columns,`  
-  
- `[Date].[Calendar].MEMBERS`  
-  
- `ON Rows`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH  
+MEMBER MEASURES.DIMENSIONNAME AS [Date].[Calendar].CURRENTMEMBER.DIMENSION.NAME  
+MEMBER MEASURES.HIERARCHYNAME AS [Date].[Calendar].CURRENTMEMBER.HIERARCHY.NAME  
+MEMBER MEASURES.LEVELNAME AS [Date].[Calendar].LEVEL.NAME  
+SELECT  
+{MEASURES.DIMENSIONNAME, MEASURES.HIERARCHYNAME, MEASURES.LEVELNAME}  
+ON Columns,  
+[Date].[Calendar].MEMBERS  
+ON Rows  
+FROM [Adventure Works]  
+```  
   
 ## See Also  
  [Dimension &#40;MDX&#41;](../mdx/dimension-mdx.md)   

--- a/docs/mdx/using-logical-functions.md
+++ b/docs/mdx/using-logical-functions.md
@@ -19,21 +19,16 @@ ms.custom: mdx
   
  The following query shows how to use the **IsLeaf** and **IsAncestor** functions:  
   
- `WITH`  
-  
- `//Returns true if the CurrentMember on Calendar is a leaf member, ie it has no children`  
-  
- `MEMBER MEASURES.[IsLeafDemo] AS IsLeaf([Date].[Calendar].CurrentMember)`  
-  
- `//Returns true if the CurrentMember on Calendar is an Ancestor of July 1st 2001`  
-  
- `MEMBER MEASURES.[IsAncestorDemo] AS IsAncestor([Date].[Calendar].CurrentMember, [Date].[Calendar].[Date].&[1])`  
-  
- `SELECT{MEASURES.[IsLeafDemo],MEASURES.[IsAncestorDemo] } ON 0,`  
-  
- `[Date].[Calendar].MEMBERS ON 1`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH  
+//Returns true if the CurrentMember on Calendar is a leaf member, ie it has no children  
+MEMBER MEASURES.[IsLeafDemo] AS IsLeaf([Date].[Calendar].CurrentMember)  
+//Returns true if the CurrentMember on Calendar is an Ancestor of July 1st 2001  
+MEMBER MEASURES.[IsAncestorDemo] AS IsAncestor([Date].[Calendar].CurrentMember, [Date].[Calendar].[Date].&[1])  
+SELECT{MEASURES.[IsLeafDemo],MEASURES.[IsAncestorDemo] } ON 0,  
+[Date].[Calendar].MEMBERS ON 1  
+FROM [Adventure Works]  
+```  
   
 ## See Also  
  [Functions &#40;MDX Syntax&#41;](../mdx/functions-mdx-syntax.md)  

--- a/docs/mdx/using-member-functions.md
+++ b/docs/mdx/using-member-functions.md
@@ -17,29 +17,20 @@ ms.custom: mdx
   
  Of the many member functions in MDX, the most important is the **CurrentMember** function, which is used to determine the current member on a hierarchy. The following query illustrates how to use it, along with the **Parent**, **Ancestor**, and **Prevmember** functions:  
   
- `WITH`  
-  
- `//Returns the name of the currentmember on the Calendar hierarchy`  
-  
- `MEMBER MEASURES.[CurrentMemberDemo] AS [Date].[Calendar].CurrentMember.Name`  
-  
- `//Returns the name of the parent of the currentmember on the Calendar hierarchy`  
-  
- `MEMBER MEASURES.[ParentDemo] AS [Date].[Calendar].CurrentMember.Parent.Name`  
-  
- `//Returns the name of the ancestor of the currentmember on the Calendar hierarchy at the Year level`  
-  
- `MEMBER MEASURES.[AncestorDemo] AS ANCESTOR([Date].[Calendar].CurrentMember, [Date].[Calendar].[Calendar Year]).Name`  
-  
- `//Returns the name of the member before the currentmember on the Calendar hierarchy`  
-  
- `MEMBER MEASURES.[PrevMemberDemo] AS [Date].[Calendar].CurrentMember.Prevmember.Name`  
-  
- `SELECT{MEASURES.[CurrentMemberDemo],MEASURES.[ParentDemo],MEASURES.[AncestorDemo],MEASURES.[PrevMemberDemo] } ON 0,`  
-  
- `[Date].[Calendar].MEMBERS ON 1`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH  
+//Returns the name of the currentmember on the Calendar hierarchy  
+MEMBER MEASURES.[CurrentMemberDemo] AS [Date].[Calendar].CurrentMember.Name  
+//Returns the name of the parent of the currentmember on the Calendar hierarchy  
+MEMBER MEASURES.[ParentDemo] AS [Date].[Calendar].CurrentMember.Parent.Name  
+//Returns the name of the ancestor of the currentmember on the Calendar hierarchy at the Year level  
+MEMBER MEASURES.[AncestorDemo] AS ANCESTOR([Date].[Calendar].CurrentMember, [Date].[Calendar].[Calendar Year]).Name  
+//Returns the name of the member before the currentmember on the Calendar hierarchy  
+MEMBER MEASURES.[PrevMemberDemo] AS [Date].[Calendar].CurrentMember.Prevmember.Name  
+SELECT{MEASURES.[CurrentMemberDemo],MEASURES.[ParentDemo],MEASURES.[AncestorDemo],MEASURES.[PrevMemberDemo] } ON 0,  
+[Date].[Calendar].MEMBERS ON 1  
+FROM [Adventure Works]  
+```  
   
 ## See Also  
  [Functions &#40;MDX Syntax&#41;](../mdx/functions-mdx-syntax.md)   

--- a/docs/mdx/using-scalar-expressions.md
+++ b/docs/mdx/using-scalar-expressions.md
@@ -19,31 +19,21 @@ ms.custom: mdx
   
  Scalar expressions are typically used in calculated member definitions, as calculated members must return a scalar value. The following query shows examples of calculated members on the Measures dimension that use different types of scalar expression:  
   
- `WITH`  
-  
- `MEMBER MEASURES.NumericValue AS 10`  
-  
- `MEMBER MEASURES.NumericExpression AS 10 + 10`  
-  
- `MEMBER MEASURES.NumericExpressionBasedOnMeasure AS [Measures].[Internet Sales Amount] + 10`  
-  
- `MEMBER MEASURES.StringValue AS "10"`  
-  
- `MEMBER MEASURES.ConcatenatedString AS "10" + "10"`  
-  
- `MEMBER MEASURES.StringFunction AS MEASURES.CURRENTMEMBER.NAME`  
-  
- `MEMBER MEASURES.TodaysDate AS NOW()`  
-  
- `SELECT`  
-  
- `{MEASURES.NumericValue,MEASURES.NumericExpression,MEASURES.NumericExpressionBasedOnMeasure,`  
-  
- `MEASURES.StringValue, MEASURES.ConcatenatedString, MEASURES.StringFunction, MEASURES.TodaysDate}`  
-  
- `ON COLUMNS`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH  
+MEMBER MEASURES.NumericValue AS 10  
+MEMBER MEASURES.NumericExpression AS 10 + 10  
+MEMBER MEASURES.NumericExpressionBasedOnMeasure AS [Measures].[Internet Sales Amount] + 10  
+MEMBER MEASURES.StringValue AS "10"  
+MEMBER MEASURES.ConcatenatedString AS "10" + "10"  
+MEMBER MEASURES.StringFunction AS MEASURES.CURRENTMEMBER.NAME  
+MEMBER MEASURES.TodaysDate AS NOW()  
+SELECT  
+{MEASURES.NumericValue,MEASURES.NumericExpression,MEASURES.NumericExpressionBasedOnMeasure,  
+MEASURES.StringValue, MEASURES.ConcatenatedString, MEASURES.StringFunction, MEASURES.TodaysDate}  
+ON COLUMNS  
+FROM [Adventure Works]  
+```  
   
  The only data type that a measure, calculated or otherwise, can return is the OLE Variant type. Therefore, sometimes you might need to cast a measure value to a particular type to receive the behavior you expect. The following query shows an example of this:  
   

--- a/docs/mdx/using-set-expressions.md
+++ b/docs/mdx/using-set-expressions.md
@@ -24,19 +24,15 @@ ms.custom: mdx
 ## Example  
  The following example shows two set expressions used on the Columns and Rows axes of a query:  
   
- `SELECT`  
-  
- `{[Measures].[Internet Sales Amount], [Measures].[Internet Tax Amount]} ON COLUMNS,`  
-  
- `{([Product].[Product Categories].[Category].&[4], [Date].[Calendar].[Calendar Year].&[2004]),`  
-  
- `([Product].[Product Categories].[Category].&[1], [Date].[Calendar].[Calendar Year].&[2003]),`  
-  
- `([Product].[Product Categories].[Category].&[3], [Date].[Calendar].[Calendar Year].&[2004])}`  
-  
- `ON ROWS`  
-  
- `FROM [Adventure Works]`  
+```  
+SELECT  
+{[Measures].[Internet Sales Amount], [Measures].[Internet Tax Amount]} ON COLUMNS,  
+{([Product].[Product Categories].[Category].&[4], [Date].[Calendar].[Calendar Year].&[2004]),  
+([Product].[Product Categories].[Category].&[1], [Date].[Calendar].[Calendar Year].&[2003]),  
+([Product].[Product Categories].[Category].&[3], [Date].[Calendar].[Calendar Year].&[2004])}  
+ON ROWS  
+FROM [Adventure Works]  
+```  
   
  On the Columns axis, the set  
   

--- a/docs/mdx/using-set-functions.md
+++ b/docs/mdx/using-set-functions.md
@@ -19,51 +19,35 @@ ms.custom: mdx
   
  One of the most common set functions is the [Members &#40;Set&#41; &#40;MDX&#41;](../mdx/members-set-mdx.md) function, which retrieves a set containing all of the members from a dimension, hierarchy, or level. The following is an example of its use within a query:  
   
- `SELECT`  
-  
- `//Returns all of the members on the Measures dimension`  
-  
- `[Measures].MEMBERS`  
-  
- `ON Columns,`  
-  
- `//Returns all of the members on the Calendar Year level of the Calendar Year Hierarchy`  
-  
- `//on the Date dimension`  
-  
- `[Date].[Calendar Year].[Calendar Year].MEMBERS`  
-  
- `ON Rows`  
-  
- `FROM [Adventure Works]`  
+```  
+SELECT  
+//Returns all of the members on the Measures dimension  
+[Measures].MEMBERS  
+ON Columns,  
+//Returns all of the members on the Calendar Year level of the Calendar Year Hierarchy  
+//on the Date dimension  
+[Date].[Calendar Year].[Calendar Year].MEMBERS  
+ON Rows  
+FROM [Adventure Works]  
+```  
   
  Another commonly used function is the [Crossjoin &#40;MDX&#41;](../mdx/crossjoin-mdx.md) function. It returns a set of tuples representing the cartesian product of the sets passed into it as parameters. In practical terms, this function enables you to create 'nested' or 'crosstabbed' axes in queries:  
   
- `SELECT`  
-  
- `//Returns all of the members on the Measures dimension`  
-  
- `[Measures].MEMBERS`  
-  
- `ON Columns,`  
-  
- `//Returns a set containing every combination of all of the members`  
-  
- `//on the Calendar Year level of the Calendar Year Hierarchy`  
-  
- `//on the Date dimension and all of the members on the Category level`  
-  
- `//of the Category hierarchy on the Product dimension`  
-  
- `Crossjoin(`  
-  
- `[Date].[Calendar Year].[Calendar Year].MEMBERS,`  
-  
- `[Product].[Category].[Category].MEMBERS)`  
-  
- `ON Rows`  
-  
- `FROM [Adventure Works]`  
+```  
+SELECT  
+//Returns all of the members on the Measures dimension  
+[Measures].MEMBERS  
+ON Columns,  
+//Returns a set containing every combination of all of the members  
+//on the Calendar Year level of the Calendar Year Hierarchy  
+//on the Date dimension and all of the members on the Category level  
+//of the Category hierarchy on the Product dimension  
+Crossjoin(  
+[Date].[Calendar Year].[Calendar Year].MEMBERS,  
+[Product].[Category].[Category].MEMBERS)  
+ON Rows  
+FROM [Adventure Works]  
+```  
   
  The [Descendants &#40;MDX&#41;](../mdx/descendants-mdx.md) function is similar the **Children** function, but is more powerful. It returns the descendants of any member at one or more levels in a hierarchy:  
   
@@ -89,125 +73,81 @@ ms.custom: mdx
   
  The [Order &#40;MDX&#41;](../mdx/order-mdx.md) function enables you to order the contents of a set in ascending or descending order according to a particular numeric expression. The following query returns the same members on rows as the previous query, but now orders them by the Internet Sales Amount measure:  
   
- `SELECT`  
-  
- `[Measures].[Internet Sales Amount]`  
-  
- `ON Columns,`  
-  
- `//Returns a set containing all of the Dates beneath Calendar Year`  
-  
- `//2004 in the Calendar hierarchy of the Date dimension`  
-  
- `//ordered by Internet Sales Amount`  
-  
- `ORDER(`  
-  
- `DESCENDANTS(`  
-  
- `[Date].[Calendar].[Calendar Year].&[2004]`  
-  
- `, [Date].[Calendar].[Date])`  
-  
- `, [Measures].[Internet Sales Amount], BDESC)`  
-  
- `ON Rows`  
-  
- `FROM [Adventure Works]`  
+```  
+SELECT  
+[Measures].[Internet Sales Amount]  
+ON Columns,  
+//Returns a set containing all of the Dates beneath Calendar Year  
+//2004 in the Calendar hierarchy of the Date dimension  
+//ordered by Internet Sales Amount  
+ORDER(  
+DESCENDANTS(  
+[Date].[Calendar].[Calendar Year].&[2004]  
+, [Date].[Calendar].[Date])  
+, [Measures].[Internet Sales Amount], BDESC)  
+ON Rows  
+FROM [Adventure Works]  
+```  
   
  This query also illustrates how the set returned from one set function, Descendants, can be passed as a parameter to another set function, Order.  
   
  Filtering a set according to certain criteria is very useful when writing queries, and for this purpose you can use the [Filter &#40;MDX&#41;](../mdx/filter-mdx.md) function, as shown in the following example:  
   
- `SELECT`  
-  
- `[Measures].[Internet Sales Amount]`  
-  
- `ON Columns,`  
-  
- `//Returns a set containing all of the Dates beneath Calendar Year`  
-  
- `//2004 in the Calendar hierarchy of the Date dimension`  
-  
- `//where Internet Sales Amount is greater than $70000`  
-  
- `FILTER(`  
-  
- `DESCENDANTS(`  
-  
- `[Date].[Calendar].[Calendar Year].&[2004]`  
-  
- `, [Date].[Calendar].[Date])`  
-  
- `, [Measures].[Internet Sales Amount]>70000)`  
-  
- `ON Rows`  
-  
- `FROM [Adventure Works]`  
+```  
+SELECT  
+[Measures].[Internet Sales Amount]  
+ON Columns,  
+//Returns a set containing all of the Dates beneath Calendar Year  
+//2004 in the Calendar hierarchy of the Date dimension  
+//where Internet Sales Amount is greater than $70000  
+FILTER(  
+DESCENDANTS(  
+[Date].[Calendar].[Calendar Year].&[2004]  
+, [Date].[Calendar].[Date])  
+, [Measures].[Internet Sales Amount]>70000)  
+ON Rows  
+FROM [Adventure Works]  
+```  
   
  Other, more sophisticated functions exist that allow you to filter a set in other ways. For example, the following query shows the [TopCount &#40;MDX&#41;](../mdx/topcount-mdx.md) function returns the top n items in a set:  
   
- `SELECT`  
-  
- `[Measures].[Internet Sales Amount]`  
-  
- `ON Columns,`  
-  
- `//Returns a set containing the top 10 Dates beneath Calendar Year`  
-  
- `//2004 in the Calendar hierarchy of the Date dimension by Internet Sales Amount`  
-  
- `TOPCOUNT(`  
-  
- `DESCENDANTS(`  
-  
- `[Date].[Calendar].[Calendar Year].&[2004]`  
-  
- `, [Date].[Calendar].[Date])`  
-  
- `,10, [Measures].[Internet Sales Amount])`  
-  
- `ON Rows`  
-  
- `FROM [Adventure Works]`  
+```  
+SELECT  
+[Measures].[Internet Sales Amount]  
+ON Columns,  
+//Returns a set containing the top 10 Dates beneath Calendar Year  
+//2004 in the Calendar hierarchy of the Date dimension by Internet Sales Amount  
+TOPCOUNT(  
+DESCENDANTS(  
+[Date].[Calendar].[Calendar Year].&[2004]  
+, [Date].[Calendar].[Date])  
+,10, [Measures].[Internet Sales Amount])  
+ON Rows  
+FROM [Adventure Works]  
+```  
   
  Finally it is possible to perform a number of logical set operations using functions such as [Intersect &#40;MDX&#41;](../mdx/intersect-mdx.md), [Union  &#40;MDX&#41;](../mdx/union-mdx.md) and [Except &#40;MDX&#41;](../mdx/except-mdx-function.md) functions. The following query shows examples of the latter two functions:  
   
- `SELECT`  
-  
- `//Returns a set containing the Measures Internet Sales Amount, Internet Tax Amount and`  
-  
- `//Internet Total Product Cost`  
-  
- `UNION(`  
-  
- `{[Measures].[Internet Sales Amount], [Measures].[Internet Tax Amount]}`  
-  
- `, {[Measures].[Internet Total Product Cost]}`  
-  
- `)`  
-  
- `ON Columns,`  
-  
- `//Returns a set containing all of the Dates beneath Calendar Year`  
-  
- `//2004 in the Calendar hierarchy of the Date dimension`  
-  
- `//except the January 1st 2004`  
-  
- `EXCEPT(`  
-  
- `DESCENDANTS(`  
-  
- `[Date].[Calendar].[Calendar Year].&[2004]`  
-  
- `, [Date].[Calendar].[Date])`  
-  
- `,{[Date].[Calendar].[Date].&[915]})`  
-  
- `ON Rows`  
-  
- `FROM [Adventure Works]`  
+```  
+SELECT  
+//Returns a set containing the Measures Internet Sales Amount, Internet Tax Amount and  
+//Internet Total Product Cost  
+UNION(  
+{[Measures].[Internet Sales Amount], [Measures].[Internet Tax Amount]}  
+, {[Measures].[Internet Total Product Cost]}  
+)  
+ON Columns,  
+//Returns a set containing all of the Dates beneath Calendar Year  
+//2004 in the Calendar hierarchy of the Date dimension  
+//except the January 1st 2004  
+EXCEPT(  
+DESCENDANTS(  
+[Date].[Calendar].[Calendar Year].&[2004]  
+, [Date].[Calendar].[Date])  
+,{[Date].[Calendar].[Date].&[915]})  
+ON Rows  
+FROM [Adventure Works]  
+```  
   
 ## See Also  
  [Functions &#40;MDX Syntax&#41;](../mdx/functions-mdx-syntax.md)   

--- a/docs/mdx/using-string-functions.md
+++ b/docs/mdx/using-string-functions.md
@@ -20,77 +20,52 @@ ms.custom: mdx
 ## Examples  
  The following example queries show how to use these functions:  
   
- `WITH`  
-  
- `//Returns the name of the current Product on rows`  
-  
- `MEMBER [Measures].[ProductName] AS [Product].[Product].CurrentMember.Name`  
-  
- `//Returns the uniquename of the current Product on rows`  
-  
- `MEMBER [Measures].[ProductUniqueName] AS [Product].[Product].CurrentMember.Uniquename`  
-  
- `//Returns the name of the Product dimension`  
-  
- `MEMBER [Measures].[ProductDimensionName] AS [Product].Name`  
-  
- `SELECT  {[Measures].[ProductName],[Measures].[ProductUniqueName],[Measures].[ProductDimensionName]}`  
-  
- `ON COLUMNS,`  
-  
- `[Product].[Product].MEMBERS  ON ROWS`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH  
+//Returns the name of the current Product on rows  
+MEMBER [Measures].[ProductName] AS [Product].[Product].CurrentMember.Name  
+//Returns the uniquename of the current Product on rows  
+MEMBER [Measures].[ProductUniqueName] AS [Product].[Product].CurrentMember.Uniquename  
+//Returns the name of the Product dimension  
+MEMBER [Measures].[ProductDimensionName] AS [Product].Name  
+SELECT  {[Measures].[ProductName],[Measures].[ProductUniqueName],[Measures].[ProductDimensionName]}  
+ON COLUMNS,  
+[Product].[Product].MEMBERS  ON ROWS  
+FROM [Adventure Works]  
+```  
   
  The **Generate** function can be used to execute a string function on every member of a set and concatenate the results. This also can be useful when debugging calculations as it allows you to visualize the contents of a set. The following example shows how to use it in this way:  
   
- `WITH`  
-  
- `//Returns the names of the current Product and its ancestors up to the All Member`  
-  
- `MEMBER [Measures].[AncestorNames] AS`  
-  
- `GENERATE(`  
-  
- `ASCENDANTS([Product].[Product Categories].CurrentMember)`  
-  
- `, [Product].[Product Categories].CurrentMember.Name, ", ")`  
-  
- `SELECT`  
-  
- `{[Measures].[AncestorNames]}`  
-  
- `ON COLUMNS,`  
-  
- `[Product].[Product Categories].MEMBERS  ON ROWS`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH  
+//Returns the names of the current Product and its ancestors up to the All Member  
+MEMBER [Measures].[AncestorNames] AS  
+GENERATE(  
+ASCENDANTS([Product].[Product Categories].CurrentMember)  
+, [Product].[Product Categories].CurrentMember.Name, ", ")  
+SELECT  
+{[Measures].[AncestorNames]}  
+ON COLUMNS,  
+[Product].[Product Categories].MEMBERS  ON ROWS  
+FROM [Adventure Works]  
+```  
   
  Another group of widely used string functions are those that enable you to cast a string containing the uniquename of an object or an expression which resolves to the object into the object itself. The following example query demonstrates how the **StrToMember** and **StrToSet** functions do this:  
   
- `SELECT`  
-  
- `{StrToMember("[Measures].[Inter" + "net Sales Amount]")}`  
-  
- `ON COLUMNS,`  
-  
- `StrToSet("{`  
-  
- `[Product].[Product Categories].[Category].&[3],`  
-  
- `[Product].[Product Categories].[Product].&[477],`  
-  
- `[Product].[Product Categories].[Product].&[788],`  
-  
- `[Product].[Product Categories].[Product].&[708],`  
-  
- `[Product].[Product Categories].[Product].&[711]`  
-  
- `}")`  
-  
- `ON ROWS`  
-  
- `FROM [Adventure Works]`  
+```  
+SELECT  
+{StrToMember("[Measures].[Inter" + "net Sales Amount]")}  
+ON COLUMNS,  
+StrToSet("{  
+[Product].[Product Categories].[Category].&[3],  
+[Product].[Product Categories].[Product].&[477],  
+[Product].[Product Categories].[Product].&[788],  
+[Product].[Product Categories].[Product].&[708],  
+[Product].[Product Categories].[Product].&[711]  
+}")  
+ON ROWS  
+FROM [Adventure Works]  
+```  
   
 > [!NOTE]  
 >  The **StrToMember** and **StrToSet** functions should be used with caution. They can lead to poor query performance if they are used within calculation definitions.  

--- a/docs/mdx/using-tuple-functions.md
+++ b/docs/mdx/using-tuple-functions.md
@@ -19,27 +19,19 @@ ms.custom: mdx
   
  There are three tuple functions in MDX, [Current &#40;MDX&#41;](../mdx/current-mdx.md), [Item &#40;Tuple&#41; &#40;MDX&#41;](../mdx/item-tuple-mdx.md) and [StrToTuple &#40;MDX&#41;](../mdx/strtotuple-mdx.md). The following example query shows how to use of each of them:  
   
- `WITH`  
-  
- `//Creates a set of tuples consisting of Years and Countries`  
-  
- `SET MyTuples AS  [Date].[Calendar Year].[Calendar Year].MEMBERS * [Customer].[Country].[Country].MEMBERS`  
-  
- `//Returns a string representation of that set using the Current and Generate functions`  
-  
- `MEMBER MEASURES.CURRENTDEMO AS GENERATE(MyTuples, TUPLETOSTR(MyTuples.CURRENT), ", ")`  
-  
- `//Retrieves the fourth tuple from that set and displays it as a string`  
-  
- `MEMBER MEASURES.ITEMDEMO AS TUPLETOSTR(MyTuples.ITEM(3))`  
-  
- `//Creates a tuple consisting of the measure Internet Sales Amount and the country Australia from a string`  
-  
- `MEMBER MEASURES.STRTOTUPLEDEMO AS STRTOTUPLE("([Measures].[Internet Sales Amount]" + ", [Customer].[Country].&[Australia])")`  
-  
- `SELECT{MEASURES.CURRENTDEMO,MEASURES.ITEMDEMO,MEASURES.STRTOTUPLEDEMO} ON COLUMNS`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH  
+//Creates a set of tuples consisting of Years and Countries  
+SET MyTuples AS  [Date].[Calendar Year].[Calendar Year].MEMBERS * [Customer].[Country].[Country].MEMBERS  
+//Returns a string representation of that set using the Current and Generate functions  
+MEMBER MEASURES.CURRENTDEMO AS GENERATE(MyTuples, TUPLETOSTR(MyTuples.CURRENT), ", ")  
+//Retrieves the fourth tuple from that set and displays it as a string  
+MEMBER MEASURES.ITEMDEMO AS TUPLETOSTR(MyTuples.ITEM(3))  
+//Creates a tuple consisting of the measure Internet Sales Amount and the country Australia from a string  
+MEMBER MEASURES.STRTOTUPLEDEMO AS STRTOTUPLE("([Measures].[Internet Sales Amount]" + ", [Customer].[Country].&[Australia])")  
+SELECT{MEASURES.CURRENTDEMO,MEASURES.ITEMDEMO,MEASURES.STRTOTUPLEDEMO} ON COLUMNS  
+FROM [Adventure Works]  
+```  
   
 ## See Also  
  [Functions &#40;MDX Syntax&#41;](../mdx/functions-mdx-syntax.md)   

--- a/docs/mdx/validmeasure-mdx.md
+++ b/docs/mdx/validmeasure-mdx.md
@@ -55,13 +55,12 @@ FROM [Adventure Works]
   
  Similarly, the Sales Targets measure group has no relationship at all with the Promotion dimension, so below the All Member of any hierarchy on Promotion it will return null. Again, this behavior can be changed by using ValidMeasure:  
   
- `WITH MEMBER MEASURES.VTEST AS VALIDMEASURE([Measures].[Sales Amount Quota])`  
-  
- `SELECT {[Measures].[Sales Amount Quota], MEASURES.VTEST} ON 0,`  
-  
- `[Promotion].[Promotions].members ON 1`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH MEMBER MEASURES.VTEST AS VALIDMEASURE([Measures].[Sales Amount Quota])  
+SELECT {[Measures].[Sales Amount Quota], MEASURES.VTEST} ON 0,  
+[Promotion].[Promotions].members ON 1  
+FROM [Adventure Works]  
+```  
   
 ## See Also  
  [MDX Function Reference &#40;MDX&#41;](../mdx/mdx-function-reference-mdx.md)  

--- a/docs/mdx/working-with-empty-values.md
+++ b/docs/mdx/working-with-empty-values.md
@@ -62,51 +62,35 @@ WHERE([Date].[Calendar].[Calendar Year].&[2001])
   
  To remove empty rows or columns from a query, you can use the NON EMPTY statement before the axis set definition. For example, the following query only returns the Product Category Bikes because that is the only Category that was sold in the Calendar Year 2001:  
   
- `SELECT`  
-  
- `{[Measures].[Internet Tax Amount]}`  
-  
- `ON COLUMNS,`  
-  
- `//Comment out the following line to display all the empty rows for other Categories`  
-  
- `NON EMPTY`  
-  
- `[Product].[Category].[Category].MEMBERS`  
-  
- `ON ROWS`  
-  
- `FROM [Adventure Works]`  
-  
- `WHERE([Date].[Calendar].[Calendar Year].&[2001])`  
+```  
+SELECT  
+{[Measures].[Internet Tax Amount]}  
+ON COLUMNS,  
+//Comment out the following line to display all the empty rows for other Categories  
+NON EMPTY  
+[Product].[Category].[Category].MEMBERS  
+ON ROWS  
+FROM [Adventure Works]  
+WHERE([Date].[Calendar].[Calendar Year].&[2001])  
+```  
   
  More generally, to remove empty tuples from a set you can use the NonEmpty function. The following query shows two calculated measures, one of which counts the number of Product Categories and the second shows the number of Product Categories which have values for the measure [Internet Tax Amount] and the Calendar Year 2001:  
   
- `WITH`  
-  
- `MEMBER MEASURES.CategoryCount AS`  
-  
- `COUNT([Product].[Category].[Category].MEMBERS)`  
-  
- `MEMBER MEASURES.NonEmptyCategoryCountFor2001 AS`  
-  
- `COUNT(`  
-  
- `NONEMPTY(`  
-  
- `[Product].[Category].[Category].MEMBERS`  
-  
- `,([Date].[Calendar].[Calendar Year].&[2001], [Measures].[Internet Tax Amount])`  
-  
- `))`  
-  
- `SELECT`  
-  
- `{MEASURES.CategoryCount,MEASURES.NonEmptyCategoryCountFor2001 }`  
-  
- `ON COLUMNS`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH  
+MEMBER MEASURES.CategoryCount AS  
+COUNT([Product].[Category].[Category].MEMBERS)  
+MEMBER MEASURES.NonEmptyCategoryCountFor2001 AS  
+COUNT(  
+NONEMPTY(  
+[Product].[Category].[Category].MEMBERS  
+,([Date].[Calendar].[Calendar Year].&[2001], [Measures].[Internet Tax Amount])  
+))  
+SELECT  
+{MEASURES.CategoryCount,MEASURES.NonEmptyCategoryCountFor2001 }  
+ON COLUMNS  
+FROM [Adventure Works]  
+```  
   
  For more information, see [NonEmpty &#40;MDX&#41;](../mdx/nonempty-mdx.md).  
   

--- a/docs/mdx/ytd-mdx.md
+++ b/docs/mdx/ytd-mdx.md
@@ -50,15 +50,13 @@ WHERE
   
  **Ytd** is frequently used in combination with no parameters specified, meaning that the [CurrentMember &#40;MDX&#41;](../mdx/currentmember-mdx.md) function will display a running cumulative year-to-date total in a report, as shown in the following query:  
   
- `WITH MEMBER MEASURES.YTDDEMO AS`  
-  
- `AGGREGATE(YTD(), [Measures].[Internet Sales Amount])`  
-  
- `SELECT {[Measures].[Internet Sales Amount], MEASURES.YTDDEMO} ON 0,`  
-  
- `[Date].[Calendar].MEMBERS ON 1`  
-  
- `FROM [Adventure Works]`  
+```  
+WITH MEMBER MEASURES.YTDDEMO AS  
+AGGREGATE(YTD(), [Measures].[Internet Sales Amount])  
+SELECT {[Measures].[Internet Sales Amount], MEASURES.YTDDEMO} ON 0,  
+[Date].[Calendar].MEMBERS ON 1  
+FROM [Adventure Works]  
+```  
   
 ## See Also  
  [MDX Function Reference &#40;MDX&#41;](../mdx/mdx-function-reference-mdx.md)  


### PR DESCRIPTION
Currently, there are many MDX examples that look like they should be code blocks but are single-line code segments separated by blank lines. This is not good for readability, and they should be combined in a true fenced code block.