### PR TITLE
Update create-external-data-source-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/create-external-data-source-transact-sql.md
+++ b/docs/t-sql/statements/create-external-data-source-transact-sql.md
@@ -1707,7 +1707,7 @@ GO
 CREATE EXTERNAL DATA SOURCE MyAzureStorage
 WITH (
     LOCATION = 'abs://<container>@<storage_account_name>.blob.core.windows.net/',
-    CREDENTIAL = AzureStorageCredentialv2,
+    CREDENTIAL = AzureStorageCredentialv2
 );
 ```
 


### PR DESCRIPTION
Removed invalid comma after the CREDENTIAL name in the "CREATE EXTERNAL DATA SOURCE" example under section F ("Create external data source to access data in Azure Blob Storage using the abs:// interface"), which was causing a syntax error.