### PR TITLE
Replace Pure Storage with Everpure in documentation

### DIFF
--- a/docs/relational-databases/backup-restore/sql-server-backup-and-restore-with-s3-compatible-object-storage.md
+++ b/docs/relational-databases/backup-restore/sql-server-backup-and-restore-with-s3-compatible-object-storage.md
@@ -52,7 +52,7 @@ The following table provides a nonexhaustive summary of object storage providers
 | [MinIO](https://min.io) | Multicloud Object Storage |
 | [NetApp](https://www.netapp.com/data-storage/storagegrid/) | StorageGRID, ONTAP |
 | [Nutanix](https://www.nutanix.com/products/objects) | Nutanix Object Storage |
-| [Pure Storage](https://www.purestorage.com/products/unstructured-data-storage/flashblade-s.html) | Pure FlashBlade |
+| [Everpure](https://www.everpuredata.com/products/unstructured-data-storage/flashblade-s.html) | Everpure FlashBlade |
 | [Red Hat](https://www.redhat.com/technologies/cloud-computing/openshift) | OpenShift Container Storage |
 | [Scality](https://www.artesca.scality.com/) | Scality Artesca |
 | [Weka](https://www.weka.io) | Weka S3 |


### PR DESCRIPTION
Replace Pure Storage with Everpure in documentation. Company rebrand. Also fixes a typo.