### PR TITLE
Update sys-fn-hadr-backup-is-preferred-replica-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-functions/sys-fn-hadr-backup-is-preferred-replica-transact-sql.md
+++ b/docs/relational-databases/system-functions/sys-fn-hadr-backup-is-preferred-replica-transact-sql.md
@@ -46,6 +46,8 @@ Returns data type **bit**: `1` if the database on the current instance is on the
 
 For databases that aren't part of an availability group, this function always returns `1`.
 
+If the database specified does not exist, the function would return 1 before SQL 2019 CU20 and SQL 2022 CU2. Starting from these 2 versions, the function would return 0 in this scenario. 
+
 ## Remarks
 
 Use this function in a backup script to determine if the current database is on the replica that is preferred for backups. You can run a script on every availability replica. Each of these jobs looks at the same data to determine which job should run, so only one of the scheduled jobs actually proceeds to the backup stage. Sample code could be similar to the following.


### PR DESCRIPTION
The behavior change on this function leads some issues on our customer's side in one support case. We found that the change was introduced in SQL 2019 CU20 and SQL 2022 CU2 to fix another case sensitive issue. The related fix info is missing in official document for both CUs. Customer requests for the official document on this change.