### PR TITLE
Note that *.services.ai.azure.com isn't in the allowed endpoints list

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-invoke-external-rest-endpoint-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-invoke-external-rest-endpoint-transact-sql.md
@@ -252,7 +252,7 @@ Only calls to endpoints for the following services are allowed:
 | Azure AI Translator | `api.cognitive.microsofttranslator.com` |
 
 > [!NOTE]  
-> Azure AI Foundry resources also expose a `*.services.ai.azure.com` endpoint. That domain isn't in the allowed list. Use the `*.cognitiveservices.azure.com` endpoint of the same resource for both the database scoped credential name and the request URL.
+> Azure AI Foundry resources might also expose an endpoint under `services.ai.azure.com` (for example, `https://<name>.services.ai.azure.com`), but that domain isn't in the allowed endpoints list. Use the corresponding `https://<name>.cognitiveservices.azure.com` endpoint for both the database scoped credential name and the request URL.
 
 [Outbound firewall rules for Azure SQL Database and Azure Synapse Analytics](/azure/azure-sql/database/outbound-firewall-rule-overview) control mechanism can be used to further restrict outbound access to external endpoints.
 

--- a/docs/relational-databases/system-stored-procedures/sp-invoke-external-rest-endpoint-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-invoke-external-rest-endpoint-transact-sql.md
@@ -251,6 +251,9 @@ Only calls to endpoints for the following services are allowed:
 | Azure Maps | `*.atlas.microsoft.com` |
 | Azure AI Translator | `api.cognitive.microsofttranslator.com` |
 
+> [!NOTE]  
+> Azure AI Foundry resources also expose a `*.services.ai.azure.com` endpoint. That domain isn't in the allowed list. Use the `*.cognitiveservices.azure.com` endpoint of the same resource for both the database scoped credential name and the request URL.
+
 [Outbound firewall rules for Azure SQL Database and Azure Synapse Analytics](/azure/azure-sql/database/outbound-firewall-rule-overview) control mechanism can be used to further restrict outbound access to external endpoints.
 
 > [!NOTE]  


### PR DESCRIPTION
## Summary

`*.services.ai.azure.com` isn't in the allowed endpoints list on this page, but it's the endpoint hostname Azure AI Foundry surfaces by default for an AI Services resource. The same resource is also reachable at `*.cognitiveservices.azure.com`, which is on the list.

This adds a short note under the table pointing readers at the allowed hostname.

## Context

An AI Foundry resource (`kind: AIServices`) reports `https://<name>.cognitiveservices.azure.com/` as `properties.endpoint`, while the Foundry portal presents the `services.ai.azure.com` hostname. Readers who copy the hostname they see in the portal into a database scoped credential land on a domain this list doesn't cover, and the resulting error names the credential rather than the domain restriction, so the cause isn't obvious from the message.
