### PR TITLE
Fix SQL example by removing schema prefix

### DIFF
--- a/docs/t-sql/statements/drop-external-model-transact-sql.md
+++ b/docs/t-sql/statements/drop-external-model-transact-sql.md
@@ -54,7 +54,7 @@ Dropping an external model doesn't drop any credentials that the model was using
 This example drops the model named `dbo.myAImodel`.
 
 ```sql
-DROP EXTERNAL MODEL dbo.myAImodel;
+DROP EXTERNAL MODEL myAImodel;
 ```
 
 ## Related content


### PR DESCRIPTION
Updated SQL example to remove schema prefix from model name.

Microsoft SQL Server 2025 (RTM) - 17.0.1000.7 (X64) 
	Oct 21 2025 12:05:57 
	Copyright (C) 2025 Microsoft Corporation
	Standard Developer Edition (64-bit) on Windows 10 Pro 10.0 <X64> (Build 26200: ) (Hypervisor)


`DROP EXTERNAL MODEL dbo.myAImodel;
`
<img width="454" height="149" alt="image" src="https://github.com/user-attachments/assets/c7fed04c-2435-4891-ac9b-b6b6dacd87b8" />
