### PR TITLE
Update azure-ad-authentication-sql-server-overview.md

### DIFF
--- a/docs/relational-databases/security/authentication-access/azure-ad-authentication-sql-server-overview.md
+++ b/docs/relational-databases/security/authentication-access/azure-ad-authentication-sql-server-overview.md
@@ -101,7 +101,7 @@ Some non-GUI clients such as [Invoke-sqlcmd](/powershell/module/sqlserver/invoke
   - Member of the *Azure Connected Machine Onboarding* group or *Contributor* role in the resource group.
   - Member of the *Azure Connected Machine Resource Administrator* role in the resource group.
   - Member of the *Reader* role in the resource group.
-- Microsoft Entra authentication is not supported for SQL Server failover cluster instances and maintenance plan
+- Microsoft Entra authentication is not supported for SQL Server failover cluster instances and maintenance plans.
 
 ## Related content
 

--- a/docs/relational-databases/security/authentication-access/azure-ad-authentication-sql-server-overview.md
+++ b/docs/relational-databases/security/authentication-access/azure-ad-authentication-sql-server-overview.md
@@ -101,7 +101,7 @@ Some non-GUI clients such as [Invoke-sqlcmd](/powershell/module/sqlserver/invoke
   - Member of the *Azure Connected Machine Onboarding* group or *Contributor* role in the resource group.
   - Member of the *Azure Connected Machine Resource Administrator* role in the resource group.
   - Member of the *Reader* role in the resource group.
-- Microsoft Entra authentication is not supported for SQL Server failover cluster instances
+- Microsoft Entra authentication is not supported for SQL Server failover cluster instances and maintenance plan
 
 ## Related content
 


### PR DESCRIPTION
Maintenance Plan does not support Entra ID Authentication. If a user logs into SQL Server with Entra ID Authentication in SSMS and then starts the maintenance plan, an error will occur.