### PR TITLE
Update Database Engine Permissions Poster link

### DIFF
--- a/docs/relational-databases/includes/database-engine-permissions.md
+++ b/docs/relational-databases/includes/database-engine-permissions.md
@@ -5,6 +5,6 @@ ms.date: 07/15/2025
 ms.service: sql
 ms.topic: include
 ---
-The following image shows the permissions and their relationships to each other. Some of the higher level permissions (such as `CONTROL SERVER`) are listed many times. In this article, the poster is far too small to read. You can download the full-sized **[Database Engine Permissions Poster](https://aka.ms/sql-permissions-poster)** in PDF format.
+The following image shows the permissions and their relationships to each other. Some of the higher level permissions (such as `CONTROL SERVER`) are listed many times. In this article, the poster is far too small to read. You can download the full-sized **[Database Engine Permissions Poster](https://raw.githubusercontent.com/Microsoft/sql-server-samples/master/samples/features/security/permissions-posters/Microsoft_SQL_Server_2017_and_Azure_SQL_Database_permissions_infographic.pdf)** in PDF format.
 
 :::image type="content" source="../../includes/media/database-engine-permissions/database-engine-permissions-small.png" alt-text="Screenshot from the Database Engine permissions PDF.":::


### PR DESCRIPTION
Hi folks,

The `https://aka.ms/sql-permissions-posters` short URL no longer works (it just leads to a Bing search `https://www.bing.com/?ref=aka&shorturl=sql-permissions-poster` ).
I know it used to point to `https://raw.githubusercontent.com/Microsoft/sql-server-samples/master/samples/features/security/permissions-posters/Microsoft_SQL_Server_2017_and_Azure_SQL_Database_permissions_infographic.pdf` so I updated the hyperlink in the article to point to that file directly.

Have a great week,

Vlad