### PR TITLE
docs: remove duplicate 'to' in sp_db_selective_xml_index docs

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-db-selective-xml-index-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-db-selective-xml-index-transact-sql.md
@@ -40,7 +40,7 @@ sys.sp_db_selective_xml_index
 
 #### [ @dbname = ] N'*dbname*'
 
-The name of the database on which to to enable or disable selective XML index. *@dbname* is **sysname**, with a default of `NULL`.
+The name of the database on which to enable or disable selective XML index. *@dbname* is **sysname**, with a default of `NULL`.
 
 If *@dbname* is `NULL`, the current database is assumed.
 


### PR DESCRIPTION
Tiny docs fix: `on which to to enable` → `on which to enable` in the `sp_db_selective_xml_index` Transact-SQL reference.