### PR TITLE
Update create-availability-group-transact-sql.md for cluster_type nam…

### DIFF
--- a/docs/t-sql/statements/create-availability-group-transact-sql.md
+++ b/docs/t-sql/statements/create-availability-group-transact-sql.md
@@ -110,7 +110,7 @@ CREATE AVAILABILITY GROUP group_name
 
 #### *group_name*
 
-Specifies the name of the new availability group. *group_name* must be a valid [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)][identifier](../../relational-databases/databases/database-identifiers.md), and it must be unique across all availability groups in the WSFC cluster. The maximum length for an availability group name is 128 characters.  
+Specifies the name of the new availability group. *group_name* must be a valid [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)][identifier](../../relational-databases/databases/database-identifiers.md), and it must be unique across all availability groups in the WSFC cluster. The maximum length for an availability group name is 128 characters for cluster_type WSFC and 64 characters for cluster_type NONE and EXTERNAL.  
 
 #### AUTOMATED_BACKUP_PREFERENCE = { PRIMARY \| SECONDARY_ONLY \| SECONDARY \| NONE }  
 


### PR DESCRIPTION
Updated the documentation to provide the maximum availability group name lengths per cluster_type. WSFC has a maximum length of 128 and none/external have a maximum length of 64.