### PR TITLE
[DOC] Troubleshoot SQL Managed Instance management operations stuck after incident/failover

### DIFF
--- a/azure-sql/managed-instance/doc-changes-updates-known-issues.md
+++ b/azure-sql/managed-instance/doc-changes-updates-known-issues.md
@@ -1,0 +1,403 @@
+---
+title: Known Issues
+titleSuffix: Azure SQL Managed Instance
+description: Learn about the currently known issues with Azure SQL Managed Instance, and their possible workarounds or resolutions.
+author: MashaMSFT
+ms.author: mathoma
+ms.reviewer: randolphwest
+ms.date: 03/03/2026
+ms.service: azure-sql-managed-instance
+ms.subservice: service-overview
+ms.topic: troubleshooting-known-issue
+---
+# Known issues with Azure SQL Managed Instance
+
+[!INCLUDE [appliesto-sqlmi](../includes/appliesto-sqlmi.md)]
+
+This article lists the currently known issues with [Azure SQL Managed Instance](https://azure.microsoft.com/updates/?product=sql-database&query=sql%20managed%20instance), and their resolution date or possible workaround. To learn more about Azure SQL Managed Instance, see [What is Azure SQL Managed Instance?](sql-managed-instance-paas-overview.md), and [What's new in Azure SQL Managed Instance?](doc-changes-updates-release-notes-whats-new.md)
+
+[!INCLUDE [entra-id](../includes/entra-id.md)]
+
+## Known issues
+
+| Issue | Date discovered | Status | Date resolved |
+| --- | --- | --- | --- |
+| [Restore operation failures after migrating to SQL Managed Instance](#restore-operation-failures-after-migrating-to-sql-managed-instance) | March 2026 | Has workaround | |
+| [Management operations stuck after platform incident or failover](#management-operations-stuck-after-platform-incident-or-failover) | March 2026 | Has workaround | |
+| [Unable to use Service Broker after migrating to SQL Managed Instance](#unable-to-use-service-broker-after-migrating-to-sql-managed-instance) | March 2026 | Has workaround | |
+| [Unable to use accelerated database recovery after migrating to SQL Managed Instance](#unable-to-use-accelerated-database-recovery-after-migrating-to-sql-managed-instance) | March 2026 | Has workaround | |
+| [Misleading error message when connecting to a read replica using invalid credentials](#misleading-error-message-when-connecting-to-a-read-replica-using-invalid-credentials) | February 2026 |No resolution| |
+| [Modifying backup retention period for the free offer](#modifying-backup-retention-period-for-the-free-offer) | June 2025 | Has workaround | |
+| [Error 1412 when creating a Managed Instance link](#error-1412-when-creating-a-managed-instance-link) | May 2025 | Has workaround | |
+| [Login to read-secondary failed due to long wait on "HADR_DATABASE_WAIT_FOR_TRANSITION_TO_VERSIONING"](#login-to-read-secondary-failed-due-to-long-wait-on-hadr_database_wait_for_transition_to_versioning) | April 2025 | Has workaround | |
+| [Interim guidance on 2024 time zone updates for Paraguay](#interim-guidance-on-2024-time-zone-updates-for-paraguay) | March 2025 | Resolved | February 2026 |
+| [Error 8992 when running DBCC CHECKDB on a SQL Server database that originated from SQL Managed Instance](#error-8992-when-running-dbcc-checkdb-on-a-sql-server-database-that-originated-from-sql-managed-instance) | March 2025 | Has workaround | |
+| [Differential backups aren't taken when an instance is linked to SQL Server](#differential-backups-arent-taken-when-an-instance-is-linked-to-sql-server) | Sept 2024 | By design | |
+| [List of long-term backups in Azure portal shows backup files for active and deleted databases with the same name](#list-of-long-term-backups-in-azure-portal-shows-backup-files-for-active-and-deleted-databases-with-the-same-name) | Mar 2024 | Has workaround | |
+| [Temporary instance inaccessibility using the failover group listener during scaling operation](#temporary-instance-inaccessibility-using-the-failover-group-listener-during-scaling-operation) | Jan 2024 | Resolved | April 2025 |
+| [The event_file target of the system_health event session isn't accessible](#the-event_file-target-of-the-system_health-event-session-isnt-accessible) | Dec 2023 | Partially resolved | May 2025 |
+| [Procedure sp_send_dbmail might fail when @query parameter is used](#procedure-sp_send_dbmail-might-fail-when-query-parameter-is-used) | Dec 2023 | Has workaround | |
+| [Increased number of system logins used for transactional replication](#increased-number-of-system-logins-used-for-transactional-replication) | Dec 2022 | No resolution | |
+| [msdb table for manual backups doesn't preserve the username](#msdb-table-for-manual-backups-doesnt-preserve-the-username) | Nov 2022 | Resolved | Aug 2023 |
+| [When you use SQL Server authentication, usernames with '@' aren't supported](#when-you-use-sql-server-authentication-usernames-with-at-sign-arent-supported) | Oct 2021 | Resolved | Feb 2022 |
+| [Misleading error message on Azure portal suggesting recreation of the Service Principal](#misleading-error-message-on-azure-portal-suggesting-recreation-of-the-service-principal) | Sep 2021 | | Oct 2021 |
+| [Changing the connection type doesn't affect connections through the failover group endpoint](#changing-the-connection-type-doesnt-affect-connections-through-the-failover-group-endpoint) | Jan 2021 | Resolved | Nov 2025 |
+| [Distributed transactions can be executed after removing SQL managed instance from Server Trust Group](#distributed-transactions-can-be-executed-after-removing-sql-managed-instance-from-server-trust-group) | Oct 2020 | Has workaround | |
+| [Can't create SQL Managed Instance with the same name as logical server previously deleted](#cant-create-sql-managed-instance-with-the-same-name-as-logical-server-previously-deleted) | Aug 2020 | Has workaround | |
+| [Service Principal can't access Microsoft Entra ID and AKV](#service-principal-cant-access-azure-ad-and-akv) | Aug 2020 | Has workaround | |
+| [Restoring manual backup without CHECKSUM might fail](#restoring-manual-backup-without-checksum-might-fail) | May 2020 | Resolved | June 2020 |
+| [Permissions on resource group not applied to SQL Managed Instance](#permissions-on-resource-group-not-applied-to-sql-managed-instance) | Feb 2020 | Resolved | Nov 2020 |
+| [Microsoft Entra logins and users aren't supported in SSDT](#azure-ad-logins-and-users-arent-supported-in-ssdt) | Nov 2019 | No Workaround | |
+| [Wrong error returned while trying to remove a file that isn't empty](#wrong-error-returned-while-trying-to-remove-a-file-that-isnt-empty) | Oct 2019 | Resolved | August 2020 |
+| [Change service tier and create instance operations are blocked by ongoing database restore](#change-service-tier-and-create-instance-operations-are-blocked-by-ongoing-database-restore) | Sep 2019 | Has workaround | |
+| [Resource Governor on a readable secondary replica needs reconfiguration after failover](#resource-governor-on-a-readable-secondary-replica-needs-reconfiguration-after-failover) | Sep 2019 | Has workaround | |
+| [Cross-database Service Broker dialogs need reinitialization after service tier upgrade](#cross-database-service-broker-dialogs-need-reinitialization-after-service-tier-upgrade) | Aug 2019 | Resolved | January 2020 |
+| [Impersonation of Microsoft Entra login types isn't supported](#impersonation-of-azure-ad-login-types-isnt-supported) | Jul 2019 | No Workaround | |
+| [Transactional replication must be reconfigured after geo-failover](#transactional-replication-must-be-reconfigured-after-geo-failover) | Mar 2019 | No Workaround | |
+| [Exceeding storage space with small database files](#exceeding-storage-space-with-small-database-files) | | Has workaround | |
+| [GUID values shown instead of database names](#guid-values-shown-instead-of-database-names) | | Has workaround | |
+| [Error logs aren't persisted](#error-logs-arent-persisted) | | No Workaround | |
+| [CLR modules and linked servers sometimes can't reference a local IP address](#clr-modules-and-linked-servers-sometimes-cant-reference-a-local-ip-address) | | Has workaround | |
+| Database consistency not verified using `DBCC CHECKDB` after restore database from Azure Blob Storage. | | Resolved | Nov 2019 |
+| Point-in-time database restore from Business Critical tier to General Purpose tier doesn't succeed if source database contains in-memory OLTP objects. | | Resolved | Oct 2019 |
+| Database mail feature with external (non-Azure) mail servers using secure connection | | Resolved | Oct 2019 |
+| Contained databases not supported in SQL Managed Instance | | Resolved | Aug 2019 |
+
+## Has workaround
+
+[!INCLUDE [known-issues-after-migration](../includes/sql-managed-instance/known-issues-after-migration.md)]
+
+### Management operations stuck after platform incident or failover
+
+After an Azure incident, planned maintenance, or [user-initiated failover](user-initiated-failover.md), a small number of [management operations](management-operations-overview.md) on Azure SQL Managed Instance can remain in states such as **Provisioning**, **Starting**, **Updating**, **WaitingForManagedServerActivation**, **WaitingForOperationToComplete**, **CreatingPhysicalDatabase**, **ReadyForCreationKickOff**, or **NoComputeAvailable** longer than the [expected operation duration](management-operations-duration.md).
+
+**Symptoms:**
+
+- A create, start, scale, service-tier change, hardware change, or maintenance window change operation is running significantly longer than expected.
+- The portal **Overview** page or the resource group **Activity log** shows the same operation state for an extended period with no progress.
+- The condition started during or shortly after an Azure incident, planned maintenance, or failover affecting your region.
+
+**What to check first:**
+
+- Open **Azure Service Health** in the portal and look for active or recent incidents impacting Azure SQL Managed Instance in your region. If an incident is active, follow the incident communication - most operations resume automatically after platform recovery.
+- Verify your subnet, NSG, route tables, and DNS still meet [networking requirements](connectivity-architecture-overview.md).
+- Compare elapsed time to the [expected operation duration](management-operations-duration.md). Operations within the expected range aren't stuck - wait.
+- Check the **Activity log** for the resource group and capture the **operation ID** and **correlation ID**.
+
+**Recovery expectations:**
+
+- After an incident or failover, queued and in-progress operations typically resume automatically once the platform recovers.
+- New virtual cluster builds, large database seeding, and Business Critical service tier operations can extend operation durations to several hours.
+- Don't repeatedly retry, toggle stop/start, or initiate additional operations on the same instance - these actions can extend recovery and complicate diagnosis.
+
+**Workaround / escalation path:**
+
+- Wait for the published incident communication to indicate recovery, then re-evaluate.
+- If the operation has run beyond the expected duration, no incident is reported, and your configuration is valid, open a support request with severity matching your business impact. Provide the operation ID, correlation ID, timestamps, and instance configuration.
+
+For complete state-by-state guidance, expected timeframes, safe customer actions, and FAQ, see [Troubleshoot management operations stuck in provisioning/starting/updating states](troubleshoot-management-operations-stuck.md).
+
+
+### Modifying backup retention period for the free offer
+
+You can only modify the backup retention policy of your databases in the free SQL managed instance by using [REST API](/rest/api/sql/managed-backup-short-term-retention-policies), [PowerShell](/powershell/module/az.sql/set-azsqlinstancedatabasebackupshorttermretentionpolicy), and [Azure CLI](/cli/azure/sql/midb/short-term-retention-policy) commands. You can't modify the backup retention policy through the [Azure portal](https://portal.azure.com).
+
+### Login to read-secondary failed due to long wait on "HADR_DATABASE_WAIT_FOR_TRANSITION_TO_VERSIONING"
+
+You might see this error as an exception for the **Microsoft OLE DB Driver 19 for SQL Server** driver when you try to connect to a read-only secondary replica of a [failover group](failover-group-sql-mi.md), or a database replicated through the [Managed Instance link](managed-instance-link-feature-overview.md).
+
+This error occurs when the secondary replica isn't available for logins because row versions are missing for transactions that were in-flight when a secondary replica restarted or recycled, whether for maintenance or due to a failover. When an instance restarts or fails over, the versioning data stored in `tempdb` is cleared. Secondary read queries are aborted if there are long-running active transactions that started before the failover or restart.
+
+To resolve this issue, roll back or commit active transactions on the primary replica. To avoid this error, minimize long-running write transactions on the primary replica.
+
+
+### Error 8992 when running DBCC CHECKDB on a SQL Server database that originated from SQL Managed Instance
+
+You might see the following error when you run the `DBCC CHECKDB` command on a SQL Server 2022 database after you delete an index, or a table with an index, and the database originated from Azure SQL Managed Instance, such as after restoring a backup file, or from the [SQL Managed Instance link feature](managed-instance-link-feature-overview.md):
+
+```output
+Msg 8992, Level 16, State 1, Line <Line_Number>
+Check Catalog Msg 3853, State 1: Attribute (%ls) of row (%ls) in sys.sysrowsetrefs does not have a matching row (%ls) in sys.indexes.
+```
+
+To work around the issue, first drop the index, or the table with the index, from the source database in Azure SQL Managed Instance, and then restore, or link, the database to SQL Server 2022 again. If recreating the database from the source Azure SQL Managed Instance isn't possible, contact Microsoft support to help resolve this issue.
+
+> [!CAUTION]  
+> If you create a partitioned index on a table after dropping an index as described in this scenario, the table becomes inaccessible.
+
+### Error 1412 when creating a Managed Instance link
+
+When you first create a [link](managed-instance-link-feature-overview.md), the first part of the process seeds a full backup of the database from the primary replica to the secondary replica. After seeding of the full backup completes, the link starts to replicate data by applying the differential data from the primary replica to the secondary replica. This process continues indefinitely until a failover command is issued, or the link is removed.
+
+If a transaction log backup occurs on the primary replica during initial seeding of the full backup, the transaction log truncates. Creating the link fails with error 1412 since the data in the transaction log necessary for initial seeding is no longer available.
+
+If you see error 1412 in the SQL Server error log on Azure SQL Managed Instance, then you must [drop](managed-instance-link-configure-how-to-ssms.md#drop-a-link) and recreate the link. To preemptively avoid this issue, pause transaction log backups during the initial seeding phase. If transaction log backups are necessary during the initial seeding phase, then begin an open transaction to prevent log truncation. For more information, review [Error 1412 when creating a Managed Instance link](managed-instance-link-troubleshoot-how-to.md#error-1412) in the troubleshooting guide for the link feature.
+
+### List of long-term backups in Azure portal shows backup files for active and deleted databases with the same name
+
+Long-term backups can be listed and managed on Azure portal page for an Azure SQL Managed Instance on the *Backups* tab. The page lists active or deleted databases, basic information about their long-term backups, and link for managing backups. When you select the *Manage* link, a new side pane opens with list of backups. Due to an issue with the filtering logic, the list shows backups for both active database and deleted databases with the same name. This requires a special attention when selecting backups for deletion, to avoid deleting backups for a wrong database.
+
+**Workaround**: Use displayed *Backup time (UTC)* information in the list to differentiate backups belonging to databases with the same name that existed on the instance at different periods. Alternatively, use PowerShell commands [Get-AzSqlInstanceDatabaseLongTermRetentionBackup](/powershell/module/az.sql/get-azsqlinstancedatabaselongtermretentionbackup) and [Remove-AzSqlInstanceDatabaseLongTermRetentionBackup](/powershell/module/az.sql/remove-azsqlinstancedatabaselongtermretentionbackup), or CLI commands [az sql midb ltr-backup list](/cli/azure/sql/midb/ltr-backup?view=azure-cli-latest&preserve-view=true#az-sql-midb-ltr-backup-list) and [az sql midb ltr-backup delete](/cli/azure/sql/midb/ltr-backup?view=azure-cli-latest&preserve-view=true#az-sql-midb-ltr-backup-delete) to manage long-term backups using the *DatabaseState* parameter and *DatabaseDeletionTime* return value to filter backups for a database.
+
+<a id="procedure-sp_send_dbmail-may-fail-when-query-parameter-is-used-on-nov22fw-enabled-managed-instances"></a>
+
+### Procedure sp_send_dbmail might fail when *@query* parameter is used
+
+The `sp_send_dbmail` stored procedure might fail when the `@query` parameter is used. Failures happen when the stored procedure is executed under a **sysadmin** account.
+
+This problem is caused by a known bug related to how `sp_send_dbmail` uses impersonation.
+
+**Workaround**: Make sure you call `sp_send_dbmail` under an appropriate custom account you create, and not under a **sysadmin** account.
+
+Here's an example of how you can create a dedicated account and modify existing objects that send email via `sp_send_dbmail`.
+
+```sql
+USE [msdb];
+GO
+
+-- Step 1: Create a user mapped to a login to specify as a runtime user.
+CREATE USER [user_name] FOR LOGIN [login_name];
+GO
+
+EXECUTE msdb.dbo.sp_update_jobstep
+    @job_name = N'db_mail_sending_job',
+    @step_id = db_mail_sending_job_id,
+    @database_user_name = N'user_name';
+GO
+
+-- Step 2: Grant DB Mail permissions to the user who created it.
+ALTER ROLE [DatabaseMailUserRole] ADD MEMBER [user_name];
+GO
+
+-- Step 3: If the database of the job step is not msdb, the permission error cannot be avoided even if it is a member of the role, so set it to msdb.
+EXECUTE msdb.dbo.sp_update_jobstep
+    @job_name = N'db_mail_sending_job',
+    @step_id = db_mail_sending_job_id,
+    @database_name = N'msdb';
+GO
+
+-- Step 4: Set a principal in the email profile
+EXECUTE msdb.dbo.sysmail_add_principalprofile_sp
+    @principal_name = N'user_name',
+    @profile_name = N'profile_name',
+    @is_default = 0;
+GO
+```
+
+<a id="procedure-sp_send_dbmail-may-transiently-fail-when-query-parameter-is-used"></a>
+
+### Distributed transactions can be executed after removing SQL managed instance from Server Trust Group
+
+[Server Trust Groups](server-trust-group-overview.md) are used to establish trust between managed instances that is prerequisite for executing [distributed transactions](../database/elastic-transactions-overview.md). After removing the SQL managed instance from Server Trust Group or deleting the group, you might still be able to execute distributed transactions. To make sure that distributed transactions are disabled, perform a [user-initiated manual failover](user-initiated-failover.md) on the SQL managed instance.
+
+### Can't create SQL Managed Instance with the same name as logical server previously deleted
+
+When you create a [logical server in Azure](../database/logical-servers.md) for Azure SQL Database or a SQL Managed Instance, the system creates a DNS record for `<name>.database.windows.com`. This DNS record must be unique. If you create a logical server for SQL Database and then delete it, the name remains reserved for seven days. During this period, you can't create a SQL Managed Instance with the same name as the deleted logical server. As a workaround, use a different name for the SQL Managed Instance, or create a support ticket to release the logical server name.
+
+<a id="service-principal-cant-access-azure-ad-and-akv"></a>
+
+### Service Principal can't access Microsoft Entra ID and AKV
+
+In some circumstances, an issue exists with the Service Principal used to access Microsoft Entra ID ([formerly Azure Active Directory](/entra/fundamentals/new-name)) and Azure Key Vault (AKV) services. As a result, this issue impacts usage of Microsoft Entra authentication and transparent data encryption (TDE) with SQL Managed Instance. You might experience this problem as an intermittent connectivity issue, or not being able to run statements such are `CREATE LOGIN/USER FROM EXTERNAL PROVIDER` or `EXECUTE AS LOGIN/USER`. Setting up TDE with customer-managed key on a new Azure SQL Managed Instance might also not work in some circumstances.
+
+**Workaround**: To prevent this issue from occurring on your SQL Managed Instance, before executing any update commands, or in case you already experienced this issue after update commands, go to the **Overview page** of your SQL managed instance in the Azure portal. Under **Settings**, select **Microsoft Entra ID** to access the SQL Managed Instance [Microsoft Entra ID admin page](../database/authentication-aad-configure.md#azure-sql-managed-instance). Look for the following error message:
+
+```output
+Managed Instance needs a Service Principal to access Microsoft Entra ID. Click here to create a Service Principal.
+```
+
+If you encounter this error message, select it, and follow the step-by-step instructions provided until this error is resolved.
+
+### Wrong error returned while trying to remove a file that isn't empty
+
+SQL Server and SQL Managed Instance [don't allow a user to drop a file that isn't empty](/sql/relational-databases/databases/delete-data-or-log-files-from-a-database#Prerequisites). If you try to remove a nonempty data file by using an `ALTER DATABASE REMOVE FILE` statement, the error:
+
+```output
+Msg 5042 - The file '<file_name>' cannot be removed because it is not empty` isn't immediately returned. SQL Managed Instance keeps trying to drop the file, and the operation fails after 30 minutes with `Internal server error.
+```
+
+### Change service tier and create instance operations are blocked by ongoing database restore
+
+An ongoing `RESTORE` statement, a Data Migration Service migration process, and built-in point-in-time restore can block updates to a service tier, or resizing the existing instance and creating new instances, until the restore process finishes.
+
+The restore process blocks these operations on the managed instances and instance pools in the same subnet where the restore process is running. The instances in instance pools aren't affected. Create or change service tier operations don't fail or time out. They proceed once the restore process is completed or canceled.
+
+**Workaround**: Wait until the restore process finishes, or cancel the restore process if the creation or update-service-tier operation has higher priority.
+
+<a id="resource-governor-on-a-readable-secondary-replica-needs-to-be-reconfigured-after-its-failover"></a>
+
+### Resource Governor on a readable secondary replica needs reconfiguration after failover
+
+The [Resource governor](/sql/relational-databases/resource-governor/resource-governor) feature that enables you to limit the resources assigned to the user workload might incorrectly classify some user workloads after failover or a user-initiated change of service tier (for example, the change of max vCore or max instance storage size).
+
+**Workaround**: Run `ALTER RESOURCE GOVERNOR RECONFIGURE` periodically or as part of a SQL Agent job that executes the SQL task when the readable secondary replica starts if you're using [Resource governor](/sql/relational-databases/resource-governor/resource-governor).
+
+<a id="cross-database-service-broker-dialogs-must-be-reinitialized-after-service-tier-upgrade"></a>
+
+### Exceeding storage space with small database files
+
+`CREATE DATABASE`, `ALTER DATABASE ADD FILE`, and `RESTORE DATABASE` statements might fail because the instance reaches the Azure Storage limit on the General Purpose service tier, but not the [Next-gen General Purpose service tier upgrade](service-tiers-next-gen-general-purpose-use.md) or Business Critical service tier.
+
+Each General Purpose instance of SQL Managed Instance has up to 35 TB of storage reserved for Azure Premium Disk space. Each database file is placed on a separate physical disk. Disk sizes can be 128 GB, 256 GB, 512 GB, 1 TB, or 4 TB. You aren't charged for unused space on the disk, but the total sum of Azure Premium Disk sizes can't exceed 35 TB. In some cases, a SQL managed instance that doesn't need 8 TB in total might exceed the 35 TB Azure limit on storage size due to internal fragmentation.
+
+For example, a General Purpose instance of SQL Managed Instance might have one large file that's 1.2 TB in size placed on a 4-TB disk. It also might have 248 files that are 1 GB each and that are placed on separate 128-GB disks. In this example:
+
+- The total allocated disk storage size is 1 x 4 TB + 248 x 128 GB = 35 TB.
+- The total reserved space for databases on the instance is 1 x 1.2 TB + 248 x 1 GB = 1.4 TB.
+
+This example illustrates that under certain circumstances, due to a specific distribution of files, an instance of SQL Managed Instance might reach the 35-TB limit that's reserved for an attached Azure Premium Disk, when you might not expect it.
+
+In this example, existing databases continue to work and can grow without any problem as long as new files aren't added. You can't create or restore new databases because there isn't enough space for new disk drives, even if the total size of all databases doesn't reach the instance size limit. The error that's returned isn't clear.
+
+You can [identify the number of remaining files](https://medium.com/azure-sqldb-managed-instance/how-many-files-you-can-create-in-general-purpose-azure-sql-managed-instance-e1c7c32886c1) by using system views. If you reach this limit, try to [empty and delete some of the smaller files by using the DBCC SHRINKFILE statement](/sql/t-sql/database-console-commands/dbcc-shrinkfile-transact-sql?view=azuresqlmi-current&preserve-view=true#d-emptying-a-file) or switch to the [Business Critical tier, which doesn't have this limit](resource-limits.md#service-tier-characteristics).
+
+### GUID values shown instead of database names
+
+Several system views, performance counters, error messages, XEvents, and error log entries display GUID database identifiers instead of the actual database names. Don't rely on these GUID identifiers because they might be replaced with actual database names in the future.
+
+**Workaround**: Use `sys.databases` view to resolve the actual database name from the physical database name, specified in the form of GUID database identifiers:
+
+```sql
+SELECT name AS ActualDatabaseName,
+       physical_database_name AS GUIDDatabaseIdentifier
+FROM sys.databases
+WHERE database_id > 4;
+```
+
+### CLR modules and linked servers sometimes can't reference a local IP address
+
+CLR modules in SQL Managed Instance and linked servers or distributed queries that reference a current instance sometimes can't resolve the IP of a local instance. This error is a transient issue.
+
+## No resolution
+
+### Misleading error message when connecting to a read replica using invalid credentials
+
+When you attempt to connect to a Business Critical tier instance's read-secondary replica by using `ApplicationIntent=ReadOnly` and invalid credentials, the instance reports an error indicating that the `master` database is read-only. The instance doesn't correctly report that the credentials are invalid.
+
+### Differential backups aren't taken when an instance is linked to SQL Server
+
+When you configure a [link](managed-instance-link-feature-overview.md) between SQL Server and Azure SQL Managed Instance, automated full and transaction log backups are taken on the SQL managed instance, whether or not it's in the primary role. However, differential backups aren't currently taken, when can lead to longer than expected restore times.
+
+### Increased number of system logins used for transactional replication
+
+Azure SQL Managed Instance service creates a system login for purposes of transactional replication. You can find this login in SSMS (in **Object Explorer** > **Security** > **Logins**) or in the `sys.syslogins` system view. The login name format looks like `DBxCy\WF-abcde01234QWERT`, and the login has the **public** server role. Under certain conditions, this login is recreated, and due to an internal issue, the previous login isn't deleted. This fault can lead to an increase in the number of logins. These logins don't represent a security threat, and you can safely ignore them. Don't delete these logins, because at least one of them is being used for transactional replication.
+
+<a id="azure-ad-logins-and-users-arent-supported-in-ssdt"></a>
+
+### Microsoft Entra logins and users aren't supported in SSDT
+
+SQL Server Data Tools don't fully support Microsoft Entra logins and users.
+
+<a id="impersonation-of-azure-ad-login-types-isnt-supported"></a>
+
+### Impersonation of Microsoft Entra login types isn't supported
+
+Impersonation using `EXECUTE AS USER` or `EXECUTE AS LOGIN` isn't supported for the following Microsoft Entra principals:
+
+- Aliased Microsoft Entra users. In this case, the operation returns error `15517`.
+- Microsoft Entra logins and users based on Microsoft Entra applications or service principals. In this case, the operation returns errors `15517` and `15406`.
+
+### Transactional replication must be reconfigured after geo-failover
+
+If you enable transactional replication on a database in a failover group, the SQL Managed Instance administrator must clean up all publications on the old primary and reconfigure them on the new primary after a failover to another region occurs. For more information, see [Replication](transact-sql-tsql-differences-sql-server.md#replication).
+
+### Error logs aren't persisted
+
+Error logs that are available in SQL Managed Instance aren't persisted, and their size isn't included in the maximum storage limit. Error logs might be automatically erased if failover occurs. Gaps might exist in the error log history because SQL Managed Instance was moved several times on several virtual machines.
+
+## Resolved
+
+### Interim guidance on 2024 time zone updates for Paraguay
+
+**(Resolved in February 2026)**
+
+On October 14, 2024, the Paraguayan government announced a permanent change to the time zone policy. Paraguay now remains on Daylight Saving Time (DST) year-round, effectively adopting UTC-3 as its standard time. As a result, clocks did not advance by 60 minutes at 12:00 a.m. on March 23, 2025, as previously scheduled. This change affects the Paraguay Standard time zone. Microsoft has released related [Windows updates in February and March 2025](https://techcommunity.microsoft.com/blog/dstblog/paraguay-2025-time-zone-update-now-available/4386720). SQL managed instances using the affected time zone reflect this change, and align to the new UTC-3 offset.
+
+### Changing the connection type doesn't affect connections through the failover group endpoint
+
+**(Resolved in November 2025)**
+
+If an instance participates in a [failover group](failover-group-sql-mi.md), changing the instance's [connection type](connection-types-overview.md) doesn't take effect for the connections established through the failover group listener endpoint.
+
+### Temporary instance inaccessibility using the failover group listener during scaling operation
+
+**(Resolved in April 2025)**
+
+Scaling SQL managed instance sometimes requires moving the instance to a different virtual cluster, along with the associated service-maintained DNS records. If the SQL managed instance participates in a failover group, the DNS record corresponding to its associated failover group listener (read-write listener, if the instance is the current geo-primary read-only listener, if the instance is the current geo-secondary) is moved to the new virtual cluster.
+
+In the current scaling operation design, the listener DNS records are removed from the originating virtual cluster before it fully migrates the SQL managed instance to the new virtual cluster. In some situations, this design leads to prolonged time during which the instance's IP address can't be resolved by using the listener. During this time, a SQL client attempting to access the instance being scaled by using the listener endpoint can expect login failures with the following error message:
+
+```output
+Error 40532: Cannot open server "xxx.xxx.xxx.xxx" requested by the login. The login failed. (Microsoft SQL Server, Error: 40532).
+```
+
+The issue will be addressed through scaling operation redesign.
+
+<a id="msdb-table-for-manual-backups-doesnt-preserve-the-username"></a>
+
+### Table for manual backups in msdb doesn't preserve the username
+
+**(Resolved in August 2023)** The recently introduced support for auto backups in `msdb` doesn't currently contain username information.
+
+<a id="when-you-use-sql-server-authentication-usernames-with-at-sign-arent-supported"></a>
+<a id="when-using-sql-server-authentication-usernames-with--arent-supported"></a>
+
+### When you use SQL Server authentication, usernames with '@' aren't supported
+
+Usernames that contain the `@` symbol in the middle (for example, `abc@xy`) can't sign in using SQL Server authentication.
+
+### Restoring manual backup without CHECKSUM might fail
+
+**(Resolved in June 2020)** In certain circumstances, restoring manual backup of databases that you made on a SQL managed instance without `CHECKSUM` might fail. In such cases, retry restoring the backup until you're successful.
+
+**Workaround**: Take manual backups of databases on SQL managed instances with `CHECKSUM` enabled.
+
+### Permissions on resource group not applied to SQL Managed Instance
+
+When you apply the SQL Managed Instance Contributor Azure role to a resource group (RG), it doesn't apply to SQL Managed Instance and has no effect.
+
+**Workaround**: Set up a SQL Managed Instance Contributor role for users at the subscription level.
+
+<a id="query-parameter-not-supported-in-sp_send_db_mail"></a>
+
+### Misleading error message on Azure portal suggesting recreation of the Service Principal
+
+The **Active Directory admin** page of Azure portal for Azure SQL Managed Instance might show the following error message, even though Service Principal already exists:
+
+```output
+Managed Instance needs a Service Principal to access Microsoft Entra ID. Click here to create a Service Principal.
+```
+
+You can neglect this error message if Service Principal for the SQL managed instance already exists, and/or Microsoft Entra authentication on the SQL managed instance works.
+
+To check whether Service Principal exists, navigate to the **Enterprise applications** page on the Azure portal, choose **Managed Identities** from the **Application type** dropdown list, select **Apply**, and type the name of the SQL managed instance in the search box. If the instance name shows up in the result list, Service Principal already exists and no further actions are needed.
+
+If you already followed the instructions from the error message and selected the link, the Service Principal of the SQL managed instance is recreated. In that case, assign Microsoft Entra ID read permissions to the newly created Service Principal in order for Microsoft Entra authentication to work properly. You can also run this step with Azure PowerShell by following the [instructions](../database/authentication-aad-configure.md?tabs=azure-powershell#assign-microsoft-graph-permissions).
+
+<a id="the-event_file-target-of-the-system_health-event-session-is-not-accessible"></a>
+
+### The event_file target of the system_health event session isn't accessible
+
+**(Partially resolved in May 2025)** When you attempt to read the contents of the `event_file` target of the `system_health` event session, you get error 40538, "A valid URL beginning with `https://` is required as value for any filepath specified."
+
+Originally, this issue occurred in SQL Server Management Studio (SSMS), or when reading the session data using the [sys.fn_xe_file_target_read_file](/sql/relational-databases/system-functions/sys-fn-xe-file-target-read-file-transact-sql) function.
+
+In May 2025, this issue was resolved for reading session data from SSMS. The issue isn't resolved when reading event data by using the `sys.fn_xe_file_target_read_file` function.
+
+This change in behavior is an unintended consequence of a required security fix. You can work around this issue by creating your own equivalent of the `system_health` session with an `event_file` target in Azure Blob Storage. For more information, including a T-SQL script to create the `system_health` session that can be modified to create your own equivalent of `system_health`, see [Use the system_health session](/sql/relational-databases/extended-events/use-the-system-health-session).
+
+### Cross-database Service Broker dialogs need reinitialization after service tier upgrade
+
+**(Resolved in January 2020)** Cross-database Service Broker dialogs stop delivering the messages to the services in other databases after change service tier operation. The messages *aren't lost*, and they can be found in the sender queue. Any change of vCores or instance storage size in SQL Managed Instance causes a `service_broke_guid` value in [sys.databases](/sql/relational-databases/system-catalog-views/sys-databases-transact-sql) view to change for all databases. Any `DIALOG` created using a [BEGIN DIALOG](/sql/t-sql/statements/begin-dialog-conversation-transact-sql) statement that references Service Brokers in other databases stops delivering messages to the target service.
+
+**Workaround**: Stop any activity that uses cross-database Service Broker dialog conversations before updating a service tier, and reinitialize them afterward. If undelivered messages remain after a service tier change, read the messages from the source queue and resend them to the target queue.
+
+## Contribute to content
+
+To contribute to the Azure SQL documentation, see the [Docs contributor guide](/sql/sql-server/sql-server-docs-contribute).
+
+## Related content
+
+- For a list of SQL Managed Instance updates and improvements, see [SQL Managed Instance service updates](https://azure.microsoft.com/updates/?product=sql-database&query=sql%20managed%20instance).
+
+- For updates and improvements to all Azure services, see [Service updates](https://azure.microsoft.com/updates).

--- a/azure-sql/managed-instance/instance-stop-start-how-to.md
+++ b/azure-sql/managed-instance/instance-stop-start-how-to.md
@@ -1,0 +1,500 @@
+---
+title: Stop and Start an Instance
+description: This article describes how to use the stop and start feature of Azure SQL Managed Instance.
+author: urosmil
+ms.author: urmilano
+ms.reviewer: mathoma, randolphwest
+ms.date: 08/27/2025
+ms.service: azure-sql-managed-instance
+ms.subservice: deployment-configuration
+ms.topic: how-to
+ms.custom:
+  - ignite-2023
+  - devx-track-azurecli
+  - devx-track-azurepowershell
+  - sfi-image-nochange
+---
+
+# Stop and start an instance - Azure SQL Managed Instance
+
+[!INCLUDE [appliesto-sqlmi](../includes/appliesto-sqlmi.md)]
+
+This article describes how to stop and start an instance to save on billing costs when you're using [Azure SQL Managed Instance](sql-managed-instance-paas-overview.md)  in the General Purpose service tier. You can stop and start your instance by using the Azure portal, Azure PowerShell, Azure CLI, or REST API.
+
+> [!NOTE]  
+> The stop and start feature controls billing and shouldn't be used to [Restart the instance](user-initiated-failover.md) as a troubleshooting step.
+
+## Overview
+
+To save on billing costs, you can stop your General Purpose SQL managed instance when you're not using it. Stopping an instance is similar to deallocating a virtual machine. When an instance is in a stopped state, you're no longer billed for compute and licensing costs but still billed for data and backup storage.
+
+Stopping a SQL managed instance clears all cached data.
+
+This feature introduces three new SQL managed instance states, as the following diagram indicates:
+
+:::row:::
+    :::column:::
+        <br />
+        <br />
+        <br />- Stopping
+        <br />- Stopped
+        <br />- Starting
+    :::column-end:::
+    :::column:::
+        :::image type="content" source="media/instance-stop-start-how-to/sql-managed-instance-states.png" alt-text="Diagram that shows the various states of a SQL Managed Instance deployment." border="false":::
+    :::column-end:::
+:::row-end:::
+
+After the stop operation is initiated, it typically takes about 5 minutes to stop the instance. However, starting an instance takes about 20 minutes from the moment the start operation is initiated. Only SQL managed instances in a ready state can be stopped. After the instance is stopped, it stays in a stopped state until a start operation is initiated, either manually or triggered with a defined schedule. Only instances that are in a stopped state can be started.
+
+When the following operations occur, Azure allocates compute resources to the underlying virtual cluster:
+
+- Creating a SQL managed instance.
+- Starting a stopped SQL managed instance.
+- Resizing a SQL managed instance. For example, changing the service tier, storage, hardware generation, or number of vCores.
+
+While there's continual investment in more infrastructure to support customer demand, there might be occasional resource allocation failures from unprecedented growth of demand for Azure services in specific regions. This situation might result in a prolonged operation duration, approximately 4 hours if there's a new virtual cluster buildout (in accordance with [management operation durations](management-operations-overview.md)). It can also result in a failure to start the instance, in which case you should try again later.
+
+> [!IMPORTANT]  
+> As a platform as a service (PaaS) service, SQL Managed Instance is responsible for compliance for every part of the system components. If there's an urgent need for system maintenance, it requires the instance to be online. In this situation, Azure can initiate the start operation and keep the instance online until the maintenance operation completes, at which time Azure stops the instance. Compute and license charges are applied for the entire time the instance is in an online state.
+
+## Action types
+
+There are two ways to stop and start an instance: either manually on demand or by creating a schedule.
+
+### Manual commands
+
+You can use manual commands to immediately trigger a stop and start action. Manual commands are good for instances that have longer periods of inactivity without regular patterns, or for testing purposes. Alternatively, you can use [Azure Automation schedules](/azure/automation/shared-resources/schedules) or any custom solution that creates customized and more flexible schedules that you can't set up by using the built-in stop and start scheduler in SQL Managed Instance.
+
+### Scheduled commands
+
+You can also create a schedule with one or more multiple points of time when a stop or start action is triggered. Scheduled commands are good for instances that have regular patterns. For example, starting an instance every weekday at 8 AM, stopping it at 5 PM, and then starting it during the weekend at 7 AM and stopping it at 11 AM. Scheduling your commands eliminates the need for you to create custom solutions or to use Azure Automation to create stop and start schedules.
+
+Scheduled items represent points in time when stop and start events are initiated, not when the instance is up and running. When you're creating a schedule, take the operation duration into account. For example, if you want to have your instance up and running at 8 AM, you can define a schedule that initiates the start operation at 7:40 AM.
+
+Consider the following rules for a stop and start schedule:
+
+- Each scheduled item is defined as a stop-and-start pair, and it must have both stop and start values populated. It's not possible to have a populated stop value with a missing start value, and vice versa.
+- The scheduled pairs can't overlap. If there's an overlap of scheduled times, the API returns an error.
+- The time span between any two successive actions (that is, a start after a stop or a stop after a start) must be at least one hour. For example, if a start is scheduled for 10 AM, the stop action can't be scheduled before 11 AM.
+- If conflicting operations occur when a stop is triggered, such as a scaling vCore in progress, the mechanism retries after 10 minutes. If after 10 minutes the conflicting operation is still active, the stop operation is skipped.
+
+## Billing
+
+Stopped instances don't get billed for vCores and the SQL license, they're charged only for data and backup storage. However, vCores and license billing is charged for every *started* hour. For example, at 12:01, you're charged for the entire hour, even if the instance is stopped within the hour.
+
+### Azure Hybrid Benefit
+
+The [Azure Hybrid Benefit (AHB)](../azure-hybrid-benefit.md) is applied per resource. If your instance is using the Azure Hybrid Benefit for the discount on licensing costs, you can apply the Azure Hybrid Benefit to another resource when the instance is in a stopped state. You must first disable AHB on the instance, and then stop the instance. Similarly, after you restart the instance, you have to reenable AHB on it to apply the licensing benefit.
+
+### Reservation pricing
+
+[Azure Reservation](../database/reservations-discount-overview.md) is applied for the vCores and hours emitted. When an instance that's eligible for reserved pricing is stopped, reserved pricing is automatically redirected to another instance, if one exists. You can use the stop and start feature to _overprovision_ reserved instance pricing.
+
+For example, let's say that you purchase a SQL managed instance with a reservation for 16 vCores. You can run two instances with 8 vCores each from 1 PM to 2 PM, stop both instances, and then run two different instances with 8 vCores each from 2 PM to 3 PM. This approach would consume your 16 vCore limit for each hour, spread among four instances in total.
+
+Reservation discounts are offered on a ["use it or lose it"](/azure/cost-management-billing/reservations/understand-reservation-charges) basis. That is, if you don't have matching resources for a specified hour, the reservation quantity for that hour is lost. Unused reserved hours can't be carried forward.
+
+## Limitations of the stop and start feature
+
+Consider the following limitations:
+
+- Stop and start of an instance is currently only possible for instances in the General Purpose service tier.
+- You can't stop instances that:
+  - Have an ongoing [management operation](management-operations-overview.md) (such as an ongoing restore, vCore scaling, and so on)
+  - Are part of a [failover group](failover-group-sql-mi.md)
+  - Use the [Managed Instance link](managed-instance-link-feature-overview.md)
+  - have [zone redundancy enabled](high-availability-sla-local-zone-redundancy.md)
+  - are part of [Instance pool](instance-pools-overview.md)
+- While a SQL managed instance is in a stopped state, it's not possible to change its configuration properties. To change any properties, you must start the instance.
+- While the instance is in a stopped state, it's not possible to take backups. For example, let's say that you have [long-term backups](long-term-backup-retention-configure.md) configured, with yearly backups in place. If you stop the instance during the defined yearly backup period, the backup is skipped. We recommend that you keep the instance up and running during the yearly backup period.
+- It's not possible to cancel a stop or start operation once you initiate it.
+- If a vulnerability assessment scan is scheduled for SQL Managed Instance while the instance is stopped, the scan execution fails.
+- [Maintenance notifications](advance-notifications.md) aren't sent for instances that are in a stopped state. The result is:
+  - An incomplete sequence of notifications. For example, an *advanced notification* isn't sent, while an *in progress notification* is sent.
+  - SQL Managed Instance is missing from the list of affected resources in the notification content.
+- Error logs that are available in SQL Managed Instance [aren't persisted](doc-changes-updates-known-issues.md#error-logs-arent-persisted) and are automatically erased when the instance is stopped.
+
+## Prerequisites
+
+To use the instance stop and start feature, your instance must be in the General Purpose service tier. Users that have permission to manage the instance can stop and start the instance. To learn more, review [Azure permissions for Databases](/azure/role-based-access-control/permissions/databases#microsoftsql).
+
+Instances that don't meet the prerequisite have the stop and start controls disabled on the **Overview** page for the SQL managed instance resource in the Azure portal. Hovering over the control explains why the instance can't use the stop and start feature.
+
+## Prepare command line environment
+
+Skip this step if you're using the Azure portal.
+
+If you want to stop or start an instance by using PowerShell or the Azure CLI, you need to prepare your environment by configuring command line tools and defining your parameters.
+
+Alternatively to configuring your command line tools, you can also use the Azure Cloud Shell. A free interactive shell you can use to run the steps in this article. It has common preinstalled Azure tools and is configured to use with your account. [!INCLUDE [quickstarts-free-trial-note](../includes/quickstarts-free-trial-note.md)]
+
+To open the Cloud Shell, select **Try it** from the upper right corner of a code block. You can also launch Cloud Shell in a separate browser tab by going to <https://shell.azure.com>.
+
+### [PowerShell](#tab/azure-powershell-prep)
+
+To stop and start your instance with PowerShell, you can [install Azure PowerShell](/powershell/azure/install-az-ps), or use the Azure Cloud Shell.
+
+When Cloud Shell opens, verify that **PowerShell** is selected for your environment. Subsequent sessions use Azure CLI in a PowerShell environment. Select **Copy** to copy the blocks of code, paste it into the Cloud Shell, and press **Enter** to run it.
+
+Once PowerShell or Cloud Shell is launched, define the parameters:
+
+```powershell-interactive
+$SubscriptionId = "<Subscription-ID>"
+$SqlMIName = "<SQL-MI-name>"
+$RgName = "<SQL-MI-resource-group>"
+
+# Login-AzAccount
+Select-AzSubscription -SubscriptionName $SubscriptionID
+```
+
+### [Azure CLI](#tab/azure-cli-prep)
+
+To stop and start your instance with the Azure CLI, you can [install Azure CLI](/cli/azure/install-azure-cli), or use the Azure Cloud Shell.
+
+When Cloud Shell opens, verify that **Bash** is selected for your environment. Subsequent sessions use Azure CLI in a Bash environment. Select **Copy** to copy the blocks of code, paste it into the Cloud Shell, and press **Enter** to run it.
+
+Cloud Shell is automatically authenticated under the initial account signed-in with. Use the following script to sign in using a different subscription, replacing `<Subscription ID>` with your Azure Subscription ID.
+
+```azurecli-interactive
+subscription="<Subscription-ID>"
+instanceName="<SQL-MI-name>"
+resourceGroupName="<SQL-MI-resource-group>"
+
+az account set -s $subscription # ...or use 'az login'
+```
+
+For more information, see [set active subscription](/cli/azure/account#az-account-set) or [log in interactively](/cli/azure/reference-index#az-login).
+
+---
+
+## Stop the SQL managed instance
+
+You can stop the instance by using:
+
+- Azure portal
+- PowerShell
+- The Azure CLI
+- The REST API call, invoked through any tool
+
+### [Portal](#tab/azure-portal)
+
+To stop your SQL managed instance by using the [Azure portal](https://portal.azure.com), go to the **Overview** page of your instance, and then select the **Stop** button.
+
+:::image type="content" source="media/instance-stop-start-how-to/manual-instance-stop.png" alt-text="Screenshot of the SQL managed instance 'Overview' page in the Azure portal, with the 'Stop' button highlighted. ":::
+
+If your instance is already stopped, the **Stop** button is unavailable.
+
+### [PowerShell](#tab/azure-powershell)
+
+To stop your SQL managed instance with PowerShell, use [Stop-AzSqlInstance](/powershell/module/az.sql/stop-azsqlinstance), such as the following sample script:
+
+```powershell
+Stop-AzSqlInstance -Name $SqlMIName -ResourceGroupName $RgName
+```
+
+### [Azure CLI](#tab/azure-cli)
+
+To stop your SQL managed instance with the Azure CLI, use [az sql mi stop](/cli/azure/sql/mi#az-sql-mi-stop), such as the following sample script:
+
+```azurecli
+az sql mi stop --mi $instanceName -g $resourceGroupName
+```
+
+### [REST API](#tab/API)
+
+Stop the SQL managed instance by calling the [Managed Instances - Stop](/rest/api/sql/managed-instances/stop) API:
+
+```http
+POST
+https://management.azure.com/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/
+providers/Microsoft.Sql/managedInstances/{managedInstanceName}/stop?api-version=2021-08-01-preview
+```
+
+---
+
+## Start the SQL managed instance
+
+You can start the instance by using:
+
+- Azure portal
+- PowerShell
+- The Azure CLI
+- The REST API call, invoked through any tool
+
+### [Portal](#tab/azure-portal)
+
+After your SQL managed instance is stopped, to start it by using the [Azure portal](https://portal.azure.com), go to the **Overview** page of your instance, and then select the **Start** button.
+
+:::image type="content" source="media/instance-stop-start-how-to/manual-instance-start.png" alt-text="Screenshot of the SQL managed instance 'Overview' page in the Azure portal, with the 'Start' button highlighted. ":::
+
+If your instance is already started, the **Start** button is unavailable.
+
+### [PowerShell](#tab/azure-powershell)
+
+To start your SQL managed instance with PowerShell, use [Start-AzSqlInstance](/powershell/module/az.sql/start-azsqlinstance), such as the following sample script:
+
+```powershell
+Start-AzSqlInstance -Name $SqlMIName -ResourceGroupName $RgName
+```
+
+### [Azure CLI](#tab/azure-cli)
+
+To start your SQL managed instance with the Azure CLI, use [az sql mi start](/cli/azure/sql/mi#az-sql-mi-start), such as the following sample script:
+
+```azurecli
+az sql mi start --mi $instanceName -g $resourceGroupName
+```
+
+### [REST API](#tab/API)
+
+Start the SQL managed instance by calling the [Managed Instances - Start](/rest/api/sql/managed-instances/start) API:
+
+```http
+https://management.azure.com/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/
+providers/Microsoft.Sql/managedInstances/{managedInstanceName}/start?api-version=2021-08-01-preview
+```
+
+---
+
+## Manage a stop and start schedule
+
+You can manage a stop and start schedule by using:
+
+- Azure portal
+- PowerShell
+- The Azure CLI
+- The REST API call, invoked through any tool
+
+### [Portal](#tab/azure-portal)
+
+To manage a stop and start schedule by using the [Azure portal](https://portal.azure.com), go to your instance, and then select **Start/Stop Schedule** in the resource menu.
+
+:::image type="content" source="media/instance-stop-start-how-to/start-stop-schedule.png" alt-text="Screenshot of the 'Start/Stop schedule' page of the SQL managed instance." lightbox="media/instance-stop-start-how-to/start-stop-schedule.png":::
+
+On the **Start/Stop Schedule** pane, you can:
+
+- View existing schedules.
+- Specify the time zone of your scheduled events in the **Time zone** dropdown list.
+- Create a new schedule by selecting **Create a schedule item**.
+- Modify an existing schedule by selecting the pencil icon.
+- Delete an existing schedule by selecting the trash can icon.
+
+### [PowerShell](#tab/azure-powershell)
+
+#### Create schedule
+
+To create a schedule to stop and start a SQL managed instance with PowerShell, use [New-AzSqlInstanceStartStopSchedule](/powershell/module/az.sql/new-azsqlinstancestartstopschedule) and [New-AzSqlInstanceScheduleItem](/powershell/module/az.sql/new-azsqlinstancescheduleitem), such as the following sample script:
+
+```powershell
+$newSchedule = [System.Collections.ArrayList]::new()
+
+$newScheduleMonday = New-AzSqlInstanceScheduleItem -StartDay Monday -StopDay Monday -StartTime "09:00" -StopTime "17:00"
+$newSchedule.add($newScheduleMonday)
+
+$newScheduleTuesday = New-AzSqlInstanceScheduleItem -StartDay Tuesday -StopDay Tuesday -StartTime "09:00" -StopTime "17:00"
+$newSchedule.add($newScheduleTuesday)
+
+$newScheduleWednesday = New-AzSqlInstanceScheduleItem -StartDay Wednesday -StopDay Wednesday -StartTime "07:00" -StopTime "19:00"
+$newSchedule.add($newScheduleWednesday)
+
+$newScheduleThursday = New-AzSqlInstanceScheduleItem -StartDay Thursday -StopDay Thursday -StartTime "09:00" -StopTime "17:00"
+$newSchedule.add($newScheduleThursday)
+
+$newScheduleFriday = New-AzSqlInstanceScheduleItem -StartDay Friday -StopDay Friday -StartTime "11:00" -StopTime "17:00"
+$newSchedule.add($newScheduleFriday)
+
+New-AzSqlInstanceStartStopSchedule -InstanceName $SqlMIName -ResourceGroupName $RgName -TimeZone "Central Europe Standard Time" -ScheduleList $newSchedule
+```
+
+#### Check a schedule
+
+To check an existing schedule, use [Get-AzSqlInstanceStartStopSchedule](/powershell/module/az.sql/get-azsqlinstancestartstopschedule), such as the following sample script:
+
+```powershell
+$currentSchedule = Get-AzSqlInstanceStartStopSchedule -InstanceName $SqlMIName -ResourceGroupName $RgName
+$scheduleItemsList = $currentSchedule.ScheduleList
+$scheduleItemsList
+```
+
+#### Update schedule
+
+To update an existing schedule to stop and start a SQL managed instance, use [New-AzSqlInstanceStartStopSchedule](/powershell/module/az.sql/new-azsqlinstancestartstopschedule) and [New-AzSqlInstanceScheduleItem](/powershell/module/az.sql/new-azsqlinstancescheduleitem), such as the following sample script:
+
+```powershell
+$currentSchedule = Get-AzSqlInstanceStartStopSchedule -InstanceName $SqlMIName -ResourceGroupName $RgName
+$scheduleItemsList = $currentSchedule.ScheduleList
+
+# Remove Thursday item
+$scheduleItemsList = $scheduleItemsList | Where-Object { $_.StartDay -ne "Thursday" }
+
+# Adjust Friday item
+$fridaySchedule = $scheduleItemsList | Where-Object { $_.StartDay -eq "Friday" }
+$fridaySchedule.StartTime = "09:00"
+
+# Add new Thursday item
+$newScheduleThursday = New-AzSqlInstanceScheduleItem -StartDay Thursday -StopDay Thursday -StartTime "12:00" -StopTime "18:00"
+$scheduleItemsList += $newScheduleThursday
+
+# Update schedule with new configuration
+New-AzSqlInstanceStartStopSchedule -InstanceName $SqlMIName -ResourceGroupName $RgName -TimeZone "Central Europe Standard Time" -ScheduleList $scheduleItemsList
+```
+
+#### Delete a schedule
+
+To delete an existing schedule, use [Remove-AzSqlInstanceStartStopSchedule](/powershell/module/az.sql/remove-azsqlinstancestartstopschedule), such as the following sample script:
+
+```powershell
+Remove-AzSqlInstanceStartStopSchedule -InstanceName $SqlMIName -ResourceGroupName $RgName
+```
+
+### [Azure CLI](#tab/azure-cli)
+
+#### Create schedule
+
+To create a schedule to stop and start a SQL managed instance with the Azure CLI, use [az sql mi start-stop-schedule create](/cli/azure/sql/mi/start-stop-schedule#az-sql-mi-start-stop-schedule-create), such as the following sample script:
+
+```azurecli
+scheduleItems="[{'startDay':'Monday','startTime':'10:00','stopDay':'Monday','stopTime':'18:00'},{'startDay':'Tuesday','startTime':'10:00','stopDay':'Tuesday','stopTime':'18:00'},{'startDay':'Wednesday','startTime':'12:00','stopDay':'Wednesday','stopTime':'22:00'},{'startDay':'Thursday','startTime':'14:00','stopDay':'Thursday','stopTime':'20:00'},{'startDay':'Friday','startTime':'14:00','stopDay':'Friday','stopTime':'20:00'}]"
+
+timezone="Central Europe Standard Time"
+
+az sql mi start-stop-schedule create --mi "$instanceName" -g "$resourceGroupName" --timezone-id "$timezone" --schedule-list "$scheduleItems"
+```
+
+#### Check a schedule
+
+To check an existing schedule, use [az sql mi start-stop-schedule show](/cli/azure/sql/mi/start-stop-schedule#az-sql-mi-start-stop-schedule-show), such as the following sample script:
+
+```azurecli
+az sql mi start-stop-schedule show --mi "$instanceName" -g "$resourceGroupName"
+```
+
+#### Update schedule
+
+To update an existing schedule to stop and start a SQL managed instance, use [az sql mi start-stop-schedule update](/cli/azure/sql/mi/start-stop-schedule#az-sql-mi-start-stop-schedule-update), such as the following sample script:
+
+```azurecli
+# append an item
+newScheduleItem="{'startDay':'Friday','startTime':'09:00 PM','stopDay':'Friday','stopTime':'11:00 PM'}"
+az sql mi start-stop-schedule update --mi $instanceName -g $resourceGroupName --add schedule_list "$newScheduleItem"
+
+# remove an item
+#items in list are indexed (0 based)
+az sql mi start-stop-schedule update --mi $instanceName -g $resourceGroupName --remove schedule_list 2
+```
+
+#### Delete a schedule
+
+To delete an existing schedule, use [az sql mi start-stop-schedule delete](/cli/azure/sql/mi/start-stop-schedule#az-sql-mi-start-stop-schedule-delete), such as the following sample script:
+
+```azurecli
+az sql mi start-stop-schedule delete --mi "$instanceName" -g "$resourceGroupName"
+```
+
+### [REST API](#tab/API)
+
+#### Create or update schedule
+
+To create or update a schedule to stop and start a SQL managed instance call the [Start Stop Managed Instance Schedules - Create Or Update](/rest/api/sql/start-stop-managed-instance-schedules/create-or-update) API and adjust the body content to match your schedule:
+
+```http
+PUT https://management.azure.com/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/startStopSchedules/default?api-version=2022-08-01-preview
+
+{
+  "properties": {
+    "timeZoneId": "Central European Standard Time",
+    "description": "This is a schedule for our Dev/Test environment.",
+    "scheduleList": [
+      {
+        "startDay": "Monday",
+        "startTime": "07:30",
+        "stopDay": "Wednesday",
+        "stopTime": "17:00"
+      },
+      {
+        "startDay": "Thursday",
+        "startTime": "15:00",
+        "stopDay": "Friday",
+        "stopTime": "15:00"
+      }
+    ]
+  }
+}
+```
+
+#### Check a schedule
+
+To check an existing schedule, call the [Start Stop Managed Instance Schedules - Get](/rest/api/sql/start-stop-managed-instance-schedules/get) API:
+
+```http
+GET
+https://management.azure.com/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/
+providers/Microsoft.Sql/managedInstances/{managedInstanceName}/startStopSchedules/default?api-version=2022-08-01-preview
+```
+
+#### Delete a schedule
+
+To delete an existing schedule, call the [Start Stop Managed Instance Schedules - Delete](/rest/api/sql/start-stop-managed-instance-schedules/delete) API:
+
+```http
+DELETE
+https://management.azure.com/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/
+providers/Microsoft.Sql/managedInstances/{managedInstanceName}/startStopSchedules/default?api-version=2022-08-01-preview
+```
+
+---
+
+> [!NOTE]  
+> Currently, the Activity Log only captures operations initiated via Azure Resource Manager (ARM). The scheduled start and stop operations aren't tracked on the Activity Log. So, at this time, it isn't possible to view the history of the scheduled start and stop operations via the Activity Log in Azure portal. Or, via any monitoring that is based on such logs.
+
+## Troubleshooting
+
+If a stop or start operation appears stuck after an Azure incident, planned maintenance, or [user-initiated failover](user-initiated-failover.md), use the following guidance.
+
+### Common stuck states
+
+The portal **Overview** page or the resource group **Activity log** may show one of these states for an extended period:
+
+- **Starting** - The instance is starting from a stopped state, or restarting after a maintenance/failover event.
+- **Updating** - A reconfiguration step is in progress, often after a failover or post-incident recovery.
+- **WaitingForOperationToComplete** - A dependent backend step (such as activation or seeding) is still progressing.
+
+> [!NOTE]
+> Stop and start operations can't be cancelled after they're initiated. See [Limitations of the stop and start feature](#limitations-of-the-stop-and-start-feature).
+
+### Safe actions
+
+When a stop or start operation appears stuck:
+
+- **Wait** for at least the [expected duration](management-operations-duration.md). A start typically takes about 20 minutes; longer if a virtual cluster build is required.
+- **Check Azure Service Health** in the portal for active incidents impacting Azure SQL Managed Instance in your region. Most operations resume automatically after platform recovery.
+- **Check the Activity log** in the resource group and capture the **operation ID** and **correlation ID** for the stop or start operation.
+- **Avoid repeated toggles**. Don't repeatedly start, stop, or scale the instance while a prior operation is in progress - these actions can extend recovery and complicate diagnosis.
+- **Don't change the maintenance window, service tier, hardware, or other configuration** while a stop/start operation is unfinished.
+
+### When to contact support
+
+Open a support request with severity matching your business impact when:
+
+- The operation has exceeded the [expected duration](management-operations-duration.md) by a significant margin.
+- No Azure Service Health incident covers the symptom in your region.
+- The operation has remained in the same state for several hours with no progress in the Activity log.
+
+Provide these details to support:
+
+- **Subscription ID**, **resource group**, **managed instance name**, and **region**.
+- **Operation ID** and **correlation ID** from the Activity log.
+- **Operation type** (stop or start) and submission timestamp.
+- **Recent events**: any failover, maintenance, or scale operation in the last 24-48 hours.
+- **Instance configuration**: service tier, hardware, vCores, storage size, subnet, virtual network, maintenance window.
+
+For complete troubleshooting guidance across all management operations, see [Troubleshoot management operations stuck in provisioning/starting/updating states](troubleshoot-management-operations-stuck.md).
+
+## Related content
+
+- [What is Azure SQL Managed Instance?](sql-managed-instance-paas-overview.md)
+- [Connectivity architecture for Azure SQL Managed Instance](connectivity-architecture-overview.md)
+- [Configure an existing virtual network for Azure SQL Managed Instance](vnet-existing-add-subnet.md)
+- [Quickstart: Create Azure SQL Managed Instance](instance-create-quickstart.md)
+- [Resolve private domain names in Azure SQL Managed Instance](resolve-private-domain-names.md)

--- a/azure-sql/managed-instance/management-operations-overview.md
+++ b/azure-sql/managed-instance/management-operations-overview.md
@@ -1,0 +1,202 @@
+---
+title: Management Operations Overview
+titleSuffix: Azure SQL Managed Instance
+description: Learn about Azure SQL Managed Instance management operations.
+author: urosmil
+ms.author: urmilano
+ms.reviewer: mathoma, randolphwest
+ms.date: 06/18/2025
+ms.service: azure-sql-managed-instance
+ms.subservice: deployment-configuration
+ms.topic: overview
+ms.custom:
+  - ignite-2025
+---
+
+# Overview of management operations in Azure SQL Managed Instance
+[!INCLUDE [appliesto-sqldb-sqlmi](../includes/appliesto-sqlmi.md)]
+
+This article provides an overview of the different operations that occur when managing [Azure SQL Managed Instance](sql-managed-instance-paas-overview.md). Management operations are operations that are performed on the backend when you create, update, or delete an instance.
+
+For a detailed description of the steps and estimated duration of each management operation, review [Management operations duration](management-operations-duration.md).
+
+## What are management operations?
+
+Managing Azure SQL Managed Instance involves the following operations: 
+
+- **Create**: The operations that occur when you first create a new SQL managed instance. This includes creating the underlying virtual machine (VM) group, and deploying the SQL Database Engine process.
+- **Update**: Operations that occur when you change the properties of an existing SQL managed instance, such as scaling compute or storage, changing the service tier, or updating the instance configuration. Making updates often involves resizing the VM group, as well as seeding data, and then failing over, to a new SQL Database Engine process.
+- **Delete**: Operations that occur when you delete an existing SQL managed instance, including the cleanup of resources such as the VM group associated with the instance.
+
+For a detailed description of the steps and estimated duration of each management operation, review [Management operations duration](management-operations-duration.md).
+
+SQL Managed Instance management operations are accomplished through the following underlying processes:
+
+- [Virtual machine (VM) group operations](#vm-group-operations): Operations that involve creating and managing the underlying VM group that host the SQL managed instance. This includes resizing the VM group, creating new VM groups, and managing the virtual machines within those groups.
+- [Seeding](#seeding): The initialization and synchronization of data across SQL Database Engine processes, usually to prepare for a failover. 
+- [Failover](#failover): Operations involved in failing traffic over to another SQL Database Engine process, either in the same, or in a new VM group. 
+
+## VM group operations
+
+To support [deployments within Azure virtual networks](/azure/virtual-network/virtual-network-for-azure-services) and provide isolation and security for customers, SQL Managed Instance relies on [virtual clusters](virtual-cluster-architecture.md). The virtual cluster represents a dedicated set of isolated virtual machines (VMs) deployed inside your virtual network subnet and organized within *VM groups*. Essentially, every SQL managed instance deployed to an empty subnet results in a new virtual cluster which builds the very first VM group. 
+
+Subsequent management operations on SQL managed instances can affect the underlying [VM groups](virtual-cluster-architecture.md#role-in-management-operations). Changes that affect the underlying VM groups might affect the duration of management operations, as deploying more virtual machines to the virtual cluster comes with an overhead that you need to consider when you plan new deployments or updates to existing instances.
+
+For detailed information about the virtual cluster architecture, see [Virtual cluster architecture](virtual-cluster-architecture.md).
+
+## Seeding
+
+Seeding plays a critical role in the operation of Azure SQL Managed Instance, particularly during the setup and replication of databases. Seeding is the process that initializes and synchronizes data across SQL Database Engine processes, which is a crucial part of instance management. While often the most time-consuming step in lengthy but successful operations, seeding serves as a cornerstone to establishing a healthy and functional SQL managed instance environment. 
+
+For an estimated duration of seeding operations, see [Management operations duration](management-operations-duration.md#seeding-duration).
+
+The seeding process typically involves the following stages, regardless of the service tier: 
+- **Initialization**: The system identifies the source and destination database and starts a number of tasks that prepare the SQL Database Engine processes for data transfer.  
+- **Data Transfer**: Actual data packages are transferred from the source to the target SQL Database Engine process, which includes a full or partial copy of the database, depending on the scenario. 
+- **Synchronization**: Once initial data transfer completes, the system synchronizes any subsequent updates or changes through the replication of transaction log blocks to ensure data integrity. 
+- **Validation and finalization**: The process is finalized, and the target SQL Database Engine process is validated to confirm successful replication and seeding. Failover occurs so that traffic is routed to the new SQL Database Engine process. 
+
+There is no data seeding in the **General Purpose** service tier except when you change the service tier to the **Business Critical** service tier. Management operations in the **General Purpose** service tier involve detaching remote storage from the old SQL Database Engine process and attaching it to the new SQL Database Engine process.
+
+Conversely, the **Business Critical** service tier, designed for high-performance workloads, requires local storage and the codependency of compute and storage layers. Consequently, almost every operation and scenario in this service tier necessitates seeding to ensure data availability and consistency.
+
+Whether or not seeding is triggered depends on the particular scenario and service tier, such as: 
+
+- **General Purpose and [Next-gen General Purpose](service-tiers-next-gen-general-purpose-use.md)** service tiers:  
+   - *Changing to the Business Critical service tier* – data must be transferred from the remote storage to the local storage used in the General Purpose service tier.
+   - *Enabling or disabling [zone redundancy](high-availability-sla-local-zone-redundancy.md#high-availability-through-zone-redundancy)* – data must be copied to or from the zone redundant regions.
+- **Business Critical** service tier: 
+   - *Scaling storage*: Since storage is physically attached to the local machine, every storage change requires creating a new VM group, so data must be transferred from the old machine to the new machine (on all 4 replicas). 
+   - *Scaling vCores*: Every compute scaling operation requires creating a new VM group, so data must be copied from the old machine to the new machine (on all 4 replicas).
+   - *Changing hardware or maintenance window*: If a VM group already exists within the subnet with a matching configuration, that VM group is resized. If this is a new configuration, then a new VM group is created. Data must be copied from the old VM group to the new VM group (on all 4 replicas).
+   - *Changing service tier*: Data must be copied from local storage to the remote storage used in the General Purpose service tier.
+   - *Enabling or disabling [zone redundancy](high-availability-sla-local-zone-redundancy.md#high-availability-through-zone-redundancy)* – data must be copied to or from the zone redundant regions.
+
+### Seeding speeds
+
+The following factors affect the duration of the seeding process: 
+
+- **Database size**: Larger databases require more time to transfer data and synchronize across SQL Database Engine processes.
+- **Network dependencies**: Network bandwidth and latency can significantly influence seeding speeds. 
+- **Backup and restore operations**: Ongoing backup operations on the source SQL Database Engine process can influence preparing data to send to another SQL Database Engine process.
+- **Instance workload**: Instance workload during seeding can cause throttling and severely prolong the process. 
+
+While most of these factors are beyond your control, you can manage instance traffic to significantly optimize seeding speeds. Seeding uses the same instance computing resources that manage instance traffic. Heavy traffic during seeding can reduce vCore availability, leading to insufficient capacity for the seeding process, causing throttling.
+
+High traffic during seeding can impact synchronization since seeding is designed to package and transfer all currently stored data in a single operation. Subsequent data changes to the old SQL Database Engine process that arrive after seeding is initiated must be synchronized to the new SQL Database Engine process incrementally through transaction log block replication before failover can occur. If the instance is under heavy load, seeding might struggle keeping up with incoming data, leading to delays and potential failures in the synchronization phase. Continuous high traffic on the old SQL Database Engine process after seeding starts can lead to a situation where the synchronization phase never completes, as new data keeps arriving and must be transferred. This can result in a perpetual cycle of data transfer that prevents failover to the new SQL Database Engine process.
+
+For an estimated duration of seeding operations, see [Management operations duration](management-operations-duration.md#seeding-duration).
+
+### Azure infrastructure and notices 
+
+Seeding is a process that can't be precisely quantified or strictly predicted, as it relies on the *shared Azure services*. The data transfer and seeding operations depend on various internal Azure services and infrastructure, which are shared across the entire Azure ecosystem. These services are utilized by numerous other unrelated services within Azure. All services within the Azure ecosystem compete for available resources, which leads to fluctuations in momentary availability influenced by multiple factors. While Microsoft can provide a range in which the infrastructure capacity operates, making precise predictions is challenging. 
+
+## Failover
+
+Instance failover is the moment when traffic is routed from an old SQL Database Engine process to a new SQL Database Engine process within the group of nodes in a VM group that encompass the SQL managed instance. Failover is a crucial part of most management operations, especially when updating an instance. The short moment of broken connections while traffic is redirected to the new SQL Database Engine process is referred to as *failover*. 
+
+Your instance is *only unavailable during failover*, when traffic is rerouted to the new SQL Database Engine process. In the **Business Critical** service tier, your instance is unavailable for up to 20 seconds, while in the **General Purpose** service tier, your instance can be unavailable for up to 2 minutes. Any backend operations that occur to prepare for failover due to a management operation, such as reseeding databases in the **Business Critical** service tier, happen in the background and don't affect the availability of your instance.
+
+> [!IMPORTANT]
+> For update operations that don't complete in place but that result in reattaching the database (such as scaling vCores, scaling memory, changing hardware or the maintenance window), failover duration of databases on the [Next-gen General Purpose service tier](service-tiers-next-gen-general-purpose-use.md) scales with the number of databases, up to 10 minutes. While the instance becomes available after 2 minutes, some databases might be available after a delay. Failover duration is measured from the moment when the first database goes offline, until the moment when the last database comes online. The Next-gen General Purpose service tier increases the maximum number of databases per instance from 100 to 500.
+
+Architectural differences between service tiers are explained in depth in [availability](high-availability-sla-local-zone-redundancy.md#locally-redundant-availability). 
+
+## When management operations get stuck (platform-side issues)
+
+Most management operations complete within their [expected duration](management-operations-duration.md). In a small number of cases, an operation can remain in a particular state significantly longer than expected. The cause is sometimes customer configuration (for example, networking or quota), and sometimes a transient platform/control-plane condition that follows an Azure incident, planned maintenance, or failover.
+
+This section helps you recognize a stuck operation, distinguish customer-side from platform-side causes, and decide when to escalate to Microsoft Support. For full state-by-state guidance, see the dedicated article: [Troubleshoot management operations stuck in provisioning/starting/updating states](troubleshoot-management-operations-stuck.md).
+
+### Common stuck states
+
+The following states are most commonly reported by customers when an operation appears stuck. They're surfaced in the Azure portal **Overview** page, the resource group **Activity log**, and the ARM long-running operation status:
+
+- **Provisioning**
+- **ReadyForCreationKickOff**
+- **WaitingForManagedServerActivation**
+- **CreatingPhysicalDatabase**
+- **WaitingForOperationToComplete**
+- **NoComputeAvailable**
+- **Starting**
+- **Updating**
+
+### Operation state mapping
+
+The following table maps each observable operation state to its typical meaning, what you can check, and the recommended next step. Use it together with the [expected operation duration](management-operations-duration.md).
+
+| State | Typical meaning | What you can check | Recommended next step |
+| --- | --- | --- | --- |
+| **Provisioning** | Standard creation step. The virtual cluster, VM group, and SQL Database Engine processes are being prepared. | Subnet configuration, vCore quota, region capacity. | Wait. New virtual cluster builds can take several hours. |
+| **ReadyForCreationKickOff** | The control plane has accepted the request and is queuing it for execution. | Recent operations in the same subnet ([cross-impact](#management-operations-cross-impact)) and capacity. | Wait. The operation starts after queued work clears. |
+| **WaitingForManagedServerActivation** | The instance VM group is built; the SQL Database Engine process is being activated. | Service Health for active incidents, recent failover/maintenance. | Wait. Activation usually completes within minutes after VM group readiness. |
+| **CreatingPhysicalDatabase** | System databases are being created on the new SQL Database Engine process. | Subnet/storage configuration. | Wait. |
+| **WaitingForOperationToComplete** | A dependent backend step (seeding, replication, or failover) is still in progress. | Database size, instance workload (seeding throughput is sensitive to both). | Wait. Avoid initiating additional operations on the same instance/subnet. |
+| **NoComputeAvailable** | The platform couldn't allocate the requested compute. | Region/SKU capacity, quota, planned maintenance. | Retry later. Consider an alternate region or SKU if the condition persists. |
+| **Starting** | The instance is starting from a stopped state, or restarting after maintenance/failover. | Service Health, Activity log for the start operation. | Wait. Starts typically take about 20 minutes; longer if a virtual cluster build is required. |
+| **Updating** | A scale, service-tier change, hardware change, maintenance window, or post-failover reconfiguration is in progress. | Operation type and [expected duration](management-operations-duration.md), other conflicting operations. | Wait. Don't submit additional updates while one is in progress. |
+
+### Decision tree: customer configuration vs platform issue
+
+Use the following checks to distinguish customer-side causes from platform-side causes before opening a support ticket:
+
+1. **Check Azure Service Health.** If there's an active incident affecting Azure SQL Managed Instance in your region, follow the incident communication. Most operations resume automatically after platform recovery.
+2. **Compare elapsed time to expected duration.** Reference [Management operations duration](management-operations-duration.md). If the operation is within the expected range, it isn't stuck - wait.
+3. **Check the subnet and networking.** Verify the subnet still meets [networking requirements](connectivity-architecture-overview.md), including [service-aided subnet configuration](subnet-service-aided-configuration-enable.md), required NSG rules, route tables, and DNS. Misconfigured networking can block create, start, and scale operations.
+4. **Check for conflicting operations.** Confirm there is no other long-running operation in the same subnet/virtual cluster (for example, a long restore or a recently submitted scale). See [Management operations cross-impact](#management-operations-cross-impact).
+5. **Check quota and regional capacity.** Insufficient capacity can produce `NoComputeAvailable` states. See [Resource limits](resource-limits.md).
+6. **Capture operation IDs.** In the resource group **Activity log**, locate the operation entry and capture the **operation ID** and **correlation ID**.
+
+If the operation has run beyond the expected duration, no incident is reported, and your configuration is valid, the cause is most likely platform-side and may require Microsoft Support to unblock the workflow.
+
+### Escalation guidance
+
+When you escalate to Microsoft Support, providing the following information up front significantly reduces time to mitigation:
+
+- **Subscription ID**, **resource group**, **managed instance name**, and **region**.
+- **Operation ID** and **correlation ID** from the Activity log entry for the stuck operation.
+- **Operation type** (create, start, stop, scale vCores, scale storage, change service tier, change hardware, change maintenance window, failover).
+- **Timestamps**: when the operation was submitted and when it last showed progress.
+- **Current observable state** in the portal and as returned by ARM.
+- **Instance configuration**: service tier, hardware, vCores, storage size, zone redundancy, maintenance window, subnet, virtual network.
+- **Recent events**: any failover, maintenance, scale, or restore performed in the last 24-48 hours; any Service Health incident that overlaps with the operation.
+
+> [!IMPORTANT]
+> Customers can't restart internal control-plane agents or backend orchestrator components. When a stuck operation is caused by a transient platform-side condition, the resolution requires the platform to recover or Microsoft Support to unblock the workflow. Don't repeatedly retry, toggle stop/start, or initiate additional operations on the same instance - these actions can extend recovery and complicate diagnosis.
+
+For complete troubleshooting guidance, including a full state-to-action matrix, expected timeframes, safe actions, and FAQ, see [Troubleshoot management operations stuck in provisioning/starting/updating states](troubleshoot-management-operations-stuck.md).
+
+## Management operations cross-impact
+
+Management operations on a SQL managed instance can affect the management operations of other instances placed inside the same subnet:
+
+- **Long-running restore operations** in a virtual cluster put other operations in the same virtual cluster on hold, such as create or scale operations.
+
+  **Example:** If there's a long-running restore operation, and also a scale request that shrinks the VM group, the shrink request takes longer to complete as it waits for the restore operation to finish before it can continue.
+
+- **A subsequent instance creation or scaling** operation is put on hold by a previously initiated instance creation or instance scale that initiated a resize of the VM group.
+
+  **Example:** If there are multiple create and/or scale requests in the same subnet under the same VM group, and one of them initiates a VM group resize, all requests that were submitted 1+ minutes after the initial operation request last longer than expected, as these requests must wait for the resize to complete before resuming.
+
+- **Create/scale operations submitted in a 1-minute window** are batched and executed in parallel.
+
+  **Example:** Only one virtual cluster resize is performed for all operations submitted in a 1-minute window (measured from the moment when the first operation request is submitted). If another request is submitted more than 1 minute after the first one is submitted, it waits for the virtual cluster resize to complete before execution starts.
+
+> [!IMPORTANT]
+> Management operations that are put on hold because of another operation that is in progress are automatically resumed once conditions to proceed are met. No user action is necessary to resume the temporarily paused management operations.
+
+## Monitor management operations
+
+To learn how to monitor management operation progress and status, see [Monitoring Azure SQL Managed Instance management operations](management-operations-monitor.md).
+
+## Cancel management operations
+
+To learn how to cancel management operation, see [Canceling Azure SQL Managed Instance management operations](management-operations-cancel.md).
+
+## Related content
+
+- [Quickstart: Create Azure SQL Managed Instance](instance-create-quickstart.md)
+- [Features comparison: Azure SQL Database and Azure SQL Managed Instance](../database/features-comparison.md)
+- [Connectivity architecture for Azure SQL Managed Instance](connectivity-architecture-overview.md)
+- [Virtual cluster architecture - Azure SQL Managed Instance](virtual-cluster-architecture.md)
+- [SQL Managed Instance migration using Database Migration Service](/azure/dms/tutorial-sql-server-to-managed-instance)

--- a/azure-sql/managed-instance/troubleshoot-management-operations-stuck.md
+++ b/azure-sql/managed-instance/troubleshoot-management-operations-stuck.md
@@ -1,0 +1,181 @@
+---
+title: Troubleshoot Stuck Management Operations
+titleSuffix: Azure SQL Managed Instance
+description: Learn how to diagnose and unblock Azure SQL Managed Instance management operations that are stuck in provisioning, starting, or updating states, including states caused by platform-side issues after an incident or failover.
+author: urosmil
+ms.author: urmilano
+ms.reviewer: mathoma, randolphwest
+ms.date: 03/03/2026
+ms.service: azure-sql-managed-instance
+ms.subservice: deployment-configuration
+ms.topic: troubleshooting
+---
+
+# Troubleshoot Azure SQL Managed Instance management operations stuck in provisioning/starting/updating states
+
+[!INCLUDE [appliesto-sqlmi](../includes/appliesto-sqlmi.md)]
+
+This article helps you diagnose and unblock [management operations](management-operations-overview.md) on [Azure SQL Managed Instance](sql-managed-instance-paas-overview.md) that appear stuck in states such as **Provisioning**, **Starting**, **Updating**, **WaitingForManagedServerActivation**, **WaitingForOperationToComplete**, **NoComputeAvailable**, **CreatingPhysicalDatabase**, or **ReadyForCreationKickOff**.
+
+These states are most commonly observed during create, start, scale, service-tier change, or post-failover operations. While most operations complete within their [expected duration](management-operations-duration.md), certain operations can take longer than expected because of customer-side configuration, capacity availability, or transient platform/control-plane conditions following an Azure incident or failover.
+
+> [!NOTE]
+> Customers can't restart internal control-plane agents or backend orchestrator components. When a stuck operation is caused by a platform-side condition, the resolution requires the platform to recover, or Microsoft Support to unblock the workflow.
+
+## Symptoms
+
+You might experience one or more of the following symptoms:
+
+- A create, start, or scale operation has been running significantly longer than the [expected duration](management-operations-duration.md) for that operation.
+- The portal **Overview** page for the managed instance shows a state such as **Provisioning**, **Starting**, **Updating**, or a long-lived "operation in progress" banner.
+- An ARM `GET` on the managed instance, or on its operation, returns a state such as `WaitingForManagedServerActivation`, `WaitingForOperationToComplete`, `CreatingPhysicalDatabase`, `ReadyForCreationKickOff`, or `NoComputeAvailable` for an extended period.
+- The instance was healthy before a region incident, planned maintenance, or [user-initiated failover](user-initiated-failover.md), and a subsequent management operation hasn't progressed.
+- Repeated retries of the same operation produce no observable progress.
+
+## Quick triage: platform vs configuration
+
+Before opening a support request, run through the following checklist to determine whether the cause is likely customer configuration or a platform-side issue.
+
+| Check | Action | Outcome |
+| --- | --- | --- |
+| Azure Service Health | Open **Service Health** in the Azure portal and look for active or recent incidents impacting **Azure SQL Managed Instance** in your region. | If an incident is active, follow the incident communication. Most operations resume automatically after platform recovery. |
+| Subnet and networking | Verify the subnet still meets [networking requirements](connectivity-architecture-overview.md), including [service-aided subnet configuration](subnet-service-aided-configuration-enable.md), required NSG rules, route tables, and DNS. | Misconfigured networking can block create, start, and scale operations. |
+| Conflicting operations | Confirm there is no other long-running operation in the same subnet/virtual cluster (for example, a long restore or a recently submitted scale). See [Management operations cross-impact](management-operations-overview.md#management-operations-cross-impact). | If a conflicting operation is in progress, the queued operation resumes automatically when the prior one completes. |
+| Quota and capacity | Confirm subscription vCore quota and regional capacity are sufficient for the requested SKU. | Insufficient capacity can produce `NoComputeAvailable` states. See [Resource limits](resource-limits.md). |
+| Operation age | Compare elapsed time with the [expected duration](management-operations-duration.md) for the operation type and instance size. | Operations within expected ranges aren't stuck - wait. |
+| Activity log | In the Azure portal, open the resource group **Activity log** and locate the operation entry. Capture the **operation ID** and **correlation ID**. | These IDs are required for support escalation. |
+
+If the operation has run beyond the expected duration, no incident is reported, and your configuration appears valid, the issue is likely platform-side and may require Microsoft Support.
+
+## State-to-action matrix
+
+The following table maps observable operation states to typical meanings, what you can check, and the recommended next step. State names match those reported by the Azure portal and ARM operation status.
+
+| State | Typical meaning | What you can check | Recommended next step | Escalation threshold |
+| --- | --- | --- | --- | --- |
+| **Provisioning** | Standard creation step. The virtual cluster, VM group, and SQL Database Engine processes are being prepared. | Subnet configuration, vCore quota, region capacity. | Wait. New virtual cluster builds can take several hours. | More than 6 hours without progress, or significantly beyond the [expected create duration](management-operations-duration.md). |
+| **ReadyForCreationKickOff** | The control plane has accepted the request and is queuing it for execution. | Recent operations in the same subnet (cross-impact), capacity. | Wait. The operation starts after queued work clears. | More than 1 hour stuck in this state. |
+| **WaitingForManagedServerActivation** | The instance VM group is built; the SQL Database Engine process is being activated. | Service Health for active incidents, recent failover/maintenance. | Wait. Activation usually completes within minutes after VM group readiness. | More than 1 hour stuck in this state without an active incident. |
+| **CreatingPhysicalDatabase** | System databases are being created on the new SQL Database Engine process. | Subnet/storage configuration. | Wait. | More than 2 hours without progress. |
+| **WaitingForOperationToComplete** | A dependent backend step (seeding, replication, or failover) is still in progress. | Database size and instance workload (seeding throughput is sensitive to both). | Wait. Avoid initiating additional operations on the same instance/subnet. | Significantly beyond expected [seeding duration](management-operations-overview.md#seeding-speeds) for the database size. |
+| **NoComputeAvailable** | The platform couldn't allocate the requested compute. | Region/SKU capacity, quota, planned maintenance. | Retry later. Consider an alternate region or SKU if the condition persists. See [Stop and start - capacity allocation](instance-stop-start-how-to.md#overview). | Multiple consecutive failures across several hours. |
+| **Starting** | The instance is starting from a stopped state, or restarting after maintenance/failover. | Service Health, Activity log for the start operation. | Wait. Starts typically take about 20 minutes; longer if a virtual cluster build is required. | More than 4 hours stuck without progress. |
+| **Updating** | A scale, service-tier change, hardware change, maintenance window, or post-failover reconfiguration is in progress. | Operation type and [expected duration](management-operations-duration.md), other conflicting operations. | Wait. Don't submit additional updates while one is in progress. | Significantly beyond expected duration with no Activity log progress. |
+
+## Expected timeframes
+
+Most management operations complete within the ranges documented in [Management operations duration](management-operations-duration.md). An operation should be considered abnormal when it:
+
+- Exceeds the documented expected duration by a significant margin (for example, more than 2x).
+- Hasn't produced any new Activity log entries for several hours.
+- Remains in a single state with no progress while no Service Health incident is reported.
+
+A new virtual cluster build can extend create and start operations to approximately 4 hours. Large databases and Business Critical service tier operations require seeding, which scales with database size and instance workload.
+
+## Safe customer actions
+
+When an operation is stuck, take only safe actions to avoid making the situation worse.
+
+**Recommended:**
+
+- Wait for the documented expected duration before taking any action.
+- Check **Azure Service Health** for active incidents and follow the published guidance.
+- Capture the **operation ID** and **correlation ID** from the **Activity log** for the failing operation. These IDs are required for any support engagement.
+- Verify the subnet, NSG, route tables, and DNS configuration are still compliant with [networking requirements](connectivity-architecture-overview.md).
+
+**Avoid:**
+
+- Don't repeatedly toggle stop/start, retry scale, or initiate additional operations on the same instance while one is already in progress. These actions can extend recovery time and complicate diagnosis.
+- Don't change the service tier, hardware configuration, or maintenance window while a prior operation is unfinished.
+- Don't delete the instance to "reset" it unless you have validated backups and accept the data loss; deletion isn't a supported troubleshooting workaround.
+
+**Cancellation:**
+
+- Some management operations can be cancelled. See [Cancel management operations](management-operations-cancel.md) for the operations that support cancellation and the expected behavior.
+- Stop and start operations can't be cancelled after they're initiated. See [Stop and start limitations](instance-stop-start-how-to.md#limitations-of-the-stop-and-start-feature).
+
+## Monitor operation progress
+
+Use the following channels to monitor operation progress:
+
+- **Azure portal**: The instance **Overview** page shows the current state and the in-progress operation banner.
+- **Activity log**: The resource group **Activity log** lists every management operation, with status, operation ID, correlation ID, and timestamps.
+- **ARM operation status**: Query the long-running operation status using the ARM REST API. See [Monitor management operations](management-operations-monitor.md) for details on retrieving operation state programmatically.
+- **Azure Service Health**: Subscribe to alerts for SQL Managed Instance in your region(s) so you're notified of incidents that may impact your instance.
+
+## Data to collect for Microsoft Support
+
+Before opening a support request, collect the following information. Providing it up front significantly reduces time to mitigation:
+
+- **Subscription ID**, **resource group**, **managed instance name**, and **region**.
+- **Operation ID** and **correlation ID** from the Activity log entry for the stuck operation.
+- **Operation type** (create, start, stop, scale vCores, scale storage, change service tier, change hardware, change maintenance window, failover).
+- **Timestamps**: when the operation was submitted and when it last showed progress.
+- **Current observable state** as displayed in the portal and as returned by ARM.
+- **Instance configuration**: service tier, hardware, vCores, storage size, zone redundancy, maintenance window, subnet, virtual network, and any recent configuration changes.
+- **Recent events**: any failover, maintenance, scale, or restore performed in the last 24-48 hours; any Service Health incident that overlaps with the operation.
+- **Screenshots** of the portal **Overview** and **Activity log** pages.
+
+## When to open a support ticket
+
+Open a support ticket when:
+
+- The operation has exceeded the [expected duration](management-operations-duration.md) by a significant margin.
+- No Service Health incident covers the symptom, or the published incident no longer mentions impact in your region.
+- The operation has remained in the same state for longer than the escalation threshold in the [state-to-action matrix](#state-to-action-matrix), without progress in the Activity log.
+- Production workloads are impacted and you need a defined response time.
+
+Choose the support severity that matches your business impact. Production-down scenarios should use the severity supported by your [support plan](https://azure.microsoft.com/support/plans/).
+
+## What Microsoft Support may do
+
+To set expectations, Microsoft Support engineers can do the following at a high level (specific internal mechanics aren't published):
+
+- Inspect the state of the backend workflow associated with your operation ID and confirm whether it's actively progressing, queued behind other work, or blocked.
+- Unblock workflows that became stuck because of transient control-plane conditions following an incident or failover.
+- Repair dependencies on shared platform components (for example, capacity, storage, or networking pipelines) that affect a specific operation.
+- Coordinate with engineering when an issue requires code-level investigation.
+
+Customers can't perform any of these actions directly because they require access to internal control-plane components.
+
+## Post-incident guidance
+
+After a regional incident, planned maintenance, or failover, some operations may be queued or briefly degraded while the platform recovers:
+
+- Allow the platform to stabilize before submitting non-essential management operations.
+- Avoid bulk operations across many instances in the same subnet/virtual cluster while recovery is in progress; they can extend overall recovery time. See [Management operations cross-impact](management-operations-overview.md#management-operations-cross-impact).
+- For instances that returned to the **Ready** state, a brief delay before scaling, service-tier changes, or maintenance window changes reduces the chance of conflicts.
+- Continue to monitor **Service Health** and the **Activity log** for the all-clear.
+
+## Frequently asked questions
+
+### Why does my operation say "Updating" hours after I started it?
+
+Long-running update operations (scale vCores or storage, service-tier change, hardware change, maintenance window change) can require building a new VM group and seeding data. Business Critical service tier operations require seeding for almost every change. See [Seeding](management-operations-overview.md#seeding) and [Management operations duration](management-operations-duration.md).
+
+### Can I cancel a stuck stop or start operation?
+
+No. Stop and start operations can't be cancelled. See [Limitations of the stop and start feature](instance-stop-start-how-to.md#limitations-of-the-stop-and-start-feature).
+
+### Will retrying the operation help?
+
+Usually no. Retrying while an operation is in progress doesn't accelerate recovery and can extend it. Retry only after the prior operation has completed or failed.
+
+### Does failing over the instance unblock a stuck operation?
+
+No. [User-initiated failover](user-initiated-failover.md) is a separate operation and is itself a management operation that can be queued behind the in-progress one.
+
+### My instance is in `NoComputeAvailable`. What can I do?
+
+Wait and retry later. If the condition persists across multiple attempts and several hours, consider an alternate region or SKU, and open a support ticket if the impact is production-critical.
+
+## Related content
+
+- [Overview of management operations in Azure SQL Managed Instance](management-operations-overview.md)
+- [Management operations duration](management-operations-duration.md)
+- [Monitoring Azure SQL Managed Instance management operations](management-operations-monitor.md)
+- [Canceling Azure SQL Managed Instance management operations](management-operations-cancel.md)
+- [Stop and start an instance](instance-stop-start-how-to.md)
+- [Known issues with Azure SQL Managed Instance](doc-changes-updates-known-issues.md)
+- [Resource health for Azure SQL Managed Instance](resource-health-to-troubleshoot-connectivity.md)
+- [Azure Service Health](/azure/service-health/overview)


### PR DESCRIPTION
## Summary

Adds troubleshooting guidance for Azure SQL Managed Instance management operations that get stuck in states such as **Provisioning**, **Starting**, **Updating**, **WaitingForManagedServerActivation**, **WaitingForOperationToComplete**, **CreatingPhysicalDatabase**, **ReadyForCreationKickOff**, or **NoComputeAvailable** - typically after an Azure incident, planned maintenance, or [user-initiated failover](https://learn.microsoft.com/azure/azure-sql/managed-instance/user-initiated-failover).

Tracks ADO work item **37049935**. Driven by ~135 customer support cases where customers were unable to determine whether stuck operations were caused by their own configuration or by platform-side conditions, and didn't know what data to provide for escalation.

## Changes

This PR implements all 5 documentation actions from the work item:

1. **New article** `azure-sql/managed-instance/troubleshoot-management-operations-stuck.md` - End-to-end troubleshooting guide with state-to-action matrix, expected timeframes, safe customer actions, escalation data checklist, and FAQ.
2. **`management-operations-overview.md`** - New `## When management operations get stuck (platform-side issues)` section: common stuck states, operation-state mapping table, decision tree (customer config vs platform), escalation guidance, cross-link to the new article.
3. **`instance-stop-start-how-to.md`** - New `## Troubleshooting` section: common stuck states for stop/start, safe actions, when-to-contact-support criteria with required data, cross-link to the new article.
4. **`doc-changes-updates-known-issues.md`** - New row in the Known Issues summary table and a new `### Management operations stuck after platform incident or failover` subsection under Has workaround, with symptoms / what to check / recovery expectations / workaround / escalation, plus cross-link to the new article.
5. Cross-linking and TOC integration via cross-references from all three modified articles to the new troubleshoot article.

## Customer outcomes

- Self-service triage to distinguish customer-side from platform-side causes.
- Clear list of operation IDs / correlation IDs / configuration data to attach when opening a support request.
- Explicit guidance to avoid actions that extend recovery (repeated retries, stop/start toggles, additional config changes).
- Realistic expectations on timeframes, including new virtual cluster builds (~4 hours) and large-database seeding.

## Internal reference

ADO work item: msazure / OneCloud / 37049935 - "[DOC] Stuck operation - what's the next step?"
