### PR TITLE
Update permissions guidance for managed identities

### DIFF
--- a/docs/sql-server/azure-arc/microsoft-entra-authentication-with-managed-identity.md
+++ b/docs/sql-server/azure-arc/microsoft-entra-authentication-with-managed-identity.md
@@ -183,6 +183,9 @@ The system-assigned managed identity, which uses the Arc-enabled machine name, m
 
 You can use PowerShell to grant required permissions to the managed identity. Alternatively, you can [create a role-assignable group](/entra/identity/role-based-access-control/groups-create-eligible). After the group is created, assign the **Directory Readers** role or the `User.Read.All`, `GroupMember.Read.All`, and `Application.Read.All` permissions to the group, and add all system-assigned managed identities for your Azure Arc-enabled machines to the group. We don't recommend using the **Directory Readers** role in your production environment.
 
+> [!Note]
+> Even when the System-Assigned Managed Identity is a member of a group, the above three required Microsoft Graph application permissions must still be explicitly assigned to the managed identity itself.
+
 The following PowerShell script grants the required permissions to the managed identity. Make sure this script is run on PowerShell 7.5 or a later version, and has the `Microsoft.Graph` module 2.28 or later installed.
 
 ```powershell

--- a/docs/sql-server/azure-arc/microsoft-entra-authentication-with-managed-identity.md
+++ b/docs/sql-server/azure-arc/microsoft-entra-authentication-with-managed-identity.md
@@ -183,8 +183,8 @@ The system-assigned managed identity, which uses the Arc-enabled machine name, m
 
 You can use PowerShell to grant required permissions to the managed identity. Alternatively, you can [create a role-assignable group](/entra/identity/role-based-access-control/groups-create-eligible). After the group is created, assign the **Directory Readers** role or the `User.Read.All`, `GroupMember.Read.All`, and `Application.Read.All` permissions to the group, and add all system-assigned managed identities for your Azure Arc-enabled machines to the group. We don't recommend using the **Directory Readers** role in your production environment.
 
-> [!Note]
-> Even when the System-Assigned Managed Identity is a member of a group, the above three required Microsoft Graph application permissions must still be explicitly assigned to the managed identity itself.
+> [!NOTE]
+> Even when the system-assigned managed identity is a member of a group, the preceding three required Microsoft Graph application permissions must still be explicitly assigned to the managed identity itself.
 
 The following PowerShell script grants the required permissions to the managed identity. Make sure this script is run on PowerShell 7.5 or a later version, and has the `Microsoft.Graph` module 2.28 or later installed.
 


### PR DESCRIPTION
The description is to make clear statement to end users that System Assigned  Managed identities required graph permissions even if they are added to the group.. The current statement is confusing, hence the same was confirmed with MIcrosoft Support and propsing this statement.