### PR TITLE
docs: remove duplicate 'to' in Updategram ADO guide

### DIFF
--- a/docs/relational-databases/sqlxml-annotated-xsd-schemas-xpath-queries/updategrams/executing-an-updategram-by-using-ado-sqlxml-4-0.md
+++ b/docs/relational-databases/sqlxml-annotated-xsd-schemas-xpath-queries/updategrams/executing-an-updategram-by-using-ado-sqlxml-4-0.md
@@ -1,6 +1,6 @@
 ---
 title: "Executing an Updategram by Using ADO (SQLXML)"
-description: Learn how to to establish a connection to an instance of Microsoft SQL Server and execute an updategram.by using ADO (SQLXML 4.0).
+description: Learn how to establish a connection to an instance of Microsoft SQL Server and execute an updategram.by using ADO (SQLXML 4.0).
 author: rwestMSFT
 ms.author: randolphwest
 ms.date: "03/14/2017"


### PR DESCRIPTION
Tiny docs fix: `how to to establish` → `how to establish` in the SQLXML 4.0 Updategram ADO guide description.