### PR TITLE
Moniker fix? Stop redirecting SQL Server docs to Fabric by aligning with “Applies to” versions

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-invoke-external-rest-endpoint-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-invoke-external-rest-endpoint-transact-sql.md
@@ -19,7 +19,7 @@ helpviewer_keywords:
   - "sp_invoke_external_rest_endpoint"
 dev_langs:
   - "TSQL"
-monikerRange: "=fabric"
+monikerRange: '=fabric'  # Likely too narrow — this causes redirects for SQL MI and SQL Server views
 ---
 # sp_invoke_external_rest_endpoint (Transact-SQL)
 


### PR DESCRIPTION
This page currently only supports the =fabric moniker, which causes unexpected redirects when browsing Azure SQL, SQL MI or SQL 2025+ content . May I suggest reviewing the moniker configuration. 