### PR TITLE
Update authentication-aad-directory-readers-role-tutorial.md.

### DIFF
--- a/azure-sql/database/authentication-aad-directory-readers-role-tutorial.md
+++ b/azure-sql/database/authentication-aad-directory-readers-role-tutorial.md
@@ -143,7 +143,7 @@ Assigning the **Directory Readers** role to the server identity isn't required f
     ```
 
     ```powershell
-    $GrOwner = New-MgGroupOwnerByRef -GroupId $group.Id -DirectoryObjectId $newGroupOwner.Id
+    $GrOwner = New-MgGroupOwnerByRef -GroupId $group.Id -OdataId "https://graph.microsoft.com/v1.0/users/$($newGroupOwner.Id)" 
     ```
 
     Check owners of the group:


### PR DESCRIPTION
Fixes out of date PowerShell example for creating a new group owner.
The PowerShell cmdlet [New-MgGroupOwnerByRef](https://learn.microsoft.com/en-us/powershell/module/microsoft.graph.groups/new-mggroupownerbyref?view=graph-powershell-1.0) does not support the argument `DirectoryObjectId` as specified in these docs.

This change updates the documentation to reflect a functionally-tested working example of a usage of `New-MgGroupOwnerByRef` within the context of this example.