### PR TITLE
Changed Non-cluster behavior when Clustered index is dropped.

### DIFF
--- a/docs/relational-databases/indexes/enable-indexes-and-constraints.md
+++ b/docs/relational-databases/indexes/enable-indexes-and-constraints.md
@@ -51,7 +51,7 @@ monikerRange: "=azuresqldb-current || >=sql-server-2016 || >=sql-server-linux-20
     |----------------------------|-----------------------------------|  
     |ALTER INDEX REBUILD.|Remains disabled.|  
     |ALTER INDEX ALL REBUILD.|Is rebuilt and enabled.|  
-    |DROP INDEX.|Remains disabled.|  
+    |DROP INDEX.|Is enabled.|  
     |CREATE INDEX WITH DROP_EXISTING.|Remains disabled.|  
   
      Creating a new clustered index, behaves the same as ALTER INDEX ALL REBUILD.  


### PR DESCRIPTION
Currently the documentations says that Non Clustered Index remains disabled, when Clustered Index is dropped, however that is not what actually happens in the product. So have updated the documentation accordingly.