### PR TITLE
Fix T-SQL credential creation and clipboard command

### DIFF
--- a/docs/relational-databases/tutorial-use-azure-blob-storage-service-with-sql-server.md
+++ b/docs/relational-databases/tutorial-use-azure-blob-storage-service-with-sql-server.md
@@ -114,8 +114,8 @@ To create a policy on the container and generate a Shared Access Signature (SAS)
 
    # Outputs the Transact SQL to the clipboard and to the screen to create the credential using the Shared Access Signature
    Write-Host 'Credential T-SQL'
-   $tSql = "CREATE CREDENTIAL [{0}] WITH IDENTITY='Shared Access Signature', SECRET='{1}'" -f $cbc.Uri, $sas.Substring(1)
-   $tSql | clip
+   $tSql = "CREATE CREDENTIAL [{0}] WITH IDENTITY='SHARED ACCESS SIGNATURE', SECRET='{1}'" -f $cbc.Uri, $sas
+   Set-Clipboard -Value $tSql
    Write-Host $tSql
 
    # Once you're done with the tutorial, remove the resource group to clean up the resources.


### PR DESCRIPTION
The New-AzStorageContainerSASToken command has a breaking change where it no longer returns "?sv..." and now only returns "sv...". Consequently, the T-SQL command generation needs to be updated to avoid losing a necessary portion of the token.

Additionally, the PR includes an update to the clipboard command because of a recent customer issue where clip was not available and a change to the casing for the identity.