### PR TITLE
Fix output formatting in trim-transact-sql.md

### DIFF
--- a/docs/t-sql/functions/trim-transact-sql.md
+++ b/docs/t-sql/functions/trim-transact-sql.md
@@ -157,7 +157,7 @@ SELECT TRIM(TRAILING '.,! ' FROM '     .#     test    .') AS Result;
 [!INCLUDE [ssResult_md](../../includes/ssresult-md.md)]
 
 ```output
-.#     test
+     .#     test
 ```
 
 ### E. Remove specified characters from the beginning and end of a string


### PR DESCRIPTION
Added missing spaces from `TRIM` output