### PR TITLE
Fix SQL Server 2025 MSSQL_PID table

### DIFF
--- a/docs/linux/includes/editions-sql-server-2025-later-versions.md
+++ b/docs/linux/includes/editions-sql-server-2025-later-versions.md
@@ -11,9 +11,9 @@ ms.custom:
 | --- | --- |
 | `Evaluation` | SQL Server Evaluation edition |
 | `Express` | SQL Server Express edition |
-| `StandardDeveloper` | SQL Server Developer edition |
+| `StandardDeveloper`<br /><br />(For containers, use `DeveloperStandard`) | SQL Server Standard Developer edition |
 | `Standard` | SQL Server Standard edition |
-| `EnterpriseDeveloper` | SQL Server Developer edition |
+| `EnterpriseDeveloper`<br /><br />(For containers, use `Developer`) | SQL Server Enterprise Developer edition |
 | `Enterprise` | This legacy option represents Enterprise edition Server + Client Access License (CAL) based licensing, and is limited to a maximum of 20 cores per SQL Server instance. `Enterprise` isn't available for new agreements. You should choose `EnterpriseCore` when you wish to deploy Enterprise edition. |
 | `EnterpriseCore` | SQL Server Enterprise Core edition. `EnterpriseCore` represents the core-based server licensing model with no core limits. For more information, see [Compute capacity limits by edition of SQL Server](../../sql-server/compute-capacity-limits-by-edition-of-sql-server.md). |
 | `A product key` | If you specify a product key, it must be in the form of `#####-#####-#####-#####-#####`, where `#` is a number or a letter. |


### PR DESCRIPTION
https://learn.microsoft.com/sql/linux/sql-server-linux-configure-environment-variables?view=sql-server-ver17
> When you deploy a container for SQL Server 2025 (17.x) or a later version, use MSSQL_PID=DeveloperStandard for Standard Developer edition, and MSSQL_PID=Developer for Enterprise Developer edition.