### PR TITLE
Clarify file extension conventions for backups

### DIFF
--- a/docs/relational-databases/backup-restore/back-up-and-restore-of-sql-server-databases.md
+++ b/docs/relational-databases/backup-restore/back-up-and-restore-of-sql-server-databases.md
@@ -105,9 +105,9 @@ Designing an effective backup and restore strategy requires careful planning, im
 
 The accounts that perform backup or restore operations shouldn't be granted more privileges than necessary. Review [backup](../../t-sql/statements/backup-transact-sql.md#permissions) and [restore](../../t-sql/statements/restore-statements-transact-sql.md#permissions) for specific permission details. It's recommended that backups are [encrypted](../security/encryption/transparent-data-encryption.md) and, if possible, [compressed](backup-compression-sql-server.md).
 
-To ensure security, backup files should have extensions that follow proper conventions:
+Use consistent file extensions to make backups easier to identify and manage. SQL Server doesn't require or enforce these extensions, but following a convention helps with operational tasks such as configuring antivirus exclusions for backup files:
 
-- Database backup files should have the `.BAK` extension
+- Database backup files should have the `.BAK` extension.
 - Log backup files should have the `.TRN` extension.
 
 ### Use Separate Storage

--- a/docs/relational-databases/backup-restore/back-up-and-restore-of-sql-server-databases.md
+++ b/docs/relational-databases/backup-restore/back-up-and-restore-of-sql-server-databases.md
@@ -105,7 +105,7 @@ Designing an effective backup and restore strategy requires careful planning, im
 
 The accounts that perform backup or restore operations shouldn't be granted more privileges than necessary. Review [backup](../../t-sql/statements/backup-transact-sql.md#permissions) and [restore](../../t-sql/statements/restore-statements-transact-sql.md#permissions) for specific permission details. It's recommended that backups are [encrypted](../security/encryption/transparent-data-encryption.md) and, if possible, [compressed](backup-compression-sql-server.md).
 
-Use consistent file extensions to make backups easier to identify and manage. SQL Server doesn't require or enforce these extensions, but following a convention helps with operational tasks such as configuring antivirus exclusions for backup files:
+Use consistent file extensions to make backups easier to identify and manage. SQL Server doesn't require or enforce these extensions, but following a convention helps with operational tasks such as configuring antivirus exclusions for backup files. For more information, see [Configure antivirus software to work with SQL Server](/troubleshoot/sql/database-engine/security/antivirus-and-sql-server).
 
 - Database backup files should have the `.BAK` extension.
 - Log backup files should have the `.TRN` extension.


### PR DESCRIPTION
The "Best practice recommendations" section listed .BAK/.TRN under "To ensure security," but these extensions are a naming conventions. SQL Server doesn't enforce or read them, and they provide no security property. This rewords the guidance to reflect that, while keeping a concrete operational reason to follow the convention (antivirus exclusion configuration, per [Configure antivirus software to work with SQL Server](https://learn.microsoft.com/en-us/troubleshoot/sql/database-engine/security/antivirus-and-sql-server)). Also adds a missing terminal period to the .BAK list item for consistency.