### PR TITLE
Fix SQL command for altering external model

### DIFF
--- a/docs/t-sql/statements/alter-external-model-transact-sql.md
+++ b/docs/t-sql/statements/alter-external-model-transact-sql.md
@@ -90,7 +90,7 @@ This example alters the `EXTERNAL MODEL` named `dbo.myAImodel`, and changes the 
 
 ```sql
 -- Alter an external model
-ALTER EXTERNAL MODEL dbo.myAImodel
+ALTER EXTERNAL MODEL myAImodel
 SET
 (
   MODEL = 'text-embedding-3-large'


### PR DESCRIPTION
removed xtra schema specification - statement fails if schema is specified

Microsoft SQL Server 2025 (RTM) - 17.0.1000.7 (X64) 
	Oct 21 2025 12:05:57 
	Copyright (C) 2025 Microsoft Corporation
	Standard Developer Edition (64-bit) on Windows 10 Pro 10.0 <X64> (Build 26200: ) (Hypervisor)

```
-- Alter an external model
ALTER EXTERNAL MODEL dbo.myAImodel
SET
(
  MODEL = 'text-embedding-3-large'
);

```

<img width="430" height="279" alt="image" src="https://github.com/user-attachments/assets/74547ce5-a0ec-4ee6-a66a-264516732911" />


