### PR TITLE
Update ceiling-transact-sql.md

### DIFF
--- a/docs/t-sql/functions/ceiling-transact-sql.md
+++ b/docs/t-sql/functions/ceiling-transact-sql.md
@@ -46,7 +46,7 @@ The return type depends on the input type of *numeric_expression*:
 | Input type | Return type |
 | --- | --- |
 | **float**, **real** | **float** |
-| **decimal(*p*, *s*)** | **decimal(38, *s*)** |
+| **decimal(*p*, *s*)** | **decimal(*p*, 0)** |
 | **int**, **smallint**, **tinyint** | **int** |
 | **bigint** | **bigint** |
 | **money**, **smallmoney** | **money** |


### PR DESCRIPTION
Actually observed behavior as of version 15.0.2140.

This can give unexpected results, such as in this case:
```
declare @a numeric(38,12) = 7;
declare @b numeric(38,12) = 1.5;

select ceiling(@a) + @b;
```