### PR TITLE
Update correct permissions for sys.traces

### DIFF
--- a/docs/relational-databases/system-catalog-views/sys-traces-transact-sql.md
+++ b/docs/relational-databases/system-catalog-views/sys-traces-transact-sql.md
@@ -53,7 +53,7 @@ For a complete list of supported trace events, see [SQL Server Event Class Refer
 
 [!INCLUDE [ssCatViewPerm](../../includes/sscatviewperm-md.md)] For more information, see [Metadata Visibility Configuration](../../relational-databases/security/metadata-visibility-configuration.md).
 
-[!INCLUDE [sssql22-md](../../includes/sssql22-md.md)] and later versions require VIEW SERVER PERFORMANCE STATE permission on the server.
+Requires ALTER TRACE permission on the server.
 
 ## Related content
 


### PR DESCRIPTION
Here's the proof of correct permissions:

```sql
/* For security reasons the login is created disabled and with a random password. */
/****** Object:  Login [VuSrvState]    Script Date: 3/5/2026 7:50:58 AM ******/
DROP LOGIN [VuSrvState] 
go
CREATE LOGIN [VuSrvState] WITH PASSWORD=N'mFJ6wiNa76O+EjXYWtn36T1JPuZ9Jb7nFxxJe6lBU8s=', DEFAULT_DATABASE=[master], DEFAULT_LANGUAGE=[us_english], CHECK_EXPIRATION=OFF, CHECK_POLICY=OFF
GO

ALTER LOGIN [VuSrvState] ENABLE
GO


GRANT VIEW SERVER STATE TO [VuSrvState];  
GRANT VIEW SERVER PERFORMANCE STATE TO [VuSrvState];

GO

EXECUTE AS LOGIN = 'VuSrvState';

SELECT * FROM sys.traces;
GO
REVERT;


EXECUTE AS LOGIN = 'VuSrvState';
SELECT *
FROM sys.fn_my_permissions(NULL, 'SERVER')
WHERE permission_name IN
(
    'VIEW SERVER STATE',
    'VIEW SERVER PERFORMANCE STATE'
);
GO
REVERT;

SELECT *
FROM sys.server_permissions
WHERE grantee_principal_id = SUSER_ID('VuSrvState');

-- Now grant it ALTER TRACE 
GRANT ALTER TRACE TO [VuSrvState]
GO

EXECUTE AS LOGIN = 'VuSrvState';

SELECT * FROM sys.traces;
GO
REVERT;

```
