### PR TITLE
Update entra-id-tutorial.md

### DIFF
--- a/docs/includes/entra-id-tutorial.md
+++ b/docs/includes/entra-id-tutorial.md
@@ -46,7 +46,7 @@ In this tutorial, you learn how to:
 > [!WARNING]  
 > Connections authenticated by Microsoft Entra ID are always encrypted. If SQL Server is using a self-signed certificate, you must add `trust server cert = true` in the connection string. SQL Server and Windows authenticated connections don't require encryption, but it is strongly recommended.
 >
-> If the machine requires using a proxy server, Entra ID requires that the machine-level WinHTTP proxy be set using the commands:
+> SQL Server will connect directly to Entra ID for authentication. Either [explicit firewall urls](https://learn.microsoft.com/en-us/sql/sql-server/azure-arc/prerequisites?view=sql-server-ver16&tabs=azure#network-requirements-for-enabling-entra-id-authentication) need to be opened for direct access, or utilize a proxy server. Entra ID does not use the Arc Connected Machine Agent proxy for authentication. If the machine requires using a proxy server, Entra ID requires that the machine-level WinHTTP proxy be set using the commands:
 > ```cmd
 > netsh winhttp set proxy proxy-server="http://proxyserver:port"
 > ```

--- a/docs/includes/entra-id-tutorial.md
+++ b/docs/includes/entra-id-tutorial.md
@@ -45,7 +45,18 @@ In this tutorial, you learn how to:
 
 > [!WARNING]  
 > Connections authenticated by Microsoft Entra ID are always encrypted. If SQL Server is using a self-signed certificate, you must add `trust server cert = true` in the connection string. SQL Server and Windows authenticated connections don't require encryption, but it is strongly recommended.
-
+>
+> If the machine requires using a proxy server, Entra ID requires that the machine-level WinHTTP proxy be set using the commands:
+> ```cmd
+> netsh winhttp set proxy proxy-server="http://proxyserver:port"
+> ```
+> Entra ID authentication does not utililze the Arc agent proxy setting.
+> The Arc Agent proxy may be set using the commands:
+> 
+> ```cmd
+> azcmagent config set proxy.url "http://proxyserver:port"
+> ```
+> 
 <a name='create-and-register-an-azure-ad-application'></a>
 
 ## Create and register a Microsoft Entra application


### PR DESCRIPTION
Added options for using proxy server with Entra ID as it was found that the Arc Agent proxy does not use this for Entra ID authentication, and the machine wide proxy needs to be used.