### PR TITLE
DatabaseMail - Display Name - Caractere "\"

### DIFF
--- a/docs/relational-databases/database-mail/configure-database-mail.md
+++ b/docs/relational-databases/database-mail/configure-database-mail.md
@@ -151,6 +151,8 @@ The following steps use SQL Server Management Studio (SSMS). Download the latest
  **Display name**  
  Type the name to show on e-mail messages sent from this account. The display name is optional. This is the name displayed on messages sent from this account. For example, an account for [!INCLUDE [ssNoVersion](../../includes/ssnoversion-md.md)] Agent can display the name "SQL Server Agent Automated Mailer" on e-mail messages.  
 
+ If the name contains the character “\“, you must enter “\\”, otherwise this character will “disappear” from the Display Name.
+
  **Reply e-mail**  
  Type the e-mail address that is used for replies to e-mail messages sent from this account. The reply e-mail is optional. For example, replies to an account for [!INCLUDE [ssNoVersion](../../includes/ssnoversion-md.md)] Agent can go to the database administrator, danw@Adventure-Works.com.  
 

--- a/docs/relational-databases/database-mail/configure-database-mail.md
+++ b/docs/relational-databases/database-mail/configure-database-mail.md
@@ -151,7 +151,7 @@ The following steps use SQL Server Management Studio (SSMS). Download the latest
  **Display name**  
  Type the name to show on e-mail messages sent from this account. The display name is optional. This is the name displayed on messages sent from this account. For example, an account for [!INCLUDE [ssNoVersion](../../includes/ssnoversion-md.md)] Agent can display the name "SQL Server Agent Automated Mailer" on e-mail messages.  
 
- If the name contains the character “\“, you must enter “\\”, otherwise this character will “disappear” from the Display Name.
+ If the display name contains backslash characters (`\`), you must escape them by using double backslashes (`\\`). For example, to display `SERVER\SQL`, enter `SERVER\\SQL` in the Display Name field. Single backslashes are interpreted as escape characters and will not appear in sent emails.
 
  **Reply e-mail**  
  Type the e-mail address that is used for replies to e-mail messages sent from this account. The reply e-mail is optional. For example, replies to an account for [!INCLUDE [ssNoVersion](../../includes/ssnoversion-md.md)] Agent can go to the database administrator, danw@Adventure-Works.com.  

--- a/docs/relational-databases/database-mail/configure-database-mail.md
+++ b/docs/relational-databases/database-mail/configure-database-mail.md
@@ -151,7 +151,7 @@ The following steps use SQL Server Management Studio (SSMS). Download the latest
  **Display name**  
  Type the name to show on e-mail messages sent from this account. The display name is optional. This is the name displayed on messages sent from this account. For example, an account for [!INCLUDE [ssNoVersion](../../includes/ssnoversion-md.md)] Agent can display the name "SQL Server Agent Automated Mailer" on e-mail messages.  
 
- If the display name contains backslash characters (`\`), you must escape them by using double backslashes (`\\`). For example, to display `SERVER\SQL`, enter `SERVER\\SQL` in the **Display Name** field. Single backslashes are interpreted as escape characters and will not appear in sent emails.
+ If the display name contains backslash characters (`\`), you must escape them by using double backslashes (`\\`). For example, to display `SERVER\SQL`, enter `SERVER\\SQL` in the **Display Name** field. Single backslashes are interpreted as escape characters and won't appear in sent emails.
 
  **Reply e-mail**  
  Type the e-mail address that is used for replies to e-mail messages sent from this account. The reply e-mail is optional. For example, replies to an account for [!INCLUDE [ssNoVersion](../../includes/ssnoversion-md.md)] Agent can go to the database administrator, danw@Adventure-Works.com.  

--- a/docs/relational-databases/database-mail/configure-database-mail.md
+++ b/docs/relational-databases/database-mail/configure-database-mail.md
@@ -151,7 +151,7 @@ The following steps use SQL Server Management Studio (SSMS). Download the latest
  **Display name**  
  Type the name to show on e-mail messages sent from this account. The display name is optional. This is the name displayed on messages sent from this account. For example, an account for [!INCLUDE [ssNoVersion](../../includes/ssnoversion-md.md)] Agent can display the name "SQL Server Agent Automated Mailer" on e-mail messages.  
 
- If the display name contains backslash characters (`\`), you must escape them by using double backslashes (`\\`). For example, to display `SERVER\SQL`, enter `SERVER\\SQL` in the Display Name field. Single backslashes are interpreted as escape characters and will not appear in sent emails.
+ If the display name contains backslash characters (`\`), you must escape them by using double backslashes (`\\`). For example, to display `SERVER\SQL`, enter `SERVER\\SQL` in the **Display Name** field. Single backslashes are interpreted as escape characters and will not appear in sent emails.
 
  **Reply e-mail**  
  Type the e-mail address that is used for replies to e-mail messages sent from this account. The reply e-mail is optional. For example, replies to an account for [!INCLUDE [ssNoVersion](../../includes/ssnoversion-md.md)] Agent can go to the database administrator, danw@Adventure-Works.com.  


### PR DESCRIPTION
I have an instance named “DESKTOP-LUIZLIMA\SQL2022" and when I copy its name (SELECT @@SERVERNAME) into the Database Mail Display Name field, the “\” character disappears when the email is sent. I was able to simulate this behavior and I've seen it happen in clients I work with as well. 

<img width="719" height="572" alt="DATABASEMAIL" src="https://github.com/user-attachments/assets/80267d20-7cca-4b32-9df3-7893bc9552b4" />

Here is an example of the email:

<img width="499" height="138" alt="image" src="https://github.com/user-attachments/assets/3d94da2d-3a8c-4111-a898-ab57090421a8" />

When adjusting by including “\\” the name appears correctly in the email. 

<img width="617" height="490" alt="image" src="https://github.com/user-attachments/assets/eac16654-6eb7-41c7-9413-2243a8bb55a1" />

Here is the correct email:

<img width="627" height="177" alt="image" src="https://github.com/user-attachments/assets/5fb05dbf-cc27-4a0a-858c-c5be5175bdb9" />

My suggestion would be to include something in this part of Database Mail talking about this slash “\” or other characters that may have a similar “disappearing” behavior.

https://learn.microsoft.com/en-us/sql/relational-databases/database-mail/configure-database-mail?view=sql-server-ver17

Also validate whether it is valid to insert it into the profile and account configuration pages, which also use the Display Name.

https://learn.microsoft.com/en-us/sql/relational-databases/database-mail/create-a-database-mail-profile?view=sql-server-ver17

https://learn.microsoft.com/en-us/sql/relational-databases/database-mail/create-a-database-mail-account?view=sql-server-ver17