### PR TITLE
Improve documentation for resumable index limitations

### DIFF
--- a/docs/t-sql/statements/create-index-transact-sql.md
+++ b/docs/t-sql/statements/create-index-transact-sql.md
@@ -887,7 +887,7 @@ Resumable index create operations have the following limitations:
 - The DDL command with `RESUMABLE = ON` can't be executed inside an explicit transaction.
 - You cannot create a resumable index that contains:
   - Computed or `timestamp` (`rowversion`) column(s) as key columns.
-  - LOB column as an included column.
+  - Computed or LOB column as an included column.
 - Resumable index operations aren't supported for:
   - The `ALTER INDEX REBUILD ALL` command
   - The `ALTER TABLE REBUILD` command


### PR DESCRIPTION
I'm seeing a limitation when trying to use RESUMABLE and I have a computed column in the `INCLUDED` columns definition.

It errors as not supported.

``` 
Msg 10675, Level 16, State 1, Line 3
Internal Query Processor Error: The query processor could not produce a query plan. The RESUMABLE option is not supported for this index build. Remove the RESUMABLE option and rerun the statement.
```

If I remove that column from the `INCLUDED` columns, it works fine.