### PR TITLE
Fix description of Import action parameters

### DIFF
--- a/docs/tools/sqlpackage/sqlpackage-import.md
+++ b/docs/tools/sqlpackage/sqlpackage-import.md
@@ -33,7 +33,7 @@ SqlPackage /Action:Import {parameters} {properties}
 
 The Import action requires a `SourceFile` parameter to specify the name and location of the .bacpac file containing the database objects and data.
 
-The Export action requires a target connection where a new database will be created by SqlPackage or where a blank database is present. This is specified either through a combination of:
+The Import action requires a target connection where a new database will be created by SqlPackage or where a blank database is present. This is specified either through a combination of:
 - `TargetServerName` and `TargetDatabaseName` parameters, or
 - `TargetConnectionString` parameter.
 


### PR DESCRIPTION

# Bug: Incorrect wording on "SqlPackage Import" page (SQL Server v17)

**Article URL**
- https://learn.microsoft.com/en-us/sql/tools/sqlpackage/sqlpackage-import?view=sql-server-ver17

**Affected section**
- Introduction / description of the Import action

**Observed error**
- Current text:
  > The Export action requires a target connection where a new database will be created by SqlPackage or where a blank database is present. This is specified either through a combination of:
- Problem: The sentence refers to **Export**, but the page is about **Import**.

**Proposed correction**
- Correct text:
  > The Import action requires a target connection where a new database will be created by SqlPackage or where a blank database is present. This is specified either through a combination of:

**Reason**
- The page documents the Import action, so mentioning Export is a typo.

**Impact**
- This may confuse readers and lead them to think the syntax applies to Export.

**Suggestion**
- Check if other sections contain incorrect references to Export and fix them.

<!-- Suggested labels -->
`doc-bug` `sqlpackage` `import` `sql-server-ver17
