### PR TITLE
Update the password policy frequently-asked-questions-faq.yml

### DIFF
--- a/azure-sql/managed-instance/frequently-asked-questions-faq.yml
+++ b/azure-sql/managed-instance/frequently-asked-questions-faq.yml
@@ -558,7 +558,7 @@ sections:
           | --- | --- |
           | Maximum password age | 42 days |
           | Minimum password age | One day |
-          | Minimum password length | 10 characters |
+          | Minimum password length | 14 characters |
           | Password must meet complexity requirements | Enabled |
 
       - question: Is it possible to disable password complexity and expiration in SQL Managed Instance at the login level?


### PR DESCRIPTION
We executed the net accounts command via a SQL Agent job on some SQL MIs. The results showed that the minimum password length and other settings differed from the information on MS Learn.  Has the password policy been changed on all SQL MIs? If so, I believe MS Learn should be updated as well. I edited the article based on my command results. Would you kindly verify what the latest password policy settings are? 
================================
Force user logoff how long after time expires?:       Never
Minimum password age (days):                          1
Maximum password age (days):                          60
Minimum password length:                              14
Length of password history maintained:                24
Lockout threshold:                                    10
Lockout duration (minutes):                           10
Lockout observation window (minutes):                 10
Computer role:                                        SERVER