### PR TITLE
Fix date format pattern in format-transact-sql.md

### DIFF
--- a/docs/t-sql/functions/format-transact-sql.md
+++ b/docs/t-sql/functions/format-transact-sql.md
@@ -45,7 +45,7 @@ Expression of a supported data type to format. For a list of valid types, see th
 
 **nvarchar** format pattern.
 
-The *format* argument must contain a valid .NET Framework format string, either as a standard format string (for example, `"C"` or `"D"`), or as a pattern of custom characters for dates and numeric values (for example, `"MMMM DD, yyyy (dddd)"`). Composite formatting isn't supported.
+The *format* argument must contain a valid .NET Framework format string, either as a standard format string (for example, `"C"` or `"D"`), or as a pattern of custom characters for dates and numeric values (for example, `"MMMM dd, yyyy (dddd)"`). Composite formatting isn't supported.
 
 For a full explanation of these formatting patterns, consult the .NET Framework documentation on string formatting in general, custom date and time formats, and custom number formats. For more information, see [Formatting Types](/dotnet/standard/base-types/formatting-types).
 


### PR DESCRIPTION
Corrected the date format pattern in the documentation.

The existing format would result in "March DD, 2026 (Friday)". Updated so results in "March 13, 2026 (Friday)"