### PR TITLE
Fix closing tag for RSWindowsNegotiate in config

### DIFF
--- a/docs/reporting-services/report-server/register-a-service-principal-name-spn-for-a-report-server.md
+++ b/docs/reporting-services/report-server/register-a-service-principal-name-spn-for-a-report-server.md
@@ -59,7 +59,7 @@ The values that you specify for `<computername>` and `<domainname>` identify the
 
 1. Open the `RsReportServer.config` file and locate the `<AuthenticationTypes>` section.
 
-1. Add `<RSWindowsNegotiate/>` as the first entry in this section to enable Kerberos.
+1. Add `<RSWindowsNegotiate />` as the first entry in this section to enable Kerberos.
 
 ## Related content
 

--- a/docs/reporting-services/report-server/register-a-service-principal-name-spn-for-a-report-server.md
+++ b/docs/reporting-services/report-server/register-a-service-principal-name-spn-for-a-report-server.md
@@ -59,7 +59,7 @@ The values that you specify for `<computername>` and `<domainname>` identify the
 
 1. Open the `RsReportServer.config` file and locate the `<AuthenticationTypes>` section.
 
-1. Add `<RSWindowsNegotiate>` as the first entry in this section to enable Kerberos.
+1. Add `<RSWindowsNegotiate/>` as the first entry in this section to enable Kerberos.
 
 ## Related content
 


### PR DESCRIPTION
Corrected XML tag in step 7:
Changed <RSWindowsNegotiate> to <RSWindowsNegotiate/> to ensure proper syntax.