### PR TITLE
Update microsoft-jdbc-driver-for-sql-server-support-matrix.md

### DIFF
--- a/docs/connect/jdbc/microsoft-jdbc-driver-for-sql-server-support-matrix.md
+++ b/docs/connect/jdbc/microsoft-jdbc-driver-for-sql-server-support-matrix.md
@@ -34,12 +34,12 @@ The following Microsoft JDBC Drivers are supported, until the indicated End of S
 |Microsoft JDBC Driver 10.2 for SQL Server|10.2|mssql-jdbc-10.2.0.jre17.jar<br> mssql-jdbc-10.2.0.jre11.jar<br> mssql-jdbc-10.2.0.jre8.jar|January 31, 2027|
 |Microsoft JDBC Driver 9.4 for SQL Server|9.4|mssql-jdbc-9.4.1.jre16.jar<br> mssql-jdbc-9.4.1.jre11.jar<br> mssql-jdbc-9.4.1.jre8.jar|July 30, 2026|
 |Microsoft JDBC Driver 9.2 for SQL Server|9.2|mssql-jdbc-9.2.1.jre15.jar<br> mssql-jdbc-9.2.1.jre11.jar<br> mssql-jdbc-9.2.1.jre8.jar|January 29, 2026|
-|Microsoft JDBC Driver 8.4 for SQL Server|8.4|mssql-jdbc-8.4.1.jre14.jar<br> mssql-jdbc-8.4.1.jre11.jar<br> mssql-jdbc-8.4.1.jre8.jar|July 31, 2025|
 
  The following Microsoft JDBC Drivers are no longer supported.
 
 |Driver Name|Driver Package Version|End of Mainstream Support|
 |-|-|-|
+|Microsoft JDBC Driver 8.4 for SQL Server|8.4|July 31, 2025|
 |Microsoft JDBC Driver 8.2 for SQL Server|8.2|January 31, 2025|
 |Microsoft JDBC Driver 7.4 for SQL Server|7.4|July 31, 2024|
 |Microsoft JDBC Driver 7.2 for SQL Server|7.2|January 31, 2024|


### PR DESCRIPTION
Hi SQL Server Docs Team,

I've moved `Microsoft JDBC Driver 8.4 for SQL Server` from "Supported" to "No Longer Supported" because its end of mainstream support date was July 31st 2025.

Thank you,

Vlad