### PR TITLE
Remove duplicated entries in time zone mapping table - sql-server-linux-configure-time-zone.md

### DIFF
--- a/docs/linux/sql-server-linux-configure-time-zone.md
+++ b/docs/linux/sql-server-linux-configure-time-zone.md
@@ -748,6 +748,7 @@ Symbolic links in `/usr/share/zoneinfo` and `/usr/lib/zoneinfo` are considered. 
 | Asia/Beirut | Middle East Standard Time |
 | Asia/Bishkek | Central Asia Standard Time |
 | Asia/Brunei | Singapore Standard Time |
+| Asia/Kolkata | India Standard Time |
 | Asia/Chita | Transbaikal Standard Time |
 | Asia/Choibalsan | Ulaanbaatar Standard Time |
 | Asia/Colombo | Sri Lanka Standard Time |

--- a/docs/linux/sql-server-linux-configure-time-zone.md
+++ b/docs/linux/sql-server-linux-configure-time-zone.md
@@ -280,7 +280,6 @@ Symbolic links in `/usr/share/zoneinfo` and `/usr/lib/zoneinfo` are considered. 
 | Asia/Beirut | Middle East Standard Time |
 | Asia/Bishkek | Central Asia Standard Time |
 | Asia/Brunei | Singapore Standard Time |
-| Asia/Kolkata | India Standard Time |
 | Asia/Chita | Transbaikal Standard Time |
 | Asia/Choibalsan | Ulaanbaatar Standard Time |
 | Asia/Colombo | Sri Lanka Standard Time |
@@ -326,9 +325,7 @@ Symbolic links in `/usr/share/zoneinfo` and `/usr/lib/zoneinfo` are considered. 
 | Asia/Qatar | Arab Standard Time |
 | Asia/Qostanay | Central Asia Standard Time |
 | Asia/Qyzylorda | Qyzylorda Standard Time |
-| Asia/Yangon | Myanmar Standard Time |
 | Asia/Riyadh | Arab Standard Time |
-| Asia/Ho_Chi_Minh | SE Asia Standard Time |
 | Asia/Sakhalin | Sakhalin Standard Time |
 | Asia/Samarkand | West Asia Standard Time |
 | Asia/Seoul | Korea Standard Time |
@@ -751,7 +748,6 @@ Symbolic links in `/usr/share/zoneinfo` and `/usr/lib/zoneinfo` are considered. 
 | Asia/Beirut | Middle East Standard Time |
 | Asia/Bishkek | Central Asia Standard Time |
 | Asia/Brunei | Singapore Standard Time |
-| Asia/Kolkata | India Standard Time |
 | Asia/Chita | Transbaikal Standard Time |
 | Asia/Choibalsan | Ulaanbaatar Standard Time |
 | Asia/Colombo | Sri Lanka Standard Time |


### PR DESCRIPTION
This PR removes redundant entries from the time zone mapping table in `sql-server-linux-configure-time-zone.md`.