### PR TITLE
Update sql-server-linux-deploy-pacemaker-cluster.md

### DIFF
--- a/docs/linux/sql-server-linux-deploy-pacemaker-cluster.md
+++ b/docs/linux/sql-server-linux-deploy-pacemaker-cluster.md
@@ -239,6 +239,7 @@ sudo systemctl restart mssql-server
 
 ```bash
 sudo zypper install mssql-server-ha mssql-server-agent
+[//]: # (mssql-server-agent package is not available in the repo: https://packages.microsoft.com/rhel/9/mssql-server-2022/Packages/m/. How can you install this package?)
 sudo systemctl restart mssql-server
 ```
 


### PR DESCRIPTION
mssql-server-agent package is not available in https://packages.microsoft.com/rhel/9/mssql-server-2022/Packages/m/