### PR TITLE
Fix syntax for ALTER INDEX REBUILD options in documentation

### DIFF
--- a/docs/t-sql/statements/alter-index-transact-sql.md
+++ b/docs/t-sql/statements/alter-index-transact-sql.md
@@ -63,11 +63,11 @@ Syntax for SQL Server, Azure SQL Database, and Azure SQL Managed Instance.
 ```syntaxsql
 ALTER INDEX { index_name | ALL } ON <object>
 {
-      REBUILD {
+      REBUILD [
             [ WITH ( <rebuild_index_option> [ , ...n ] ) ]
           | [ PARTITION = ALL [ WITH ( <rebuild_index_option> [ , ...n ] ) ] ]
           | [ PARTITION = partition_number [ WITH ( <single_partition_rebuild_index_option> [ , ...n ] ) ] ]
-      }
+      ]
     | DISABLE
     | REORGANIZE  [ PARTITION = partition_number ] [ WITH ( <reorganize_option>  ) ]
     | SET ( <set_index_option> [ , ...n ] )
@@ -148,11 +148,11 @@ Syntax for Azure Synapse Analytics and Analytics Platform System (PDW).
 ALTER INDEX { index_name | ALL }
     ON [ schema_name. ] table_name
 {
-      REBUILD {
+      REBUILD [
             [ WITH ( <rebuild_index_option> [ , ...n ] ) ]
           | [ PARTITION = ALL [ WITH ( <rebuild_index_option> ) ] ]
           | [ PARTITION = partition_number [ WITH ( <single_partition_rebuild_index_option> ) ] ]
-      }
+      ]
     | DISABLE
     | REORGANIZE [ PARTITION = partition_number ]
 }

--- a/docs/t-sql/statements/alter-index-transact-sql.md
+++ b/docs/t-sql/statements/alter-index-transact-sql.md
@@ -3,8 +3,8 @@ title: "ALTER INDEX (Transact-SQL)"
 description: Modifies an existing table or view index (rowstore, columnstore, or XML) by disabling, rebuilding, or reorganizing the index; or by setting options on the index.
 author: rwestMSFT
 ms.author: randolphwest
-ms.reviewer: wiassaf, randolphwest, dfurman
-ms.date: 04/14/2025
+ms.reviewer: wiassaf, dfurman
+ms.date: 01/05/2026
 ms.service: sql
 ms.subservice: t-sql
 ms.topic: reference

--- a/docs/t-sql/statements/alter-index-transact-sql.md
+++ b/docs/t-sql/statements/alter-index-transact-sql.md
@@ -64,7 +64,8 @@ Syntax for SQL Server, Azure SQL Database, and Azure SQL Managed Instance.
 ALTER INDEX { index_name | ALL } ON <object>
 {
       REBUILD {
-            [ PARTITION = ALL [ WITH ( <rebuild_index_option> [ , ...n ] ) ] ]
+            [ WITH ( <rebuild_index_option> [ , ...n ] ) ]
+          | [ PARTITION = ALL [ WITH ( <rebuild_index_option> [ , ...n ] ) ] ]
           | [ PARTITION = partition_number [ WITH ( <single_partition_rebuild_index_option> [ , ...n ] ) ] ]
       }
     | DISABLE
@@ -148,7 +149,8 @@ ALTER INDEX { index_name | ALL }
     ON [ schema_name. ] table_name
 {
       REBUILD {
-            [ PARTITION = ALL [ WITH ( <rebuild_index_option> ) ] ]
+            [ WITH ( <rebuild_index_option> [ , ...n ] ) ]
+          | [ PARTITION = ALL [ WITH ( <rebuild_index_option> ) ] ]
           | [ PARTITION = partition_number [ WITH ( <single_partition_rebuild_index_option> ) ] ]
       }
     | DISABLE


### PR DESCRIPTION
The current syntax description does not allow specifying index rebuild options without including a PARTITION clause. Both the examples on this page (e.g.
`ALTER INDEX IX_INDEX1
ON T1
REBUILD
WITH (DATA_COMPRESSION = PAGE);
GO`
) and elsewhere, and actual testing in SQL Server 2022 show that the proposed syntax works and is actually supported.