### PR TITLE
Update floor-transact-sql.md

### DIFF
--- a/docs/t-sql/functions/floor-transact-sql.md
+++ b/docs/t-sql/functions/floor-transact-sql.md
@@ -41,7 +41,7 @@ The return type depends on the input type of *numeric_expression*:
 |Input type|Return type|  
 |----------|-----------|  
 |**float**, **real**|**float**|
-|**decimal(*p*, *s*)**|**decimal(38, *s*)**|
+|**decimal(*p*, *s*)**|**decimal(*p*, 0)**|
 |**int**, **smallint**, **tinyint**|**int**|
 |**bigint**|**bigint**|
 |**money**, **smallmoney**|**money**|


### PR DESCRIPTION
Changed return type for `decimal(p, s)` to `decimal(p, 0)`, rather than `decimal(38, s)`.

Demonstation: https://dbfiddle.uk/Ai79GDn8