### PR TITLE
Fix sys.database_service_objectives example query

### DIFF
--- a/docs/relational-databases/system-catalog-views/sys-database-service-objectives-azure-sql-database.md
+++ b/docs/relational-databases/system-catalog-views/sys-database-service-objectives-azure-sql-database.md
@@ -53,9 +53,10 @@ This catalog view is not supported in serverless SQL pools in Azure Synapse Anal
  This query returns the name, service, and performance tier information of the current database context.
   
 ```sql  
-SELECT  DB_NAME(), slo.edition, slo.service_objective
+SELECT  d.name, slo.edition, slo.service_objective, slo.elastic_pool_name
 FROM sys.database_service_objectives AS slo
-WHERE slo.database_id = DB_ID();
+JOIN sys.databases d ON slo.database_id = d.database_id
+WHERE d.name = DB_NAME();
 ```  
 
 ## Next step


### PR DESCRIPTION
The example query doesn't return the correct information for the master database due to DB_ID() returning a different value for the database_id than sys.databases.

Also improved the example by adding elastic_pool_name to the query.