### PR TITLE
Update example in Vector article

### DIFF
--- a/docs/t-sql/functions/vector-search-transact-sql.md
+++ b/docs/t-sql/functions/vector-search-transact-sql.md
@@ -155,7 +155,7 @@ CROSS APPLY
     VECTOR_SEARCH(
         TABLE = [dbo].[wikipedia_articles_embeddings] as t, 
         COLUMN = [content_vector], 
-        SIMILAR_TO = @qv, 
+        SIMILAR_TO = t.v, 
         METRIC = 'cosine', 
         TOP_N = 10
     ) AS s

--- a/docs/t-sql/functions/vector-search-transact-sql.md
+++ b/docs/t-sql/functions/vector-search-transact-sql.md
@@ -155,7 +155,7 @@ CROSS APPLY
     VECTOR_SEARCH(
         TABLE = [dbo].[wikipedia_articles_embeddings] as t, 
         COLUMN = [content_vector], 
-        SIMILAR_TO = t.v, 
+        SIMILAR_TO = qv.v, 
         METRIC = 'cosine', 
         TOP_N = 10
     ) AS s


### PR DESCRIPTION
Update vector-search-transact-sql.md
I think there is a mistake in Example 2, line 158:
te `SIMILAR_TO` value should refer to column v of type `vector` in the table alias `t` (temporary table `#t`):
```
        SIMILAR_TO = qv.v, 
```
Instead of variable:
```
        SIMILAR_TO = @QV, 
```