### PR TITLE
Clarify overriding of hints and ignoring hints on failure

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sys-sp-query-store-set-hints-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sys-sp-query-store-set-hints-transact-sql.md
@@ -59,11 +59,11 @@ By default, the scope of a new Query Store hint is the local replica only. *@que
 
 Hints are specified in a valid T-SQL string format `N'OPTION (..)'`.
 
-- If no Query Store hints exist for a specific *query_id*, a new Query Store hint will be created.
-- If a Query Store hints already exists for a specific *query_id*, the value specified for `@query_hints` will override previously specified hints for the associated query.
+- If no Query Store hints exist for a specific `query_id`, a new Query Store hint is created.
+- If a Query Store hint already exists for a specific `query_id`, the value specified for `@query_hints` overrides previously specified hints for the associated query.
 - If a *query_id* doesn't exist, an error will be raised.
 
-In the cases where one of the hints would prevent a query plan being produced, all the hints will be ignored. The latest failure details can be viewed in [sys.query_store_query_hints](../system-catalog-views/sys-query-store-query-hints-transact-sql.md).
+In the case where one of the hints would prevent a query plan being produced, all the hints are ignored. For more information about failure details, see [sys.query_store_query_hints](../system-catalog-views/sys-query-store-query-hints-transact-sql.md).
 
 To remove hints associated with a *query_id*, use the system stored procedure [sys.sp_query_store_clear_hints](sys-sp-query-store-clear-hints-transact-sql.md).
 

--- a/docs/relational-databases/system-stored-procedures/sys-sp-query-store-set-hints-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sys-sp-query-store-set-hints-transact-sql.md
@@ -59,11 +59,11 @@ By default, the scope of a new Query Store hint is the local replica only. *@que
 
 Hints are specified in a valid T-SQL string format `N'OPTION (..)'`.
 
-- If no Query Store hint exists for a specific *query_id*, a new Query Store hint will be created.
-- If a Query Store hint already exists for a specific *query_id*, the last value provided will override previously specified values for the associated query.
+- If no Query Store hints exist for a specific *query_id*, a new Query Store hint will be created.
+- If a Query Store hints already exists for a specific *query_id*, the value specified for `@query_hints` will override previously specified hints for the associated query.
 - If a *query_id* doesn't exist, an error will be raised.
 
-In the cases where a hint would cause a query to fail, the hint is ignored and the latest failure details can be viewed in [sys.query_store_query_hints](../system-catalog-views/sys-query-store-query-hints-transact-sql.md).
+In the cases where one of the hints would prevent a query plan being produced, all the hints will be ignored. The latest failure details can be viewed in [sys.query_store_query_hints](../system-catalog-views/sys-query-store-query-hints-transact-sql.md).
 
 To remove hints associated with a *query_id*, use the system stored procedure [sys.sp_query_store_clear_hints](sys-sp-query-store-clear-hints-transact-sql.md).
 

--- a/docs/relational-databases/system-stored-procedures/sys-sp-query-store-set-hints-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sys-sp-query-store-set-hints-transact-sql.md
@@ -59,8 +59,8 @@ By default, the scope of a new Query Store hint is the local replica only. *@que
 
 Hints are specified in a valid T-SQL string format `N'OPTION (..)'`.
 
-- If no Query Store hints exist for a specific `query_id`, a new Query Store hint is created.
-- If a Query Store hint already exists for a specific `query_id`, the value specified for `@query_hints` overrides previously specified hints for the associated query.
+- If no Query Store hints exist for a specific *@query_id*, a new Query Store hint is created.
+- If a Query Store hint already exists for a specific *@query_id*, the value specified for *@query_hints* overrides previously specified hints for the associated query.
 - If a *query_id* doesn't exist, an error will be raised.
 
 In the case where one of the hints would prevent a query plan being produced, all the hints are ignored. For more information about failure details, see [sys.query_store_query_hints](../system-catalog-views/sys-query-store-query-hints-transact-sql.md).


### PR DESCRIPTION
Clarifying that executing this will store the hints passed and overwrite any existing stored hint.  

In the event of one hint preventing a plan being produced ALL hints will be ignored.

Tried to standardise on the use of hints and hint given you can specify one or more hints