### PR TITLE
docs: correct file permissions description in SQL Server on Linux FAQ

### DIFF
--- a/docs/linux/sql-server-linux-faq.md
+++ b/docs/linux/sql-server-linux-faq.md
@@ -149,7 +149,7 @@ The following sections provide common questions and answers for SQL Server runni
 
 1. **What permissions are required for SQL Server files?**
 
-   All files in the `/var/opt/mssql` file folder should be owned by the **mssql** user and belong to the **mssql** group. Both the **mssql** user and group should have read-write permissions of all files and directories. Note the following special scenarios involving file and directory permissions:
+   All files in the `/var/opt/mssql` file folder should be owned by the **mssql** user and belong to the **mssql** group. The default directory permissions vary: the root directory (`/var/opt/mssql`) is set to `770`, while subdirectories such as `data` and `log` are set to `755`. Database files (`.mdf`, `.ndf`, `.ldf`) are created with `660` permissions, ensuring only the **mssql** user and group can read or write them. Note the following special scenarios involving file and directory permissions:
 
    * Permissions for mssql owner and group are required for mounted network shares that are used to store SQL Server files.
    * If you locate database files or backups in a non-default directory, you must also set permissions for that directory.


### PR DESCRIPTION
## Summary

This PR corrects the file permissions description in the **SQL Server on Linux FAQ** page.

### Problem

The current text states:

> Both the mssql user and group should have read-write permissions of all files and directories.

This is vague and does not match the actual default permissions set by the SQL Server on Linux installer.

### Correction

Updated the description to reflect the actual default permissions verified on a fresh SQL Server 2025 installation on Ubuntu 22.04:

| Path | Permission | Description |
|------|-----------|-------------|
| `/var/opt/mssql` | `770` | Root directory, no access for others |
| `/var/opt/mssql/data` | `755` | Data directory |
| `/var/opt/mssql/log` | `755` | Log directory |
| Database files (`.mdf`, `.ndf`, `.ldf`) | `660` | Only mssql user and group can read/write |

### Verification

Permissions were verified using:

\\\ash
find /var/opt/mssql -type d -exec stat -c '%a %U:%G %n' {} \;
find /var/opt/mssql/data -type f -exec stat -c '%a %U:%G %n' {} \;
\\\

### Affected page

https://learn.microsoft.com/en-us/sql/linux/sql-server-linux-faq
