### PR TITLE
Clarify ROWS/RANGE restriction applies to ROW_NUMBER

### DIFF
--- a/docs/t-sql/functions/row-number-transact-sql.md
+++ b/docs/t-sql/functions/row-number-transact-sql.md
@@ -50,7 +50,10 @@ ROW_NUMBER ( )
 
 #### order_by_clause
 
- The `ORDER BY` clause determines the sequence in which the rows are assigned their unique `ROW_NUMBER` within a specified partition. It is required. The `<ROW or RANGE clause>` of the `OVER` clause can't be specified for the `ROW_NUMBER` function. For more information, see [OVER Clause (Transact-SQL)](../queries/select-over-clause-transact-sql.md).  
+ The `ORDER BY` clause determines the sequence in which the rows are assigned their unique `ROW_NUMBER` within a specified partition. It is required. For more information, see [OVER Clause (Transact-SQL)](../queries/select-over-clause-transact-sql.md).  
+
+> [!NOTE]  
+> You can't use `ROW` or `RANGE` from the `OVER` clause in the `ROW_NUMBER` function.
 
 ## Return types
 

--- a/docs/t-sql/functions/row-number-transact-sql.md
+++ b/docs/t-sql/functions/row-number-transact-sql.md
@@ -50,7 +50,7 @@ ROW_NUMBER ( )
 
 #### order_by_clause
 
- The `ORDER BY` clause determines the sequence in which the rows are assigned their unique `ROW_NUMBER` within a specified partition. It is required. For more information, see [OVER Clause (Transact-SQL)](../queries/select-over-clause-transact-sql.md).  
+ The `ORDER BY` clause determines the sequence in which the rows are assigned their unique `ROW_NUMBER` within a specified partition. It is required. The `<ROW or RANGE clause>` of the `OVER` clause can't be specified for the `ROW_NUMBER` function. For more information, see [OVER Clause (Transact-SQL)](../queries/select-over-clause-transact-sql.md).  
 
 ## Return types
 


### PR DESCRIPTION
This article (ROW_NUMBER) doesn't mention that the ROWS/RANGE clause of OVER can't be specified for this function, even though the same restriction applies. The RANK article states this explicitly. This change adds that clarification here to avoid ambiguity for readers.