### PR TITLE
More information needed about delimited identifiers

### DIFF
--- a/docs/relational-databases/databases/database-identifiers.md
+++ b/docs/relational-databases/databases/database-identifiers.md
@@ -138,6 +138,10 @@ When you use identifiers in [!INCLUDE [tsql](../../includes/tsql-md.md)] stateme
 
 Some rules for the format of regular identifiers depend on the database compatibility level. 
 
+## Rules for delimited identifiers
+
+[to be written]
+
 ## Catalog collation in Azure SQL Database
 
 You can't change or set the logical server collation on Azure SQL Database. However, you can configure each database's collations separately for data in the database and for catalog. The catalog collation determines the collation for system metadata, such as object identifiers. You can specify both collations independently when you [create the database in the Azure portal](/azure/azure-sql/database/single-database-create-quickstart?view=azuresql&preserve-view=true&tabs=azure-portal#create-a-single-database), in T-SQL with [CREATE DATABASE](../../t-sql/statements/create-database-transact-sql.md?view=azuresqldb-current&preserve-view=true#collation_name), or in PowerShell with [New-AzSqlDatabase](/powershell/module/az.sql/new-azsqldatabase).


### PR DESCRIPTION
Greetings.

Sorry for creating such a strange pull request but this repository has no "Issues" section and didn't know where else I could ask this. I'd be glad to write this section content but... well, I need reliable information!

I'm currently working with SQL Server and for several reasons, I needed to know exactly how to write a delimited identifier in Transact-SQL. This page mentions delimited identifiers but doesn't explain how to write `[` or `]` in a delimited identifier: https://learn.microsoft.com/en-us/sql/relational-databases/databases/database-identifiers?view=sql-server-ver17

Also, I feel this page should definitely contain everything there is to know about regular and delimited identifiers (but it doesn't): https://learn.microsoft.com/en-us/sql/t-sql/language-elements/transact-sql-syntax-conventions-transact-sql?view=sql-server-ver17&tabs=code

Or at the very least a page in this section: https://learn.microsoft.com/en-us/sql/t-sql/language-reference?view=sql-server-ver17

Closest info I could find (but that's for DMX): https://learn.microsoft.com/en-us/sql/dmx/identifiers-dmx?view=sql-server-ver17

Other pages suggested by Copilot:
* [QUOTENAME](https://learn.microsoft.com/en-us/sql/t-sql/functions/quotename-transact-sql?view=sql-server-ver17)
* [SET QUOTED_IDENTIFIER](https://learn.microsoft.com/en-us/sql/t-sql/statements/set-quoted-identifier-transact-sql?view=sql-server-ver17)

... but all of these are very implicit about escaping and supported delimiters. So far, it seems:

* Delimited identifiers using square brackets allow every character except `]` which must be escaped with `]]`?
* Delimited identifiers using double quotes allow every character except `"` which must be escaped with `""`?
* SQL Server also accepts other delimiters (cf. `QUOTENAME` page) but escaping rules are unknown.

Regular identifiers are well described, but delimited identifiers would deserve some attention in my humble opinion.
