### PR TITLE
docs: add partition truncation tip to ALTER TABLE reference

### DIFF
--- a/docs/t-sql/statements/alter-table-transact-sql.md
+++ b/docs/t-sql/statements/alter-table-transact-sql.md
@@ -975,7 +975,7 @@ A partitioned table with a clustered columnstore index behaves like a partitione
 For `SWITCH` restriction when using replication, see [Replicate Partitioned Tables and Indexes](../../relational-databases/replication/publish/replicate-partitioned-tables-and-indexes.md).
 
 > [!TIP]
-> To truncate all rows from specific partitions without dropping or switching partitions, use [TRUNCATE TABLE](truncate-table-transact-sql.md) with the `WITH (PARTITIONS (...))` clause instead of `ALTER TABLE`.
+> To delete all rows from specific partitions without dropping or switching partitions, use [TRUNCATE TABLE](truncate-table-transact-sql.md) with the `WITH (PARTITIONS (...))` clause instead of `ALTER TABLE`.
 
 Nonclustered columnstore indexes were built in a read-only format before [!INCLUDE [sssql16-md](../../includes/sssql16-md.md)] and for SQL Database before version V12. You must rebuild nonclustered columnstore indexes to the current format (which is updatable) before any `PARTITION` operations can be run.
 

--- a/docs/t-sql/statements/alter-table-transact-sql.md
+++ b/docs/t-sql/statements/alter-table-transact-sql.md
@@ -974,6 +974,9 @@ A partitioned table with a clustered columnstore index behaves like a partitione
 
 For `SWITCH` restriction when using replication, see [Replicate Partitioned Tables and Indexes](../../relational-databases/replication/publish/replicate-partitioned-tables-and-indexes.md).
 
+> [!TIP]
+> To truncate all rows from specific partitions without dropping or switching partitions, use [TRUNCATE TABLE](truncate-table-transact-sql.md) with the `WITH (PARTITIONS (...))` clause instead of `ALTER TABLE`.
+
 Nonclustered columnstore indexes were built in a read-only format before [!INCLUDE [sssql16-md](../../includes/sssql16-md.md)] and for SQL Database before version V12. You must rebuild nonclustered columnstore indexes to the current format (which is updatable) before any `PARTITION` operations can be run.
 
 **Limitations**


### PR DESCRIPTION
### Summary
Engineers coming from other database engines (like Oracle or MySQL) frequently attempt to run `ALTER TABLE <table_name> TRUNCATE PARTITION <id>` on SQL Server, which throws `Msg 156: Incorrect syntax near the keyword 'TRUNCATE'`. 

This PR adds a brief `[!TIP]` callout under the Partition Management section of `alter-table-transact-sql.md` cross-referencing `TRUNCATE TABLE ... WITH (PARTITIONS (...))` to improve discoverability and prevent syntax confusion.

### Checklist
- [x] Content is accurate and matches T-SQL syntax standards
- [x] Formatted using standard Learn Markdown syntax (`> [!TIP]`)
- [x] Included relative link to `truncate-table-transact-sql.md`