### PR TITLE
Add additional information about the use of filegroups

### DIFF
--- a/docs/relational-databases/track-changes/enable-and-disable-change-data-capture-sql-server.md
+++ b/docs/relational-databases/track-changes/enable-and-disable-change-data-capture-sql-server.md
@@ -92,6 +92,9 @@ EXEC sys.sp_cdc_enable_table
     @supports_net_changes = 1
 GO
 ```
+> [!NOTE]  
+> Attention! When creating a separate filegroup for the change table, ensure it has sufficient space to store the change data, otherwise, you will encounter error 1105 in the capture job, and changes will not be logged to the modified table until there is enough space in the file, There is a risk of losing captured changes, depending on your cleanup configuration.
+
 
 **A role for controlling access to a change table.**
 

--- a/docs/relational-databases/track-changes/enable-and-disable-change-data-capture-sql-server.md
+++ b/docs/relational-databases/track-changes/enable-and-disable-change-data-capture-sql-server.md
@@ -93,8 +93,7 @@ EXEC sys.sp_cdc_enable_table
 GO
 ```
 > [!NOTE]  
-> Attention! When creating a separate filegroup for the change table, ensure it has sufficient space to store the change data, otherwise, you will encounter error 1105 in the capture job, and changes will not be logged to the modified table until there is enough space in the file, There is a risk of losing captured changes, depending on your cleanup configuration.
-
+> When you create a separate filegroup for the change table, make sure it has enough space to store change data. If the filegroup runs out of space, the capture job can encounter error `1105` and stop capturing changes until space is available. Depending on your cleanup configuration, you might lose captured changes.
 
 **A role for controlling access to a change table.**
 


### PR DESCRIPTION
The purpose of the update is to inform the administrator of the risk associated with adding a filegroup containing a file with a limited size, thereby preventing potential loss of captured changes.

When a filegroup with limited space is added and that limit is reached, DML operations do not fail and return no message to the user, requiring proactive monitoring to identify errors; while this may be obvious, it is important to warn the administrator of the risks involved.