### PR TITLE
Update the table name in ssdt "Debug stored procedure"

### DIFF
--- a/docs/ssdt/debugger/debug-stored-procedures.md
+++ b/docs/ssdt/debugger/debug-stored-procedures.md
@@ -35,12 +35,12 @@ This example shows how to create and debug a [!INCLUDE[tsql](../../includes/tsql
     @name NVARCHAR(128)  
     AS  
     BEGIN
-        INSERT INTO [dbo].[Product] ([Id], [Name]) VALUES (@id, @name) 
-        SELECT [Name] FROM [dbo].[Product] WHERE [Id] = @id
+        INSERT INTO [dbo].[Products] ([Id], [Name]) VALUES (@id, @name) 
+        SELECT [Name] FROM [dbo].[Products] WHERE [Id] = @id
         DECLARE @nextid INT
         SET @nextid = @id + 1
-        INSERT INTO [dbo].[Product] ([Id], [Name]) VALUES (@id, @name) 
-        SELECT [Name] FROM [dbo].[Product] WHERE [Id] = @nextid
+        INSERT INTO [dbo].[Products] ([Id], [Name]) VALUES (@id, @name) 
+        SELECT [Name] FROM [dbo].[Products] WHERE [Id] = @nextid
     END
     ```  
   

--- a/docs/ssdt/debugger/debug-stored-procedures.md
+++ b/docs/ssdt/debugger/debug-stored-procedures.md
@@ -28,7 +28,7 @@ This example shows how to create and debug a [!INCLUDE[tsql](../../includes/tsql
 1. Paste the following code in the Query Editor.  
   
     ```sql  
-    CREATE TABLE [dbo].[Product] ([Id] INT, [Name] NVARCHAR(128))
+    CREATE TABLE [dbo].[Products] ([Id] INT, [Name] NVARCHAR(128))
 
     CREATE PROCEDURE [dbo].[AddProduct]  
     @id INT,  


### PR DESCRIPTION
The code provided to create a table in the initial example (table name "Product" in the create table statement) has a different table name from the code in the last example  (table name "Products" in the select statement). 
To keep convention (it's a table that contains products) it should be the name on the table creation that changes to "Products".