### PR TITLE
Clarify Deployer login requirements in arc-enabled-roles.md

### DIFF
--- a/docs/includes/arc-enabled-roles.md
+++ b/docs/includes/arc-enabled-roles.md
@@ -4,6 +4,7 @@ ms.author: mikeray
 ms.date: 04/25/2024
 ms.service: sql
 ms.topic: include
+ai-usage: ai-assisted
 ---
 
 When you install Azure extension for SQL Server, the installation:

--- a/docs/includes/arc-enabled-roles.md
+++ b/docs/includes/arc-enabled-roles.md
@@ -18,7 +18,7 @@ When you install Azure extension for SQL Server, the installation:
 
 In addition, Azure extension for SQL Server revokes permissions for these roles when they're no longer needed for specific features.
 
- [!NOTE]
+> [!NOTE]
 > The actions described above require the Deployer to connect to SQL Server as NT AUTHORITY\SYSTEM. If the NT AUTHORITY\SYSTEM login has been removed, disabled, or denied CONNECT SQL permission, the Deployer cannot perform any of these actions, and the Azure extension for SQL Server will fail to provision. See Prerequisites for steps to verify and restore this login.
 
 `SqlServerExtensionPermissionProvider` is a Windows task. It grants or revokes privileges in SQL Server when it detects:

--- a/docs/includes/arc-enabled-roles.md
+++ b/docs/includes/arc-enabled-roles.md
@@ -19,7 +19,7 @@ When you install Azure extension for SQL Server, the installation:
 In addition, Azure extension for SQL Server revokes permissions for these roles when they're no longer needed for specific features.
 
 > [!NOTE]
-> The actions described above require the Deployer to connect to SQL Server as NT AUTHORITY\SYSTEM. If the NT AUTHORITY\SYSTEM login has been removed, disabled, or denied CONNECT SQL permission, the Deployer cannot perform any of these actions, and the Azure extension for SQL Server will fail to provision. See Prerequisites for steps to verify and restore this login.
+> The actions described above require the Deployer to connect to SQL Server as `NT AUTHORITY\SYSTEM`. If the `NT AUTHORITY\SYSTEM` login has been removed, disabled, or denied `CONNECT SQL` permission, the Deployer cannot perform any of these actions, and the Azure extension for SQL Server will fail to provision. See Prerequisites for steps to verify and restore this login.
 
 `SqlServerExtensionPermissionProvider` is a Windows task. It grants or revokes privileges in SQL Server when it detects:
 

--- a/docs/includes/arc-enabled-roles.md
+++ b/docs/includes/arc-enabled-roles.md
@@ -18,6 +18,9 @@ When you install Azure extension for SQL Server, the installation:
 
 In addition, Azure extension for SQL Server revokes permissions for these roles when they're no longer needed for specific features.
 
+ [!NOTE]
+> The actions described above require the Deployer to connect to SQL Server as NT AUTHORITY\SYSTEM. If the NT AUTHORITY\SYSTEM login has been removed, disabled, or denied CONNECT SQL permission, the Deployer cannot perform any of these actions, and the Azure extension for SQL Server will fail to provision. See Prerequisites for steps to verify and restore this login.
+
 `SqlServerExtensionPermissionProvider` is a Windows task. It grants or revokes privileges in SQL Server when it detects:
 
 - A new SQL Server instance is installed on the host


### PR DESCRIPTION
Added a note about NT AUTHORITY\SYSTEM login requirements for the Deployer.