### PR TITLE
Fix include statement for sys.dm_db_vector_indexes

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-db-vector-indexes-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-db-vector-indexes-transact-sql.md
@@ -26,7 +26,7 @@ monikerRange: "=sql-server-ver17 || =sql-server-linux-ver17 || =azuresqldb-curre
 
 # sys.dm_db_vector_indexes (Transact-SQL)
 
-[!INCLUDE [sqlserver2025-asdb-fabricsqldb](../../includes/applies-to-version/sqlserver2025-asdb-fabricsqldb.md)]
+[!INCLUDE [asdb-mi-fabric-sqldb](../../includes/applies-to-version/asdb-mi-fabric-sqldb.md)]
 
 Returns real-time insights into vector index health and performance. Use this view for monitoring vector index maintenance operations and identifying indexes that need attention.
 


### PR DESCRIPTION
Updated the include statement for the sys.dm_db_vector_indexes documentation - this is not applicable to SQL 2025