### PR TITLE
Update permission references and add a note about additional required permissions

### DIFF
--- a/azure-sql/database/authentication-azure-ad-user-assigned-managed-identity.md
+++ b/azure-sql/database/authentication-azure-ad-user-assigned-managed-identity.md
@@ -61,8 +61,7 @@ These permissions should be granted before you provision a logical server or man
 - [GroupMember.Read.All](/graph/permissions-reference#groupmemberreadall): Allows access to Microsoft Entra group information.
 - [Application.Read.All](/graph/permissions-reference#applicationreadalls): Allows access to Microsoft Entra service principal (application) information.
 
-> [!NOTE]
-> For creation of a contained database userr for a Microsoft Entra group, `Group.Read.All` permission is required additionally to the ones listed above.
+To create a contained database user for a Microsoft Entra group, the `Group.Read.All` permission is required additionally to the ones listed above.
 
 ### Grant permissions
 

--- a/azure-sql/database/authentication-azure-ad-user-assigned-managed-identity.md
+++ b/azure-sql/database/authentication-azure-ad-user-assigned-managed-identity.md
@@ -57,9 +57,12 @@ These permissions should be granted before you provision a logical server or man
 > [!IMPORTANT]
 > Only a [Privileged Role Administrator](/entra/identity/role-based-access-control/permissions-reference#privileged-role-administrator) or higher role can grant these permissions.
 
-- [User.Read.All](/graph/permissions-reference#user-permissions): Allows access to Microsoft Entra user information.
-- [GroupMember.Read.All](/graph/permissions-reference#group-permissions): Allows access to Microsoft Entra group information.
-- [Application.Read.ALL](/graph/permissions-reference#application-resource-permissions): Allows access to Microsoft Entra service principal (application) information.
+- [User.Read.All](/graph/permissions-reference#userreadall): Allows access to Microsoft Entra user information.
+- [GroupMember.Read.All](/graph/permissions-reference#groupmemberreadall): Allows access to Microsoft Entra group information.
+- [Application.Read.All](/graph/permissions-reference#applicationreadalls): Allows access to Microsoft Entra service principal (application) information.
+
+> [!NOTE]
+> For creation of a contained database userr for a Microsoft Entra group, `Group.Read.All` permission is required additionally to the ones listed above.
 
 ### Grant permissions
 


### PR DESCRIPTION
This pull request includes changes to the `azure-sql/database/authentication-azure-ad-user-assigned-managed-identity.md` file to update permission references and add a note about additional required permissions for creating a contained database user for a Microsoft Entra group.

Permission reference updates:

* Updated the URLs for `User.Read.All`, `GroupMember.Read.All`, and `Application.Read.All` to correct paths.

Additional permissions note:

* Added a note indicating that the `Group.Read.All` permission is also required for the creation of a contained database user for a Microsoft Entra group.