### PR TITLE
Fix the syntax of WITH clause

### DIFF
--- a/docs/t-sql/statements/alter-resource-governor-transact-sql.md
+++ b/docs/t-sql/statements/alter-resource-governor-transact-sql.md
@@ -42,13 +42,12 @@ This statement performs the following resource governor actions:
 ```syntaxsql
 ALTER RESOURCE GOVERNOR
     { RECONFIGURE
-          [ WITH
-                ( [ CLASSIFIER_FUNCTION = { schema_name.function_name | NULL } ]
-                  [ [ , ] MAX_OUTSTANDING_IO_PER_VOLUME = value ]
-                )
-          ]
       | DISABLE
       | RESET STATISTICS
+      | WITH
+              ( [ CLASSIFIER_FUNCTION = { schema_name.function_name | NULL } ]
+                [ [ , ] MAX_OUTSTANDING_IO_PER_VOLUME = value ]
+              )
     }
 [ ; ]
 ```


### PR DESCRIPTION
The previous syntax suggests that this works:

```sql
ALTER RESOURCE GOVERNOR RECONFIGURE WITH (CLASSIFIER_FUNCTION = NULL);
```

However, after running some tests I found that `ALTER` only supports the `WITH` clause when it is *not* preceded by `RECONFIGURE`. Therefore, that part should be moved so it is separate from the `RECONFIGURE` option.

Test on SQL 22 (also in sql 25 public preview):
![image](https://github.com/user-attachments/assets/eb29a142-d27f-406b-ab5d-5d7e077757ab)

This is the correct syntax:
![image](https://github.com/user-attachments/assets/96397ab0-15b9-4662-b213-dcef7e41c546)
