### PR TITLE
Fix PowerShell Boolean casting issue in Execute method

### DIFF
--- a/docs/integration-services/ssis-quickstart-run-powershell.md
+++ b/docs/integration-services/ssis-quickstart-run-powershell.md
@@ -48,7 +48,7 @@ Below is a basic example of how to execute an SSIS package in a package catalog 
 
 ```powershell
 (Get-ChildItem SQLSERVER:\SSIS\localhost\Default\Catalogs\SSISDB\Folders\Project1Folder\Projects\'Integration Services Project1'\Packages\ |
-WHERE { $_.Name -eq 'Package.dtsx' }).Execute("false", $null)
+WHERE { $_.Name -eq 'Package.dtsx' }).Execute($false, $null)
 ```
 
 ## PowerShell script
@@ -91,7 +91,7 @@ $package = $project.Packages[$PackageName]
 
 Write-Host "Running " $PackageName "..."
 
-$result = $package.Execute("false", $null)
+$result = $package.Execute($false, $null)
 
 Write-Host "Done."
 ```


### PR DESCRIPTION
This PR corrects a misleading example in the PowerShell example for the PackageInfo.Execute method usage.

**Issue:**
In PowerShell, passing "false" (a string) instead of $false (a Boolean) incorrectly evaluates to $true.

**Fix:**
Updated documentation to clarify that false should be passed as $false (Boolean) instead of "false" (string).
Ensured that examples use the correct Boolean syntax to prevent execution mode misconfigurations.

**Impact:**
This fix ensures that users do not unintentionally enable 32-bit execution mode due to incorrect PowerShell type casting.

**Reference Issue:**
PowerShell automatically evaluates non-empty strings as $true, causing Execute("false", $envRef) to behave incorrectly.
Expected usage should be Execute($false, $envRef).

Please review and approve.