### PR TITLE
Add uniqueness documentation for database identifiers

### DIFF
--- a/docs/relational-databases/databases/database-identifiers.md
+++ b/docs/relational-databases/databases/database-identifiers.md
@@ -39,6 +39,43 @@ CREATE TABLE TableX (
 
 This table also has an unnamed constraint. The `PRIMARY KEY` constraint has no identifier.
 
+Some identifiers, such as constraint names and other schema-scoped objects, must be unique within a database schema. For example, two primary key constraints in the same schema can't share a name, so the second table creation statement isn't allowed:
+
+```sql
+USE AdventureWorks2022;
+GO
+
+CREATE TABLE [SalesOrderGeneral Table] (
+   [Order] INT NOT NULL,
+   [SalesOrderID] INT IDENTITY(1, 1) NOT NULL,
+   [SalesOrderDetailID] INT NOT NULL,
+   [ModifiedDate] DATETIME NOT NULL,
+   CONSTRAINT [PK_SalesOrder] PRIMARY KEY CLUSTERED (
+     [Order] ASC,
+     [SalesOrderID] ASC
+   )
+);
+GO
+
+-- Primary key identifier conflicts with existing primary key, and so will result in an error.
+CREATE TABLE [SalesOrderDetail Table] (
+   [Order] INT NOT NULL,
+   [SalesOrderDetailID] INT IDENTITY(1, 1) NOT NULL,
+   [OrderQty] SMALLINT NOT NULL,
+   [ProductID] INT NOT NULL,
+   [UnitPrice] MONEY NOT NULL,
+   [UnitPriceDiscount] MONEY NOT NULL,
+   [ModifiedDate] DATETIME NOT NULL,
+   CONSTRAINT [PK_SalesOrder] PRIMARY KEY CLUSTERED (
+       [Order] ASC,
+       [SalesOrderDetailID] ASC
+   )
+);
+GO
+```
+
+However, each table can contain its own column named `Order`, because column names only need to be unique within each table, not within the schema.
+
 The collation of an identifier depends on the level at which it's defined. Identifiers of instance-level objects, such as logins and database names, are assigned the default collation of the instance. Identifiers of objects in a database, such as tables, views, and column names, are assigned the default collation of the database. For example, two tables with names that differ only in case can be created in a database that has case-sensitive collation, but can't be created in a database that has case-insensitive collation.
 
 > [!NOTE]  
@@ -122,42 +159,6 @@ The names of variables, functions, and stored procedures must comply with the fo
    - The at sign (`@`), dollar sign (`$`), number sign (`#`), or underscore (`_`).
 
 1. The identifier must not be a [!INCLUDE [tsql](../../includes/tsql-md.md)] reserved word. [!INCLUDE [ssNoVersion](../../includes/ssnoversion-md.md)] reserves both the uppercase and lowercase versions of reserved words. When identifiers are used in [!INCLUDE [tsql](../../includes/tsql-md.md)] statements, the identifiers that don't comply with these rules must be delimited by double quotation marks or brackets. The words that are reserved depend on the database compatibility level. This level can be set by using the [ALTER DATABASE compatibility level](../../t-sql/statements/alter-database-transact-sql-compatibility-level.md) statement.
-
-1. Identifiers must be named uniquely within a database schema or database object. For example, two keys in the same schema may not share a name, so the second table creation statement would not be allowed:
-   ```sql
-   USE AdventureWorks2022;
-   GO
-
-   CREATE TABLE [SalesOrderGeneral Table] (
-       [Order] INT NOT NULL,
-       [SalesOrderID] INT IDENTITY(1, 1) NOT NULL,
-       [SalesOrderDetailId] INT NOT NULL,
-       [ModifiedDate] DATETIME NOT NULL,
-       CONSTRAINT [PK_SalesOrder] PRIMARY KEY CLUSTERED (
-         [Order] ASC,
-         [SalesOrderID] ASC
-       )
-   );
-   GO
-   
-   --Primary key identifier conflicts with existing primary key, and so will result in an error
-   CREATE TABLE [SalesOrderDetail Table] (
-       [Order] INT NOT NULL,
-       [SalesOrderDetailID] INT IDENTITY(1, 1) NOT NULL,
-       [OrderQty] SMALLINT NOT NULL,
-       [ProductID] INT NOT NULL,
-       [UnitPrice] MONEY NOT NULL,
-       [UnitPriceDiscount] MONEY NOT NULL,
-       [ModifiedDate] DATETIME NOT NULL,
-       CONSTRAINT [PK_SalesOrder] PRIMARY KEY CLUSTERED (
-           [Order] ASC,
-           [SalesOrderDetailID] ASC
-       )
-   );
-   GO
-   ```
-
-   However, each table may contain its own column named `Order`, as the column name is unique among columns within the table.
 
 1. Embedded spaces or special characters aren't allowed.
 

--- a/docs/relational-databases/databases/database-identifiers.md
+++ b/docs/relational-databases/databases/database-identifiers.md
@@ -123,6 +123,42 @@ The names of variables, functions, and stored procedures must comply with the fo
 
 1. The identifier must not be a [!INCLUDE [tsql](../../includes/tsql-md.md)] reserved word. [!INCLUDE [ssNoVersion](../../includes/ssnoversion-md.md)] reserves both the uppercase and lowercase versions of reserved words. When identifiers are used in [!INCLUDE [tsql](../../includes/tsql-md.md)] statements, the identifiers that don't comply with these rules must be delimited by double quotation marks or brackets. The words that are reserved depend on the database compatibility level. This level can be set by using the [ALTER DATABASE compatibility level](../../t-sql/statements/alter-database-transact-sql-compatibility-level.md) statement.
 
+1. Identifiers must be named uniquely within a database schema or database object. For example, two keys in the same schema may not share a name, so the second table creation statement would not be allowed:
+   ```sql
+   USE AdventureWorks2022;
+   GO
+
+   CREATE TABLE [SalesOrderGeneral Table] (
+       [Order] INT NOT NULL,
+       [SalesOrderID] INT IDENTITY(1, 1) NOT NULL,
+       [SalesOrderDetailId] INT NOT NULL,
+       [ModifiedDate] DATETIME NOT NULL,
+       CONSTRAINT [PK_SalesOrder] PRIMARY KEY CLUSTERED (
+         [Order] ASC,
+         [SalesOrderID] ASC
+       )
+   );
+   GO
+   
+   --Primary key identifier conflicts with existing primary key, and so will result in an error
+   CREATE TABLE [SalesOrderDetail Table] (
+       [Order] INT NOT NULL,
+       [SalesOrderDetailID] INT IDENTITY(1, 1) NOT NULL,
+       [OrderQty] SMALLINT NOT NULL,
+       [ProductID] INT NOT NULL,
+       [UnitPrice] MONEY NOT NULL,
+       [UnitPriceDiscount] MONEY NOT NULL,
+       [ModifiedDate] DATETIME NOT NULL,
+       CONSTRAINT [PK_SalesOrder] PRIMARY KEY CLUSTERED (
+           [Order] ASC,
+           [SalesOrderDetailID] ASC
+       )
+   );
+   GO
+   ```
+
+   However, each table may contain its own column named `Order`, as the column name is unique among columns within the table.
+
 1. Embedded spaces or special characters aren't allowed.
 
 1. [Supplementary characters](../../relational-databases/collations/collation-and-unicode-support.md#Supplementary_Characters) aren't allowed.


### PR DESCRIPTION
Added a rule stating that identifiers must be uniquely named within a database schema or object, including an example demonstrating naming conflicts. I can't find any other documentation on this, so it would be helpful (assuming I'm understanding correctly) to have this available. I ran into a naming conflict and didn't realize there's a bit more specificity to naming.

If anyone can help me find a good source for this, please comment.