### PR TITLE
Update SUM function syntax and OVER clause details

### DIFF
--- a/docs/t-sql/functions/sum-transact-sql.md
+++ b/docs/t-sql/functions/sum-transact-sql.md
@@ -62,9 +62,9 @@ A constant, column, or function, and any combination of arithmetic, bitwise, and
 
 *partition_by_clause* divides the result set produced by the `FROM` clause into partitions to which the function is applied. If not specified, the function treats all rows of the query result set as a single group.
 
-*order_by_clause* determines the logical order in which the operation is performed. If *row_or_range_clause* isn't specified, it assumes its default value.
+*order_by_clause* determines the logical order in which the operation is performed.
 
-*row_or_range_clause* defines the window frame in which the function is applied. The default value is `RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`. It requires *order_by_clause* to be specified. 
+*row_or_range_clause* defines the window frame in which the function is applied. It requires *order_by_clause* to be specified. If *order_by_clause* is specified and *row_or_range_clause* isn't, *row_or_range_clause* assumes its default value `RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`. 
 
 For more information, see [SELECT - OVER clause](../queries/select-over-clause-transact-sql.md).
 

--- a/docs/t-sql/functions/sum-transact-sql.md
+++ b/docs/t-sql/functions/sum-transact-sql.md
@@ -41,7 +41,7 @@ Returns the sum of all the values, or only the `DISTINCT` values, in the express
 SUM ( [ ALL | DISTINCT ] expression )
 
 -- Analytic Function Syntax
-SUM ( [ ALL ] expression) OVER ( [ partition_by_clause ] [ order_by_clause ] )
+SUM ( [ ALL ] expression) OVER ( [ partition_by_clause ] [ order_by_clause ] [row_or_range_clause] )
 ```
 
 ## Arguments
@@ -58,11 +58,15 @@ Specifies that `SUM` returns the sum of unique values.
 
 A constant, column, or function, and any combination of arithmetic, bitwise, and string operators. *expression* is an expression of the exact numeric or approximate numeric data type category, except for the **bit** data type. Aggregate functions and subqueries aren't permitted. For more information, see [Expressions](../language-elements/expressions-transact-sql.md).
 
-#### OVER ( [ *partition_by_clause* ] [ *order_by_clause* ] )
+#### OVER ( [ *partition_by_clause* ] [ *order_by_clause* ] [ *row_or_range_clause* ] )
 
 *partition_by_clause* divides the result set produced by the `FROM` clause into partitions to which the function is applied. If not specified, the function treats all rows of the query result set as a single group.
 
-*order_by_clause* determines the logical order in which the operation is performed. For more information, see [SELECT - OVER clause](../queries/select-over-clause-transact-sql.md).
+*order_by_clause* determines the logical order in which the operation is performed. If *row_or_range_clause* isn't specified, it assumes its default value.
+
+*row_or_range_clause* defines the window frame in which the function is applied. The default value is `RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`. It requires *order_by_clause* to be specified. 
+
+For more information, see [SELECT - OVER clause](../queries/select-over-clause-transact-sql.md).
 
 ## Return types
 


### PR DESCRIPTION
This article doesn't mention that the OVER clause can include the ROWS or RANGE clause. I believe this is particularly important because when the ORDER BY clause is specified, ROWS or RANGE assumes its default value, which can then be explicitly changed by the user. My suggested change clarifies this point.