### PR TITLE
Update sql-machine-learning-services-windows-install-sql-2022.md

### DIFF
--- a/docs/machine-learning/install/sql-machine-learning-services-windows-install-sql-2022.md
+++ b/docs/machine-learning/install/sql-machine-learning-services-windows-install-sql-2022.md
@@ -158,7 +158,7 @@ Beginning with [!INCLUDE [sssql22-md](../../includes/sssql22-md.md)], runtimes f
 
     ```cmd
     cd "C:\Program Files\Python310\"
-    python -m pip install -t "C:\Program Files\Python310\Lib\site-packages" dill numpy==1.22.0 pandas patsy python-dateutil
+    python -m pip install -t "C:\Program Files\Python310\Lib\site-packages" dill numpy==1.22.0 pandas patsy python-dateutil packaging
     python -m pip install -t "C:\Program Files\Python310\Lib\site-packages" https://aka.ms/sqlml/python3.10/windows/revoscalepy-10.0.1-py3-none-any.whl
     ```
 


### PR DESCRIPTION
There is a missing installation of the Python "packaging" module (added to the commands) without which the redirection of "os.devnull" doesn't work.