### PR TITLE
Enhance REGEXP_LIKE examples with case-insensitivity

### DIFF
--- a/docs/t-sql/functions/regexp-like-transact-sql.md
+++ b/docs/t-sql/functions/regexp-like-transact-sql.md
@@ -79,6 +79,14 @@ FROM Employees
 WHERE REGEXP_LIKE (FIRST_NAME, '^A.*Y$');
 ```
 
+Select all records from the `Employees` table where the first name starts with `A` and ends with `Y` using case-insensitive mode
+
+```sql
+SELECT *
+FROM Employees
+WHERE REGEXP_LIKE (FIRST_NAME, '^A.*Y$', 'i');
+```
+
 Select all records from the `Orders` table where the order date is in February 2020:
 
 ```sql


### PR DESCRIPTION
Added a case-insensitive example for REGEXP_LIKE in the Employees table.