### PR TITLE
Update sp-help-spatial-*-histogram-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-help-spatial-geography-histogram-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-help-spatial-geography-histogram-transact-sql.md
@@ -65,7 +65,7 @@ A table value is returned. The following grid describes the column contents of t
 
 ## Permissions
 
-User must be a member of the **public** role. Requires READ ACCESS permission on the server and the object.
+User must be a member of the **sysadmin** fixed server role.
 
 ## Remarks
 

--- a/docs/relational-databases/system-stored-procedures/sp-help-spatial-geometry-histogram-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-help-spatial-geometry-histogram-transact-sql.md
@@ -85,7 +85,7 @@ A table value is returned. The following grid describes the column contents of t
 
 ## Permissions
 
-User must be a member of the **public** role. Requires `READ ACCESS` permission on the server and the object.
+User must be a member of the **sysadmin** fixed server role.
 
 ## Remarks
 


### PR DESCRIPTION
Corrected the required permission based on the actual behaviour, although this has to be construed as a bug. That is, you don't get an explicit permission error, but only "A severe error occurred on the current command. The results if any should be discarded". Given how long this behaviour has been there, fixing the actual bug is unlikely to pass the triage bar. Thus, better to adopt the documentation.