### PR TITLE
Update create-function-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/create-function-transact-sql.md
+++ b/docs/t-sql/statements/create-function-transact-sql.md
@@ -768,7 +768,7 @@ SELECT * FROM Sales.ufn_SalesByStore (602);
 
 ### C. Create a multi-statement table-valued function
 
-The following example creates the table-valued function `fn_FindReports(InEmpID)` in the [!INCLUDE [sssampledbobject-md](../../includes/sssampledbobject-md.md)] database. When supplied with a valid employee ID, the function returns a table that corresponds to all the employees that report to the employee either directly or indirectly. The function uses a recursive common table expression (CTE) to produce the hierarchical list of employees. For more information about recursive CTEs, see [WITH common_table_expression (Transact-SQL)](../queries/with-common-table-expression-transact-sql.md).
+The following example creates the table-valued function `ufn_FindReports(InEmpID)` in the [!INCLUDE [sssampledbobject-md](../../includes/sssampledbobject-md.md)] database. When supplied with a valid employee ID, the function returns a table that corresponds to all the employees that report to the employee either directly or indirectly. The function uses a recursive common table expression (CTE) to produce the hierarchical list of employees. For more information about recursive CTEs, see [WITH common_table_expression (Transact-SQL)](../queries/with-common-table-expression-transact-sql.md).
 
 ```sql
 CREATE FUNCTION dbo.ufn_FindReports (@InEmpID INT)


### PR DESCRIPTION
In section "Examples", sub-section "C. Create a multi-statement table-valued function" - the UDF name in the description different from the name in the code snippet: `fn_FindReports(InEmpID)` instead of `ufn_FindReports(InEmpID)`.
In all other sections in the page, the UDF name prefix, is always `ufn_`.