### PR TITLE
explicit nvarchar limitation in binary_checksum

### DIFF
--- a/docs/t-sql/functions/binary-checksum-transact-sql.md
+++ b/docs/t-sql/functions/binary-checksum-transact-sql.md
@@ -70,7 +70,7 @@ or
   
 For example, the strings "McCavity" and "Mccavity" have different `BINARY_CHECKSUM` values. In contrast, for a case-insensitive server, `CHECKSUM` returns the same checksum values for those strings. You should avoid comparison of `CHECKSUM` values with `BINARY_CHECKSUM` values.
  
-`BINARY_CHECKSUM` supports any length of type **varbinary(max)** and up to 255 characters of type **nvarchar(max)**.
+`BINARY_CHECKSUM` supports any length of type **varbinary(max)** and up to 255 characters of type **nvarchar(n | max)**.
   
 ## Examples  
 This example uses `BINARY_CHECKSUM` to detect changes in a table row.


### PR DESCRIPTION
binary_checksum is limited to 255 characters for any nvarchar type, not just nvarchar(max)
i have added "n | " in an effort to make this clearer in a concise way