### PR TITLE
Remove sudo from tee cmd as we're already in sudo cmd mode.

### DIFF
--- a/docs/linux/includes/odbc-ubuntu.md
+++ b/docs/linux/includes/odbc-ubuntu.md
@@ -27,7 +27,7 @@ Use the following steps to install the **mssql-tools18** on Ubuntu.
 1. Import the public repository GPG keys.
 
    ```bash
-   curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc
+   curl https://packages.microsoft.com/keys/microsoft.asc | tee /etc/apt/trusted.gpg.d/microsoft.asc
    ```
 
 1. Register the Microsoft Ubuntu repository.

--- a/docs/linux/includes/odbc-ubuntu.md
+++ b/docs/linux/includes/odbc-ubuntu.md
@@ -53,7 +53,7 @@ Use the following steps to install the **mssql-tools18** on Ubuntu.
 1. Import the public repository GPG keys.
 
    ```bash
-   curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc
+   curl https://packages.microsoft.com/keys/microsoft.asc | tee /etc/apt/trusted.gpg.d/microsoft.asc
    ```
 
 1. Register the Microsoft Ubuntu repository.
@@ -79,7 +79,7 @@ Use the following steps to install the **mssql-tools18** on Ubuntu.
 1. Import the public repository GPG keys.
 
    ```bash
-   curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc
+   curl https://packages.microsoft.com/keys/microsoft.asc | tee /etc/apt/trusted.gpg.d/microsoft.asc
    ```
 
 1. Register the Microsoft Ubuntu repository.


### PR DESCRIPTION
Just reading through the docs on this and caught what I think is a possible copy/paste mistake.
Since the steps begin with an invocation of `sudo su` I think that means we should be able to invoke `tee` without it until `exit` is invoked.