### PR TITLE
Clarify PERCENT parameter description regarding row rounding behavior

### DIFF
--- a/docs/t-sql/queries/top-transact-sql.md
+++ b/docs/t-sql/queries/top-transact-sql.md
@@ -58,7 +58,7 @@ The numeric expression that specifies the number of rows to be returned. *expres
 
 #### PERCENT
 
-Indicates that the query returns only the first *expression* percent of rows from the result set. Fractional values are rounded up to the next integer value.
+Indicates that the query returns only the first *expression* percent of rows from the result set. If the calculated number of rows is a fraction, it is rounded up to the next whole number.
 
 #### WITH TIES
 

--- a/docs/t-sql/queries/top-transact-sql.md
+++ b/docs/t-sql/queries/top-transact-sql.md
@@ -58,7 +58,7 @@ The numeric expression that specifies the number of rows to be returned. *expres
 
 #### PERCENT
 
-Indicates that the query returns only the first *expression* percent of rows from the result set. If the calculated number of rows is a fraction, it is rounded up to the next whole number.
+Indicates that the query returns only the first *expression* percent of rows from the result set. If the calculated number of rows is a fraction, it's rounded up to the next whole number.
 
 #### WITH TIES
 


### PR DESCRIPTION
Reworded the documentation for the PERCENT parameter to clearly state that the number of rows returned is rounded up when the calculated percentage results in a fractional value. This avoids confusion about whether fractional percentages can be specified in the query