### PR TITLE
Revise DigiCert root certificate import instructions

### DIFF
--- a/azure-sql/managed-instance/managed-instance-link-configure-how-to-scripts.md
+++ b/azure-sql/managed-instance/managed-instance-link-configure-how-to-scripts.md
@@ -4,7 +4,7 @@ titleSuffix: Azure SQL Managed Instance
 description: Learn how to configure a link between SQL Server and Azure SQL Managed Instance with Transact-SQL (T-SQL) and Azure PowerShell or Azure CLI scripts.
 author: djordje-jeremic
 ms.author: djjeremi
-ms.reviewer: mathoma, danil
+ms.reviewer: mathoma, djjeremi
 ms.date: 10/09/2024
 ms.service: azure-sql-managed-instance
 ms.subservice: data-movement
@@ -319,48 +319,154 @@ FROM BINARY = <PublicKey>
 
 ### Import Azure-trusted root certificate authority keys to SQL Server
 
-Importing public root certificate keys of Microsoft and DigiCert certificate authorities (CA) to SQL Server is required for your SQL Server to trust certificates issued by Azure for database.windows.net domains.
+Importing Azure-trusted root certificate authority (CA) keys to SQL Server is required for your SQL Server to trust managed instance certificates issued by Azure.
 
-> [!CAUTION]
-> Ensure the PublicKey starts with an `0x`. You might need to add it manually to the beginning of the PublicKey if it's not already there. 
+Certificates which are to be imported in the next steps should be downloaded from [Root Certificate Authorities](../../security/fundamentals/azure-ca-details?tabs=root-and-subordinate-cas-list#root-certificate-authorities)
 
-First, import the Microsoft PKI root-authority certificate on SQL Server:
+First, import the DigiCert Global Root CA root-authority certificate on SQL Server:
 
 ```sql
 -- Run on SQL Server
--- Import Microsoft PKI root-authority certificate (trusted by Azure), if not already present
-IF NOT EXISTS (SELECT name FROM sys.certificates WHERE name = N'MicrosoftPKI')
+-- Import DigiCertGlobalRootCA root-authority certificate (trusted by Azure), if not already present
+IF NOT EXISTS (SELECT name FROM sys.certificates WHERE name = N'DigiCertGlobalRootCA')
 BEGIN
-    PRINT 'Creating MicrosoftPKI certificate.'
-    CREATE CERTIFICATE [MicrosoftPKI] FROM BINARY = 0x308205A830820390A00302010202101ED397095FD8B4B347701EAABE7F45B3300D06092A864886F70D01010C05003065310B3009060355040613025553311E301C060355040A13154D6963726F736F667420436F72706F726174696F6E313630340603550403132D4D6963726F736F66742052534120526F6F7420436572746966696361746520417574686F726974792032303137301E170D3139313231383232353132325A170D3432303731383233303032335A3065310B3009060355040613025553311E301C060355040A13154D6963726F736F667420436F72706F726174696F6E313630340603550403132D4D6963726F736F66742052534120526F6F7420436572746966696361746520417574686F72697479203230313730820222300D06092A864886F70D01010105000382020F003082020A0282020100CA5BBE94338C299591160A95BD4762C189F39936DF4690C9A5ED786A6F479168F8276750331DA1A6FBE0E543A3840257015D9C4840825310BCBFC73B6890B6822DE5F465D0CC6D19CC95F97BAC4A94AD0EDE4B431D8707921390808364353904FCE5E96CB3B61F50943865505C1746B9B685B51CB517E8D6459DD8B226B0CAC4704AAE60A4DDB3D9ECFC3BD55772BC3FC8C9B2DE4B6BF8236C03C005BD95C7CD733B668064E31AAC2EF94705F206B69B73F578335BC7A1FB272AA1B49A918C91D33A823E7640B4CD52615170283FC5C55AF2C98C49BB145B4DC8FF674D4C1296ADF5FE78A89787D7FD5E2080DCA14B22FBD489ADBACE479747557B8F45C8672884951C6830EFEF49E0357B64E798B094DA4D853B3E55C428AF57F39E13DB46279F1EA25E4483A4A5CAD513B34B3FC4E3C2E68661A45230B97A204F6F0F3853CB330C132B8FD69ABD2AC82DB11C7D4B51CA47D14827725D87EBD545E648659DAF5290BA5BA2186557129F68B9D4156B94C4692298F433E0EDF9518E4150C9344F7690ACFC38C1D8E17BB9E3E394E14669CB0E0A506B13BAAC0F375AB712B590811E56AE572286D9C9D2D1D751E3AB3BC655FD1E0ED3740AD1DAAAEA69B897288F48C407F852433AF4CA55352CB0A66AC09CF9F281E1126AC045D967B3CEFF23A2890A54D414B92AA8D7ECF9ABCD255832798F905B9839C40806C1AC7F0E3D00A50203010001A3543052300E0603551D0F0101FF040403020186300F0603551D130101FF040530030101FF301D0603551D0E0416041409CB597F86B2708F1AC339E3C0D9E9BFBB4DB223301006092B06010401823715010403020100300D06092A864886F70D01010C05000382020100ACAF3E5DC21196898EA3E792D69715B813A2A6422E02CD16055927CA20E8BAB8E81AEC4DA89756AE6543B18F009B52CD55CD53396D624C8B0D5B7C2E44BF83108FF3538280C34F3AC76E113FE6E3169184FB6D847F3474AD89A7CEB9D7D79F846492BE95A1AD095333DDEE0AEA4A518E6F55ABBAB59446AE8C7FD8A2502565608046DB3304AE6CB598745425DC93E4F8E355153DB86DC30AA412C169856EDF64F15399E14A75209D950FE4D6DC03F15918E84789B2575A94B6A9D8172B1749E576CBC156993A37B1FF692C919193E1DF4CA337764DA19FF86D1E1DD3FAECFBF4451D136DCFF759E52227722B86F357BB30ED244DDC7D56BBA3B3F8347989C1E0F20261F7A6FC0FBB1C170BAE41D97CBD27A3FD2E3AD19394B1731D248BAF5B2089ADB7676679F53AC6A69633FE5392C846B11191C6997F8FC9D66631204110872D0CD6C1AF3498CA6483FB1357D1C1F03C7A8CA5C1FD9521A071C193677112EA8F880A691964992356FBAC2A2E70BE66C40C84EFE58BF39301F86A9093674BB268A3B5628FE93F8C7A3B5E0FE78CB8C67CEF37FD74E2C84F3372E194396DBD12AFBE0C4E707C1B6F8DB332937344166DE8F4F7E095808F965D38A4F4ABDE0A308793D84D00716245274B3A42845B7F65B76734522D9C166BAAA8D87BA3424C71C70CCA3E83E4A6EFB701305E51A379F57069A641440F86B02C91C63DEAAE0F84
+    PRINT 'Creating DigiCertGlobalRootCA certificate.'
+    CREATE CERTIFICATE [DigiCertGlobalRootCA] FROM FILE = 'C:\Users\cloudsa\Downloads\DigiCertGlobalRootCA.crt'
 
-    --Trust certificates issued by Microsoft PKI root authority for Azure database.windows.net domains
+    --Trust certificates issued by DigiCertGlobalRootCA root authority for Azure database.windows.net domains
     DECLARE @CERTID int
-    SELECT @CERTID = CERT_ID('MicrosoftPKI')
+    SELECT @CERTID = CERT_ID('DigiCertGlobalRootCA')
+    --For government cloud, use the corresponding SQL Database DNS suffix, e.g. '*.database.usgovcloudapi.net', '*.database.chinacloudapi.cn' etc.
     EXEC sp_certificate_add_issuer @CERTID, N'*.database.windows.net'
 END
 ELSE
-    PRINT 'Certificate MicrosoftPKI already exists.'
+    PRINT 'Certificate DigiCertGlobalRootCA already exists.'
 GO
 ```
 
-Then, import DigiCert PKI root-authority certificate on SQL Server:
+Then, import DigiCert Global Root G2 root-authority certificate on SQL Server:
 
 ```sql
 -- Run on SQL Server
--- Import DigiCert PKI root-authority certificate trusted by Azure to SQL Server, if not already present
-IF NOT EXISTS (SELECT name FROM sys.certificates WHERE name = N'DigiCertPKI')
+-- Import DigiCertGlobalRootG2 root-authority certificate (trusted by Azure), if not already present
+IF NOT EXISTS (SELECT name FROM sys.certificates WHERE name = N'DigiCertGlobalRootG2')
 BEGIN
-    PRINT 'Creating DigiCertPKI certificate.'
-    CREATE CERTIFICATE [DigiCertPKI] FROM BINARY = 0x3082038E30820276A0030201020210033AF1E6A711A9A0BB2864B11D09FAE5300D06092A864886F70D01010B05003061310B300906035504061302555331153013060355040A130C446967694365727420496E6331193017060355040B13107777772E64696769636572742E636F6D3120301E06035504031317446967694365727420476C6F62616C20526F6F74204732301E170D3133303830313132303030305A170D3338303131353132303030305A3061310B300906035504061302555331153013060355040A130C446967694365727420496E6331193017060355040B13107777772E64696769636572742E636F6D3120301E06035504031317446967694365727420476C6F62616C20526F6F7420473230820122300D06092A864886F70D01010105000382010F003082010A0282010100BB37CD34DC7B6BC9B26890AD4A75FF46BA210A088DF51954C9FB88DBF3AEF23A89913C7AE6AB061A6BCFAC2DE85E092444BA629A7ED6A3A87EE054752005AC50B79C631A6C30DCDA1F19B1D71EDEFDD7E0CB948337AEEC1F434EDD7B2CD2BD2EA52FE4A9B8AD3AD499A4B625E99B6B00609260FF4F214918F76790AB61069C8FF2BAE9B4E992326BB5F357E85D1BCD8C1DAB95049549F3352D96E3496DDD77E3FB494BB4AC5507A98F95B3B423BB4C6D45F0F6A9B29530B4FD4C558C274A57147C829DCD7392D3164A060C8C50D18F1E09BE17A1E621CAFD83E510BC83A50AC46728F67314143D4676C387148921344DAF0F450CA649A1BABB9CC5B1338329850203010001A3423040300F0603551D130101FF040530030101FF300E0603551D0F0101FF040403020186301D0603551D0E041604144E2254201895E6E36EE60FFAFAB912ED06178F39300D06092A864886F70D01010B05000382010100606728946F0E4863EB31DDEA6718D5897D3CC58B4A7FE9BEDB2B17DFB05F73772A3213398167428423F2456735EC88BFF88FB0610C34A4AE204C84C6DBF835E176D9DFA642BBC74408867F3674245ADA6C0D145935BDF249DDB61FC9B30D472A3D992FBB5CBBB5D420E1995F534615DB689BF0F330D53E31E28D849EE38ADADA963E3513A55FF0F970507047411157194EC08FAE06C49513172F1B259F75F2B18E99A16F13B14171FE882AC84F102055D7F31445E5E044F4EA879532930EFE5346FA2C9DFF8B22B94BD90945A4DEA4B89A58DD1B7D529F8E59438881A49E26D56FADDD0DC6377DED03921BE5775F76EE3C8DC45D565BA2D9666EB33537E532B6
+    PRINT 'Creating DigiCertGlobalRootG2 certificate.'
+    CREATE CERTIFICATE [DigiCertGlobalRootG2] FROM FILE = 'C:\Path\To\DigiCertGlobalRootG2.crt'
 
-    --Trust certificates issued by DigiCert PKI root authority for Azure database.windows.net domains
+    --Trust certificates issued by DigiCertGlobalRootG2 root authority for Azure database.windows.net domains
     DECLARE @CERTID int
-    SELECT @CERTID = CERT_ID('DigiCertPKI')
+    SELECT @CERTID = CERT_ID('DigiCertGlobalRootG2')
+    --For government cloud, use the corresponding SQL Database DNS suffix, e.g. '*.database.usgovcloudapi.net', '*.database.chinacloudapi.cn' etc.
     EXEC sp_certificate_add_issuer @CERTID, N'*.database.windows.net'
 END
 ELSE
-    PRINT 'Certificate DigiCertPKI already exists.'
+    PRINT 'Certificate DigiCertGlobalRootG2 already exists.'
+GO
+```
+
+Then, import DigiCert Global Root G3 root-authority certificate on SQL Server:
+
+```sql
+-- Run on SQL Server
+-- Import DigiCertGlobalRootG3 root-authority certificate (trusted by Azure), if not already present
+IF NOT EXISTS (SELECT name FROM sys.certificates WHERE name = N'DigiCertGlobalRootG3')
+BEGIN
+    PRINT 'Creating DigiCertGlobalRootG3 certificate.'
+    CREATE CERTIFICATE [DigiCertGlobalRootG3] FROM FILE = 'C:\Path\To\DigiCertGlobalRootG3.crt'
+
+    --Trust certificates issued by DigiCertGlobalRootG3 root authority for Azure database.windows.net domains
+    DECLARE @CERTID int
+    SELECT @CERTID = CERT_ID('DigiCertGlobalRootG3')
+    --For government cloud, use the corresponding SQL Database DNS suffix, e.g. '*.database.usgovcloudapi.net', '*.database.chinacloudapi.cn' etc.
+    EXEC sp_certificate_add_issuer @CERTID, N'*.database.windows.net'
+END
+ELSE
+    PRINT 'Certificate DigiCertGlobalRootG3 already exists.'
+GO
+```
+
+Then, import DigiCert TLS ECC P384 Root G5 root-authority certificate on SQL Server:
+
+```sql
+-- Run on SQL Server
+-- Import DigiCertTLSECCP384RootG5 root-authority certificate (trusted by Azure), if not already present
+IF NOT EXISTS (SELECT name FROM sys.certificates WHERE name = N'DigiCertTLSECCP384RootG5')
+BEGIN
+    PRINT 'Creating DigiCertTLSECCP384RootG5 certificate.'
+    CREATE CERTIFICATE [DigiCertTLSECCP384RootG5] FROM FILE = 'C:\Path\To\DigiCertTLSECCP384RootG5.crt'
+
+    --Trust certificates issued by DigiCertTLSECCP384RootG5 root authority for Azure database.windows.net domains
+    DECLARE @CERTID int
+    SELECT @CERTID = CERT_ID('DigiCertTLSECCP384RootG5')
+    --For government cloud, use the corresponding SQL Database DNS suffix, e.g. '*.database.usgovcloudapi.net', '*.database.chinacloudapi.cn' etc.
+    EXEC sp_certificate_add_issuer @CERTID, N'*.database.windows.net'
+END
+ELSE
+    PRINT 'Certificate DigiCertTLSECCP384RootG5 already exists.'
+GO
+```
+
+Then, import DigiCert TLS RSA 4096 Root G5 root-authority certificate on SQL Server:
+
+```sql
+-- Run on SQL Server
+-- Import DigiCertTLSRSA4096RootG5 root-authority certificate (trusted by Azure), if not already present
+IF NOT EXISTS (SELECT name FROM sys.certificates WHERE name = N'DigiCertTLSRSA4096RootG5')
+BEGIN
+    PRINT 'Creating DigiCertTLSRSA4096RootG5 certificate.'
+    CREATE CERTIFICATE [DigiCertTLSRSA4096RootG5] FROM FILE = 'C:\Path\To\DigiCertTLSRSA4096RootG5.crt'
+
+    --Trust certificates issued by DigiCertTLSRSA4096RootG5 root authority for Azure database.windows.net domains
+    DECLARE @CERTID int
+    SELECT @CERTID = CERT_ID('DigiCertTLSRSA4096RootG5')
+    --For government cloud, use the corresponding SQL Database DNS suffix, e.g. '*.database.usgovcloudapi.net', '*.database.chinacloudapi.cn' etc.
+    EXEC sp_certificate_add_issuer @CERTID, N'*.database.windows.net'
+END
+ELSE
+    PRINT 'Certificate DigiCertTLSRSA4096RootG5 already exists.'
+GO
+```
+
+Then, import Microsoft ECC Root Certificate Authority 2017 root-authority certificate on SQL Server:
+
+```sql
+-- Run on SQL Server
+-- Import Microsoft ECC Root Certificate Authority 2017 root-authority certificate (trusted by Azure), if not already present
+IF NOT EXISTS (SELECT name FROM sys.certificates WHERE name = N'Microsoft ECC Root Certificate Authority 2017')
+BEGIN
+    PRINT 'Creating Microsoft ECC Root Certificate Authority 2017 certificate.'
+    CREATE CERTIFICATE [Microsoft ECC Root Certificate Authority 2017] FROM FILE = 'C:\Path\To\Microsoft ECC Root Certificate Authority 2017.crt'
+
+    --Trust certificates issued by Microsoft ECC Root Certificate Authority 2017 root authority for Azure database.windows.net domains
+    DECLARE @CERTID int
+    SELECT @CERTID = CERT_ID('Microsoft ECC Root Certificate Authority 2017')
+    --For government cloud, use the corresponding SQL Database DNS suffix, e.g. '*.database.usgovcloudapi.net', '*.database.chinacloudapi.cn' etc.
+    EXEC sp_certificate_add_issuer @CERTID, N'*.database.windows.net'
+END
+ELSE
+    PRINT 'Certificate Microsoft ECC Root Certificate Authority 2017 already exists.'
+GO
+```
+
+Then, import Microsoft RSA Root Certificate Authority 2017 root-authority certificate on SQL Server:
+
+```sql
+-- Run on SQL Server
+-- Import Microsoft RSA Root Certificate Authority 2017 root-authority certificate (trusted by Azure), if not already present
+IF NOT EXISTS (SELECT name FROM sys.certificates WHERE name = N'Microsoft RSA Root Certificate Authority 2017')
+BEGIN
+    PRINT 'Creating Microsoft RSA Root Certificate Authority 2017 certificate.'
+    CREATE CERTIFICATE [Microsoft RSA Root Certificate Authority 2017] FROM FILE = 'C:\Path\To\Microsoft RSA Root Certificate Authority 2017.crt'
+
+    --Trust certificates issued by Microsoft RSA Root Certificate Authority 2017 root authority for Azure database.windows.net domains
+    DECLARE @CERTID int
+    SELECT @CERTID = CERT_ID('Microsoft RSA Root Certificate Authority 2017')
+    --For government cloud, use the corresponding SQL Database DNS suffix, e.g. '*.database.usgovcloudapi.net', '*.database.chinacloudapi.cn' etc.
+    EXEC sp_certificate_add_issuer @CERTID, N'*.database.windows.net'
+END
+ELSE
+    PRINT 'Certificate Microsoft RSA Root Certificate Authority 2017 already exists.'
 GO
 ```
 
@@ -368,20 +474,20 @@ Finally, verify all created certificates by using the following dynamic manageme
 
 ```sql
 -- Run on SQL Server
+USE master
 SELECT * FROM sys.certificates
 ```
 
-### Validate the certificate 
+### Perform certificate chain validation on SQL Server
 
-After you've created the certificates, validate the MI endpoint certificate is configured correctly. 
+> [!NOTE]
+> Instructions in this section are intended primarily for existing link troubleshooting. They can be skipped if you are configuring new link and you have recently or just completed the steps in sections [Get the certificate public key from SQL Managed Instance and import it to SQL Server](#get-the-certificate-public-key-from-sql-managed-instance-and-import-it-to-sql-server) and [Import Azure-trusted root certificate authority keys to SQL Server](#import-azure-trusted-root-certificate-authority-keys-to-sql-server).
 
-First, determine the `certificate_id` of the exported MI certificate by replacing the value of `<ManagedInstanceFQDN>` and then running the following query on SQL Server:
+First, determine the `certificate_id` of the imported MI endpoint certificate by replacing the value of `<ManagedInstanceFQDN>` and then running the following query on SQL Server:
 
 ```sql
 -- Run on SQL Server 
-USE MASTER 
-GO 
-
+USE master 
 SELECT name, subject, certificate_id, start_date, expiry_date 
 FROM sys.certificates 
 WHERE issuer_name LIKE '%Microsoft Corporation%' AND name = '<ManagedInstanceFQDN>' 
@@ -392,29 +498,17 @@ Next, validate the certificate by replacing the value of `<certificate_id>` from
 
 ```sql
 -- Run on SQL Server 
-
-USE MASTER 
-GO 
-
+USE master
 EXEC sp_validate_certificate_ca_chain <certificate_id> 
 GO 
 ```
 
 A response of `Commands completed successfully. Completion time: …` indicates the MI endpoint certificate has been successfully validated. 
 
-If you encounter an error, then drop the certificate and follow the steps in the [Get the certificate public key from SQL Managed Instance and import it to SQL Server](#get-the-certificate-public-key-from-sql-managed-instance-and-import-it-to-sql-server) section to re-import the certificate.
+> [!IMPORTANT]
+> The stored procedure `sp_validate_certificate_ca_chain` relies on the host OS services to perform certificate validation, which might involve online certificate revocation check. If the host OS is not configured to access Internet, the execution will fail even though the certificate chain is valid. 
 
-To drop the certificate, run the following query on SQL Server:
-
-```sql
--- Run on SQL Server 
-
-USE MASTER 
-GO 
-
-DROP CERTIFICATE [<ManagedInstanceFQDN>] 
-GO 
-```
+If you encounter an error, the most reliable mitigation is to restore the certificate chain by dropping all certificates created in sections [Get the certificate public key from SQL Managed Instance and import it to SQL Server](#get-the-certificate-public-key-from-sql-managed-instance-and-import-it-to-sql-server) and [Import Azure-trusted root certificate authority keys to SQL Server](#import-azure-trusted-root-certificate-authority-keys-to-sql-server) and recreating them by following the same instructions again.
 
 ## Secure the database mirroring endpoint
 
@@ -571,7 +665,6 @@ First, find out your SQL Server name by running the following T-SQL statement:
 -- Run on the initial primary
 SELECT @@SERVERNAME AS SQLServerName 
 ```
-
 
 
 Then, use the following script to create the availability group on SQL Server. Replace:


### PR DESCRIPTION
Updated the instructions for importing DigiCert root certificates to SQL Server, including changes to the certificate names and paths. Added new sections for additional DigiCert root certificates and clarified validation steps.