### PR TITLE
Update fabric-mirrored-databases.md

### DIFF
--- a/docs/sql-server/fabric-database/fabric-mirrored-databases.md
+++ b/docs/sql-server/fabric-database/fabric-mirrored-databases.md
@@ -1,6 +1,6 @@
 ---
-title: "Microsoft Fabric mirrored databases"
-description: Learn about the mirrored databases in Microsoft Fabric, from SQL Server and Azure SQL Database, to allow for real-time analytics of data in Microsoft Fabric.
+title: "Mirroring and Database Mirroring in Microsoft Fabric"
+description: Learn about mirrored databases, from mirrored SQL Server database to mirrored Azure SQL database, to allow for real-time analytics of data in Microsoft Fabric.
 author: WilliamDAssafMSFT
 ms.author: wiassaf
 ms.reviewer: imotiwala, roblescarlos, maprycem
@@ -9,10 +9,10 @@ ms.service: fabric
 ms.topic: conceptual
 monikerRange: "=azuresqldb-current||=fabric"
 ---
-# Microsoft Fabric mirrored databases
+# Mirrored databases in Microsoft Fabric
 [!INCLUDE [asdb-fabric](../../includes/applies-to-version/asdb-fabric.md)]
 
-You can [mirror databases in Azure SQL Database to Microsoft Fabric](/fabric/database/mirrored-database/overview). You can continuously replicate your existing data estate directly into Fabric's OneLake, including data from Azure SQL Database.
+You can [mirror databases in Azure SQL Database to Microsoft Fabric](/fabric/database/mirrored-database/overview). You can continuously replicate your existing data estate directly into Fabric's OneLake, including data from Azure SQL database.
 
 For more information, see:
 
@@ -22,24 +22,24 @@ For more information, see:
 
 This feature is not currently available for Azure SQL Managed Instance or SQL Server instances.
 
-## What are Fabric mirrored databases?
+## What are mirrored databases in Fabric?
 
 Mirroring in Fabric provides an easy experience to speed the time-to-value for insights and decisions, and to break down data silos between technology solutions, without developing expensive Extract, Transform, and Load (ETL) processes to move data.
 
 With the most up-to-date data in a queryable format in OneLake, you can now use all the different services in Fabric, such as running analytics with Spark, executing notebooks, data engineering, visualizing through Power BI Reports, and more.
 
-With Mirroring in Fabric, you don't need to piece together different services from multiple vendors. Instead, you can enjoy a highly integrated, end-to-end, and easy-to-use product that is designed to simplify your analytics needs, and built for openness and collaboration between technology solutions that can read the open-source Delta Lake table format.
+With mirroring, you don't need to piece together different services from multiple vendors. Instead, you can enjoy a highly integrated, end-to-end, and easy-to-use product that is designed to simplify your analytics needs, and built for openness and collaboration between technology solutions that can read the open-source Delta Lake table format.
 
-## Fabric mirrored databases technology
+## The technology within mirrored databases
 
-The Fabric mirrored database feature uses similar change feed technology as the Azure Synapse Link, and shares some system objects.
+The mirroring feature uses similar change feed technology as the Azure Synapse Link, and shares some system objects.
 
 > [!NOTE]
-> Enabling Mirroring via the Fabric portal will create a `changefeed` database user, a `changefeed` schema, and several tables within the `changefeed` schema in your source database. Do not alter any of these system-managed objects.
+> Enabling mirroring via the Fabric portal will create a `changefeed` database user, a `changefeed` schema, and several tables within the `changefeed` schema in your source database. Do not alter any of these system-managed objects.
 
-## SQL database in Microsoft Fabric
+## Mirrored SQL database
 
-You can also create an SQL database in Microsoft Fabric. With [SQL database in Fabric](/fabric/database/sql/overview), your data is automatically accessible from other Fabric experiences. SQL database in Microsoft Fabric, which uses the same SQL Database Engine as Microsoft SQL Server and is similar to Azure SQL Database, inherits most of the Fabric mirroring capabilities from Azure SQL Database. Your SQL database in Fabric is automatically mirrored to OneLake and presented in a read-only, queryable format. You can use all the different services in Fabric, such as running analytics with Spark, executing notebooks, data engineering, visualizing through Power BI Reports, and more.
+You can also create a mirrored SQL database in Microsoft Fabric. With [SQL database in Fabric](/fabric/database/sql/overview), your data is automatically accessible from other Fabric experiences. SQL database in Microsoft Fabric, which uses the same SQL Database Engine as Microsoft SQL Server and is similar to Azure SQL Database, inherits most of the Fabric mirroring capabilities from Azure SQL database. Your SQL database in Fabric is automatically mirrored to OneLake and presented in a read-only, queryable format. You can use all the different services in Fabric, such as running analytics with Spark, executing notebooks, data engineering, visualizing through Power BI Reports, and more.
 
 For more information, see [SQL database in Microsoft Fabric (Preview)](sql-database-in-fabric.md).
 


### PR DESCRIPTION
For Mirroring, we refer to this product in two ways…


**In documentation –** We use the term Mirroring and Database Mirroring. Thus, Mirroring Azure SQL Managed Instance, Mirroring Snowflake, etc etc. 

Thus, in docs, we should refer to Mirroring SQL Server.

 
**In Fabric –** It is always Mirrored database. For example, Mirrored Azure SQL MI, Mirrored Snowflake, etc. Thus, in-product, we should refer to it as Mirrored SQL Server.