### PR TITLE
Update view-statistics-properties.md

### DIFF
--- a/docs/relational-databases/statistics/view-statistics-properties.md
+++ b/docs/relational-databases/statistics/view-statistics-properties.md
@@ -79,7 +79,7 @@ In order to view the statistics object, the user must own the table or the user 
      Average number of bytes per value for all of the key columns in the statistics object.  
   
      **String Index**  
-     Yes indicates the statistics object contains string summary statistics to improve the cardinality estimates for query predicates that use the LIKE operator; for example, `WHERE ProductName LIKE '%Bike'`. String summary statistics are stored separately from the histogram and are created on the first key column of the statistics object when it is of type **char**, **varchar**, **nchar**, **nvarchar**, **varchar(max)**, **nvarchar(max)**, **text**, or **ntext**.  
+     Yes indicates the statistics object contains string summary statistics to improve the cardinality estimates for query predicates that use the LIKE operator; for example, `WHERE ProductName LIKE '%Bike'`. String summary statistics are stored separately from the histogram and are created on the first key column of the statistics object when it is of type **char**, **varchar**, **nchar**, **nvarchar**, **varchar(max)**, **nvarchar(max)**, **text**, or **ntext**  with the exception of **char** and **varchar** columns using a  UTF-8 collation.  
   
      **Filter Expression**  
      Predicate for the subset of table rows included in the statistics object. NULL = non-filtered statistics.  


### PR DESCRIPTION
Added the same text for string indexes and UTF-8 collations that is in  DBCC SHOW_STATISTICS.  Refer to Vassilis.Papadimos@microsoft.com for verification. (This should be in the same pull request as the change for DBCC SHOW_STATISTICS, but I have not figured out how I can do that.) 