### PR TITLE
Update alter-database-transact-sql-set-options.md

### DIFF
--- a/docs/t-sql/statements/alter-database-transact-sql-set-options.md
+++ b/docs/t-sql/statements/alter-database-transact-sql-set-options.md
@@ -804,7 +804,7 @@ Controls whether the database can be accessed by external resources, such as obj
 > [!IMPORTANT]  
 > The instance of [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] recognizes this setting when the cross db ownership chaining server option is 0 (OFF). When cross db ownership chaining is 1 (ON), all user databases can participate in cross-database ownership chains, regardless of the value of this option. This option is set by using [sp_configure](../../relational-databases/system-stored-procedures/sp-configure-transact-sql.md).
 
-To set this option, requires `CONTROL SERVER` permission on the database.
+To set this option, requires the server-level `ALTER ANY DATABASE` permission.
 
 The DB_CHAINING option can't be set on the `master`, `model`, and `tempdb` system databases.
 

--- a/docs/t-sql/statements/alter-database-transact-sql-set-options.md
+++ b/docs/t-sql/statements/alter-database-transact-sql-set-options.md
@@ -804,7 +804,7 @@ Controls whether the database can be accessed by external resources, such as obj
 > [!IMPORTANT]  
 > The instance of [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] recognizes this setting when the cross db ownership chaining server option is 0 (OFF). When cross db ownership chaining is 1 (ON), all user databases can participate in cross-database ownership chains, regardless of the value of this option. This option is set by using [sp_configure](../../relational-databases/system-stored-procedures/sp-configure-transact-sql.md).
 
-To set this option, requires the server-level `ALTER ANY DATABASE` permission.
+This option requires `ALTER ANY DATABASE` permission.
 
 The DB_CHAINING option can't be set on the `master`, `model`, and `tempdb` system databases.
 


### PR DESCRIPTION
Changed the required permission for DB_CHAINING based on observation:

USE master
go
CREATE LOGIN alteranydb WITH PASSWORD = '))"?`?323Jdk' GRANT ALTER ANY DATABASE TO alteranydb
go
CREATE DATABASE chainer
ALTER AUTHORIZATION ON DATABASE::chainer TO sa
go
EXECUTE AS LOGIN = 'alteranydb'
go
ALTER DATABASE chainer SET DB_CHAINING ON
go
REVERT
go
DROP LOGIN alteranydb
DROP DATABASE chainer

Also modified the language as such. It sounds funny to talk about a server permission "on the database".