### PR TITLE
Update from-transact-sql.md to re-add incorrectly-removed OUTER keyword

### DIFF
--- a/docs/t-sql/queries/from-transact-sql.md
+++ b/docs/t-sql/queries/from-transact-sql.md
@@ -895,7 +895,7 @@ SELECT dst.SalesTerritoryKey,
     dst.SalesTerritoryRegion,
     fis.SalesOrderNumber
 FROM DimSalesTerritory AS dst
-FULL JOIN FactInternetSales AS fis
+FULL OUTER JOIN FactInternetSales AS fis
     ON dst.SalesTerritoryKey = fis.SalesTerritoryKey
 ORDER BY fis.SalesOrderNumber;
 ```


### PR DESCRIPTION
Two versions of the same query are present to demonstrate that the `OUTER` keyword is optional in the `FULL OUTER JOIN` syntax. However, currently, the two versions of the same query are actually the identical query.

This change makes the two examples different again to be consistent with the point being demonstrated as inferred from the context.

Fixes a regression in 87245a27588bf78e636c2322f4b96c199db74760.