### PR TITLE
Update JDBC driver support matrix for version 9.4

### DIFF
--- a/docs/connect/jdbc/microsoft-jdbc-driver-for-sql-server-support-matrix.md
+++ b/docs/connect/jdbc/microsoft-jdbc-driver-for-sql-server-support-matrix.md
@@ -4,7 +4,7 @@ description: This page contains the support matrix and support life-cycle policy
 author: dlevy-msft-sql
 ms.author: dlevy
 ms.reviewer: randolphwest, davidengel, machavan, sunilbs
-ms.date: 05/11/2026
+ms.date: 08/12/2026
 ms.service: sql
 ms.subservice: connectivity
 ms.topic: feature-availability

--- a/docs/connect/jdbc/microsoft-jdbc-driver-for-sql-server-support-matrix.md
+++ b/docs/connect/jdbc/microsoft-jdbc-driver-for-sql-server-support-matrix.md
@@ -39,12 +39,12 @@ JDBC driver versions 12.x and older receive five years of mainstream support fro
 | Microsoft JDBC Driver 12.2 for SQL Server | 12.2 | `mssql-jdbc-12.2.0.jre11.jar`<br />`mssql-jdbc-12.2.0.jre8.jar` | January 31, 2028 |
 | Microsoft JDBC Driver 11.2 for SQL Server | 11.2 | `mssql-jdbc-11.2.0.jre18.jar`<br />`mssql-jdbc-11.2.0.jre17.jar`<br />`mssql-jdbc-11.2.0.jre11.jar`<br />`mssql-jdbc-11.2.0.jre8.jar` | August 4, 2027 |
 | Microsoft JDBC Driver 10.2 for SQL Server | 10.2 | `mssql-jdbc-10.2.0.jre17.jar`<br />`mssql-jdbc-10.2.0.jre11.jar`<br />`mssql-jdbc-10.2.0.jre8.jar` | January 31, 2027 |
-| Microsoft JDBC Driver 9.4 for SQL Server | 9.4 | `mssql-jdbc-9.4.1.jre16.jar`<br />`mssql-jdbc-9.4.1.jre11.jar`<br />`mssql-jdbc-9.4.1.jre8.jar` | July 30, 2026 |
 
 The following Microsoft JDBC Drivers are no longer supported:
 
 | Driver name | Driver package version | End of mainstream support |
 | --- | --- | --- |
+| Microsoft JDBC Driver 9.4 for SQL Server | 9.4 | July 30, 2026 |
 | Microsoft JDBC Driver 9.2 for SQL Server | 9.2 | January 29, 2026 |
 | Microsoft JDBC Driver 8.4 for SQL Server | 8.4 | July 31, 2025 |
 | Microsoft JDBC Driver 8.2 for SQL Server | 8.2 | January 31, 2025 |


### PR DESCRIPTION
Added Microsoft JDBC Driver 9.4 for SQL Server to the no longer supported drivers list.