### PR TITLE
Removed incorrect image link

### DIFF
--- a/docs/tools/visual-studio-code-extensions/sql-database-projects/add-item-templates.md
+++ b/docs/tools/visual-studio-code-extensions/sql-database-projects/add-item-templates.md
@@ -51,8 +51,6 @@ Add database objects to your project using item templates from the Database Proj
 
 1. Enter a name for the new object.
 
-::: image type="content" source="media/add-item-templates/add-item-menu.png" alt-text="Screenshot of context menu showing Add Item option." lightbox="media/add-item-templates/add-item-menu.png":::
-
 The extension creates a T-SQL file in your project with template code for the selected object type.
 
 > [!NOTE]  


### PR DESCRIPTION
I didn't know how to provide feedback about a missing image link in the documentation, Image currently doesn't show up when loading the page.