### PR TITLE
Update trustworthy-database-property.md

### DIFF
--- a/docs/relational-databases/security/trustworthy-database-property.md
+++ b/docs/relational-databases/security/trustworthy-database-property.md
@@ -18,7 +18,8 @@ helpviewer_keywords:
 The `TRUSTWORTHY` database property is used to indicate whether the instance of [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] trusts the database and the contents within it. By default, this setting is OFF, but can be set to ON by using the `ALTER DATABASE` statement. For example: `ALTER DATABASE AdventureWorks2022 SET TRUSTWORTHY ON;`.
 
 > [!NOTE]  
-> To set this option, you must be a member of the **sysadmin** fixed server role or member of control server securable.
+> To set this option, you must have `CONTROL SERVER` permission, or be a member of the **sysadmin** fixed server role.
+
 
 We recommend that you leave the `TRUSTWORTHY` database property set to OFF to mitigate certain threats that can exist as a result of attaching a database that contains one of the following objects:
 

--- a/docs/relational-databases/security/trustworthy-database-property.md
+++ b/docs/relational-databases/security/trustworthy-database-property.md
@@ -18,7 +18,7 @@ helpviewer_keywords:
 The `TRUSTWORTHY` database property is used to indicate whether the instance of [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] trusts the database and the contents within it. By default, this setting is OFF, but can be set to ON by using the `ALTER DATABASE` statement. For example: `ALTER DATABASE AdventureWorks2022 SET TRUSTWORTHY ON;`.
 
 > [!NOTE]  
-> To set this option, you must be a member of the **sysadmin** fixed server role.
+> To set this option, you must be a member of the **sysadmin** fixed server role or member of control server securable.
 
 We recommend that you leave the `TRUSTWORTHY` database property set to OFF to mitigate certain threats that can exist as a result of attaching a database that contains one of the following objects:
 

--- a/docs/relational-databases/security/trustworthy-database-property.md
+++ b/docs/relational-databases/security/trustworthy-database-property.md
@@ -20,7 +20,6 @@ The `TRUSTWORTHY` database property is used to indicate whether the instance of 
 > [!NOTE]  
 > To set this option, you must have `CONTROL SERVER` permission, or be a member of the **sysadmin** fixed server role.
 
-
 We recommend that you leave the `TRUSTWORTHY` database property set to OFF to mitigate certain threats that can exist as a result of attaching a database that contains one of the following objects:
 
 - Malicious assemblies with an EXTERNAL_ACCESS or UNSAFE permission setting. For more information, see [CLR Integration Security](../../relational-databases/clr-integration/security/clr-integration-security.md).


### PR DESCRIPTION
Hello,

this documentation should be updated as follows:

To set this option, you must be a member of the **sysadmin** fixed server role **or member of control server securable.**

an account granted control server securable can alter/change the setting of any database trustworthy which is dangerous and i have blogged recently about it: https://databasesecurityninja.wordpress.com/2025/02/07/privilege-escalation-from-control-server-to-sysadmin-role/

Thanks,
Emad Al-Mousa
