### PR TITLE
Update sp-help-spatial-geography-histogram-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-help-spatial-geography-histogram-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-help-spatial-geography-histogram-transact-sql.md
@@ -82,8 +82,8 @@ The following example calls `sp_help_spatial_geography_histogram` on the `Person
 
 ```sql
 EXECUTE sp_help_spatial_geography_histogram
-    @tabname = Person.Address,
-    @colname = SpatialLocation,
+    @tabname = N'Person.Address',
+    @colname = N'SpatialLocation',
     @resolution = 64,
     @sample = 30;
 ```


### PR DESCRIPTION
Adding missing quotes around table and column names in the example. (They are not needed for the column name, but since the table name is two-part notations, quotes are needed.)