### PR TITLE
Update query-store-hints.md

### DIFF
--- a/docs/relational-databases/performance/query-store-hints.md
+++ b/docs/relational-databases/performance/query-store-hints.md
@@ -197,6 +197,10 @@ Finally, remove the hint from `query_id` 39, using [sp_query_store_clear_hints](
 ```sql
 EXEC sys.sp_query_store_clear_hints @query_id = 39;
 ```
+Important
+
+Please note all Query Store data will be removed including "hints" information if Query Store data is reset through "Purge Query Data" option.
+
 
 ## Related content
 


### PR DESCRIPTION
Hello,

I am recommending to add a warning note that if someone purges the query store data through "Purge Query Data" option all hints will be consequently removed. The reason I am suggesting this is that Query Store is regarded as data collector and with this new feature....its the first time we can use it for "**_setting_**" a configuration in a sense.  So, system admins will forget that their newly introduced hints will be removed. Not sure if Microsoft can protect these hints stored information in system table **sys.query_store_query_hints** from deletion when "Purge Query Data" is pressed.

Regards,
Emad
