### PR TITLE
 sys-dm-db-tuning-recommendations-transact - Example 3 fix

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-db-tuning-recommendations-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-db-tuning-recommendations-transact-sql.md
@@ -156,9 +156,9 @@ AS (
         error_prone = IIF(regressedPlanErrorCount > recommendedPlanErrorCount, 'YES', 'NO')
     FROM sys.dm_db_tuning_recommendations
     CROSS APPLY OPENJSON(Details, '$.planForceDetails') WITH (
-            [query_id] INT '$.queryId',
-            regressedPlanId INT '$.regressedPlanId',
-            recommendedPlanId INT '$.recommendedPlanId',
+            [query_id] BIGINT '$.queryId',
+            regressedPlanId BIGINT '$.regressedPlanId',
+            recommendedPlanId BIGINT '$.recommendedPlanId',
             regressedPlanErrorCount INT,
             recommendedPlanErrorCount INT,
             regressedPlanExecutionCount INT,


### PR DESCRIPTION
Fix data types.  query_id and plan_id columns from query store are BIGINT.  Fixes potential error: The conversion of the nvarchar value '2147483648' overflowed an int column.