### PR TITLE
Show INNER as optional ([ INNER ] JOIN)

### DIFF
--- a/docs/relational-databases/performance/joins.md
+++ b/docs/relational-databases/performance/joins.md
@@ -58,7 +58,7 @@ A join condition defines the way two tables are related in a query by:
 
 Joins are expressed logically using the following [!INCLUDE [tsql](../../includes/tsql-md.md)] syntax:
 
-- `INNER JOIN`
+- `[ INNER ] JOIN`
 - `LEFT [ OUTER ] JOIN`
 - `RIGHT [ OUTER ] JOIN`
 - `FULL [ OUTER ] JOIN`


### PR DESCRIPTION
This PR updates the join syntax list to use [ INNER ] JOIN instead of INNER JOIN.

Rationale: In T-SQL, JOIN defaults to INNER