### PR TITLE
Clarified not to delete or disable a previous TDE protector key after a rotation.

### DIFF
--- a/azure-sql/database/transparent-data-encryption-byok-key-rotation.md
+++ b/azure-sql/database/transparent-data-encryption-byok-key-rotation.md
@@ -36,7 +36,7 @@ This article discusses both automated and manual methods to rotate the TDE prote
 > This article applies to Azure SQL Database, Azure SQL Managed Instance, and Azure Synapse Analytics dedicated SQL pools (formerly SQL DW). For documentation on transparent data encryption (TDE) for dedicated SQL pools inside Synapse workspaces, see [Azure Synapse Analytics encryption](/azure/synapse-analytics/security/workspaces-encryption).
 
 > [!IMPORTANT]
-> Do not delete previous versions of the key after a rollover. When keys are rolled over, some data is still encrypted with the previous keys, such as older database backups, backed-up log files and transaction log files.
+> Do not delete or disable previous versions of the key after a rollover. When keys are rolled over, some data is still encrypted with the previous keys, such as older database backups, backed-up log files and transaction log files, and the previous key is still needed to access this data.
 
 ## Prerequisites
 


### PR DESCRIPTION
A user I was supporting in the past disabled their previous TDE Protector key in keyvault after rotating it. This caused their database to become unavailable following the rotation. Earlier in the doc it is advised that old backups and log files may still require access to the old key and to keep it active until sys.dm_db_log_info shows it's no longer in use, but this !important text box only mentions not to delete it. Adding a clarification to keep it active would help avoid similar situations.