### PR TITLE
Update alter-availability-group-transact-sql.md

### DIFF
--- a/docs/t-sql/statements/alter-availability-group-transact-sql.md
+++ b/docs/t-sql/statements/alter-availability-group-transact-sql.md
@@ -554,7 +554,7 @@ Initiates a manual failover of the availability group without data loss to the s
 
 Failover is only supported to a synchronous-commit secondary replica that's currently synchronized with the primary replica. For a secondary replica to be synchronized, the primary replica must also be running in synchronous-commit mode.
 
-For two SQL Server instances in an availability group, you can issue the failover command on either the primary or secondary replica. For instances replicated through the [Managed Instance link](/azure/azure-sql/managed-instance/managed-instance-link-feature-overview), you must issue the failover command on the primary replica.
+For instances replicated through the [Managed Instance link](/azure/azure-sql/managed-instance/managed-instance-link-feature-overview), you must issue the failover command on the primary replica.
 
 > [!NOTE]  
 >

--- a/docs/t-sql/statements/alter-availability-group-transact-sql.md
+++ b/docs/t-sql/statements/alter-availability-group-transact-sql.md
@@ -554,6 +554,7 @@ Initiates a manual failover of the availability group without data loss to the s
 
 Failover is only supported to a synchronous-commit secondary replica that's currently synchronized with the primary replica. For a secondary replica to be synchronized, the primary replica must also be running in synchronous-commit mode.
 
+For an availability group between two SQL Server instances, you must issue the failover command on the secondary replica (the failover target).
 For instances replicated through the [Managed Instance link](/azure/azure-sql/managed-instance/managed-instance-link-feature-overview), you must issue the failover command on the primary replica.
 
 > [!NOTE]  


### PR DESCRIPTION
FAILOVER command can only be issued on the secondary replica.

Also written in another location : https://learn.microsoft.com/en-us/sql/database-engine/availability-groups/windows/failover-and-failover-modes-always-on-availability-groups?view=sql-server-ver17#:~:text=To%20manually%20fail%20over%20an%20availability%20group%2C%20you%20must%20be%20connected%20to%20the%20secondary%20replica%20that%20is%20to%20become%20the%20new%20primary%20replica.